### PR TITLE
Revert "Bump gatsby-plugin-mdx from 3.14.0 to 3.15.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12039,9 +12039,9 @@
       }
     },
     "node_modules/gatsby-core-utils": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.15.0.tgz",
-      "integrity": "sha512-aLNrH3gGUIeD9XGk3z/27N5qaVx7y3AAgs/Vu6PJm69t25kTwuOHKNzhlnHkIZypznZkkVeN7QbHBkIKam/ZIQ==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.14.0.tgz",
+      "integrity": "sha512-JavHwcX5L+ZRoL5FKhYex3JfbwwS0273YTpf8y8SRKsObD8H+bbLOUlbOjASpqy+IU3dW+r76gT1dQdaqeH9Og==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "ci-info": "2.0.0",
@@ -12051,7 +12051,7 @@
         "fs-extra": "^10.1.0",
         "got": "^11.8.3",
         "import-from": "^4.0.0",
-        "lmdb": "2.3.10",
+        "lmdb": "^2.2.6",
         "lock": "^1.1.0",
         "node-object-hash": "^2.3.10",
         "proper-lockfile": "^4.1.2",
@@ -12355,9 +12355,9 @@
       }
     },
     "node_modules/gatsby-plugin-mdx": {
-      "version": "3.15.2",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-mdx/-/gatsby-plugin-mdx-3.15.2.tgz",
-      "integrity": "sha512-TsEgeAq40x7IwABXZkZcGStltr6gr3DnGjmhq4QZKapjtsPeTzWKp9HhB93t0OCDD9AfWUCH/teQq0rFTvsaEw==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-mdx/-/gatsby-plugin-mdx-3.14.0.tgz",
+      "integrity": "sha512-H3tZTmky67ZS1ZWOOluWoZ2tdgP052rsKvjbEumJBA+v10aqlYWx0S5Q0RcoWKyTTx90h2OHsx4r+LbLvFPW/g==",
       "dependencies": {
         "@babel/core": "^7.15.5",
         "@babel/generator": "^7.15.4",
@@ -12375,7 +12375,7 @@
         "escape-string-regexp": "^1.0.5",
         "eval": "^0.1.4",
         "fs-extra": "^10.1.0",
-        "gatsby-core-utils": "^3.15.0",
+        "gatsby-core-utils": "^3.14.0",
         "gray-matter": "^4.0.2",
         "json5": "^2.1.3",
         "loader-utils": "^1.4.0",
@@ -15814,9 +15814,9 @@
       "integrity": "sha1-7KKE910pZQeTCdwK2SVauy68FjI= sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/lmdb": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.3.10.tgz",
-      "integrity": "sha512-GtH+nStn9V59CfYeQ5ddx6YTfuFCmu86UJojIjJAweG+/Fm0PDknuk3ovgYDtY/foMeMdZa8/P7oSljW/d5UPw==",
+      "version": "2.3.7",
+      "resolved": "https://registry.yarnpkg.com/lmdb/-/lmdb-2.3.7.tgz",
+      "integrity": "sha1-cwhkEmOZZMBE/dfzYo8+KsqsYfY= sha512-oI7D1di+LbjISVh1Cv7Y5DUjHHRJ8pbU29PUccfQH72BIBknvC8o3E8ZJmKYHlL2sSmUXUY3yi/aOjd5nSb5WA==",
       "hasInstallScript": true,
       "dependencies": {
         "msgpackr": "^1.5.4",
@@ -15827,72 +15827,24 @@
         "weak-lru-cache": "^1.2.2"
       },
       "optionalDependencies": {
-        "lmdb-darwin-arm64": "2.3.10",
-        "lmdb-darwin-x64": "2.3.10",
-        "lmdb-linux-arm": "2.3.10",
-        "lmdb-linux-arm64": "2.3.10",
-        "lmdb-linux-x64": "2.3.10",
-        "lmdb-win32-x64": "2.3.10"
+        "lmdb-darwin-arm64": "2.3.7",
+        "lmdb-darwin-x64": "2.3.7",
+        "lmdb-linux-arm": "2.3.7",
+        "lmdb-linux-arm64": "2.3.7",
+        "lmdb-linux-x64": "2.3.7",
+        "lmdb-win32-x64": "2.3.7"
       }
     },
-    "node_modules/lmdb-darwin-arm64": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.3.10.tgz",
-      "integrity": "sha512-LVXbH2MYu7/ZuQ8+P9rv+SwNyBKltxo7vHAGJS94HWyfwnCbKEYER9PImBvNBwzvgtaYk6x0RMX3oor6e6KdDQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
     "node_modules/lmdb-darwin-x64": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/lmdb-darwin-x64/-/lmdb-darwin-x64-2.3.10.tgz",
-      "integrity": "sha512-gAc/1b/FZOb9yVOT+o0huA+hdW82oxLo5r22dFTLoRUFG1JMzxdTjmnW6ONVOHdqC9a5bt3vBCEY3jmXNqV26A==",
+      "version": "2.3.7",
+      "resolved": "https://registry.yarnpkg.com/lmdb-darwin-x64/-/lmdb-darwin-x64-2.3.7.tgz",
+      "integrity": "sha1-bL3nOYQn/bNGo5ifqloPEK21CSI= sha512-KKq96InbgAprCEPNQSZjD5sKs95U9+jPrD5EimV22zv9W6VCuz2DQV1XAWxN/kQh9VWVU49CMZYrRZK38PNfXw==",
       "cpu": [
         "x64"
       ],
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/lmdb-linux-arm": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/lmdb-linux-arm/-/lmdb-linux-arm-2.3.10.tgz",
-      "integrity": "sha512-Rb8+4JjsThuEcJ7GLLwFkCFnoiwv/3hAAbELWITz70buQFF+dCZvCWWgEgmDTxwn5r+wIkdUjmFv4dqqiKQFmQ==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/lmdb-linux-arm64": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/lmdb-linux-arm64/-/lmdb-linux-arm64-2.3.10.tgz",
-      "integrity": "sha512-Ihr8mdICTK3jA4GXHxrXGK2oekn0mY6zuDSXQDNtyRSH19j3D2Y04A7SEI9S0EP/t5sjKSudYgZbiHDxRCsI5A==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/lmdb-linux-x64": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/lmdb-linux-x64/-/lmdb-linux-x64-2.3.10.tgz",
-      "integrity": "sha512-E3l3pDiCA9uvnLf+t3qkmBGRO01dp1EHD0x0g0iRnfpAhV7wYbayJGfG93BUt22Tj3fnq4HDo4dQ6ZWaDI1nuw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
       ]
     },
     "node_modules/lmdb-store": {
@@ -15907,18 +15859,6 @@
         "ordered-binary": "^1.0.0",
         "weak-lru-cache": "^1.0.0"
       }
-    },
-    "node_modules/lmdb-win32-x64": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/lmdb-win32-x64/-/lmdb-win32-x64-2.3.10.tgz",
-      "integrity": "sha512-gspWk34tDANhjn+brdqZstJMptGiwj4qFNVg0Zey9ds+BUlif+Lgf5szrfOVzZ8gVRkk1Lgbz7i78+V7YK7SCA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/load-bmfont": {
       "version": "1.4.1",
@@ -20618,6 +20558,16 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.17.tgz",
       "integrity": "sha512-oajWz4kOajqpKJMPgnCvBajPq8QAvl2xIWoFjlAJPKGu6n7pjov5SxGE45a+0RxHDoo4ycOMoZw1SCOWtDERbw=="
     },
+    "node_modules/redoc-cli/node_modules/@types/chokidar": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@types/chokidar/-/chokidar-2.1.3.tgz",
+      "integrity": "sha512-6qK3xoLLAhQVTucQGHTySwOVA1crHRXnJeLwqK6KIFkkKa2aoMFXh+WEi8PotxDtvN6MQJLyYN9ag9P6NLV81w==",
+      "deprecated": "This is a stub types definition. chokidar provides its own type definitions, so you do not need this installed.",
+      "extraneous": true,
+      "dependencies": {
+        "chokidar": "*"
+      }
+    },
     "node_modules/redoc-cli/node_modules/@types/eslint": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
@@ -20644,10 +20594,29 @@
       "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
       "peer": true
     },
+    "node_modules/redoc-cli/node_modules/@types/handlebars": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.1.0.tgz",
+      "integrity": "sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==",
+      "deprecated": "This is a stub types definition. handlebars provides its own type definitions, so you do not need this installed.",
+      "extraneous": true,
+      "dependencies": {
+        "handlebars": "*"
+      }
+    },
     "node_modules/redoc-cli/node_modules/@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+    },
+    "node_modules/redoc-cli/node_modules/@types/mkdirp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.1.tgz",
+      "integrity": "sha512-HkGSK7CGAXncr8Qn/0VqNtExEE+PHMWb+qlR1faHMao7ng6P3tAaoWWBMdva0gL5h4zprjIO89GJOLXsMcDm1Q==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/redoc-cli/node_modules/@types/node": {
       "version": "15.12.2",
@@ -37677,9 +37646,9 @@
       }
     },
     "gatsby-core-utils": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.15.0.tgz",
-      "integrity": "sha512-aLNrH3gGUIeD9XGk3z/27N5qaVx7y3AAgs/Vu6PJm69t25kTwuOHKNzhlnHkIZypznZkkVeN7QbHBkIKam/ZIQ==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.14.0.tgz",
+      "integrity": "sha512-JavHwcX5L+ZRoL5FKhYex3JfbwwS0273YTpf8y8SRKsObD8H+bbLOUlbOjASpqy+IU3dW+r76gT1dQdaqeH9Og==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "ci-info": "2.0.0",
@@ -37689,7 +37658,7 @@
         "fs-extra": "^10.1.0",
         "got": "^11.8.3",
         "import-from": "^4.0.0",
-        "lmdb": "2.3.10",
+        "lmdb": "^2.2.6",
         "lock": "^1.1.0",
         "node-object-hash": "^2.3.10",
         "proper-lockfile": "^4.1.2",
@@ -37947,9 +37916,9 @@
       }
     },
     "gatsby-plugin-mdx": {
-      "version": "3.15.2",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-mdx/-/gatsby-plugin-mdx-3.15.2.tgz",
-      "integrity": "sha512-TsEgeAq40x7IwABXZkZcGStltr6gr3DnGjmhq4QZKapjtsPeTzWKp9HhB93t0OCDD9AfWUCH/teQq0rFTvsaEw==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-mdx/-/gatsby-plugin-mdx-3.14.0.tgz",
+      "integrity": "sha512-H3tZTmky67ZS1ZWOOluWoZ2tdgP052rsKvjbEumJBA+v10aqlYWx0S5Q0RcoWKyTTx90h2OHsx4r+LbLvFPW/g==",
       "requires": {
         "@babel/core": "^7.15.5",
         "@babel/generator": "^7.15.4",
@@ -37967,7 +37936,7 @@
         "escape-string-regexp": "^1.0.5",
         "eval": "^0.1.4",
         "fs-extra": "^10.1.0",
-        "gatsby-core-utils": "^3.15.0",
+        "gatsby-core-utils": "^3.14.0",
         "gray-matter": "^4.0.2",
         "json5": "^2.1.3",
         "loader-utils": "^1.4.0",
@@ -40508,16 +40477,16 @@
       "integrity": "sha1-7KKE910pZQeTCdwK2SVauy68FjI= sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "lmdb": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.3.10.tgz",
-      "integrity": "sha512-GtH+nStn9V59CfYeQ5ddx6YTfuFCmu86UJojIjJAweG+/Fm0PDknuk3ovgYDtY/foMeMdZa8/P7oSljW/d5UPw==",
+      "version": "2.3.7",
+      "resolved": "https://registry.yarnpkg.com/lmdb/-/lmdb-2.3.7.tgz",
+      "integrity": "sha1-cwhkEmOZZMBE/dfzYo8+KsqsYfY= sha512-oI7D1di+LbjISVh1Cv7Y5DUjHHRJ8pbU29PUccfQH72BIBknvC8o3E8ZJmKYHlL2sSmUXUY3yi/aOjd5nSb5WA==",
       "requires": {
-        "lmdb-darwin-arm64": "2.3.10",
-        "lmdb-darwin-x64": "2.3.10",
-        "lmdb-linux-arm": "2.3.10",
-        "lmdb-linux-arm64": "2.3.10",
-        "lmdb-linux-x64": "2.3.10",
-        "lmdb-win32-x64": "2.3.10",
+        "lmdb-darwin-arm64": "2.3.7",
+        "lmdb-darwin-x64": "2.3.7",
+        "lmdb-linux-arm": "2.3.7",
+        "lmdb-linux-arm64": "2.3.7",
+        "lmdb-linux-x64": "2.3.7",
+        "lmdb-win32-x64": "2.3.7",
         "msgpackr": "^1.5.4",
         "nan": "^2.14.2",
         "node-addon-api": "^4.3.0",
@@ -40526,34 +40495,10 @@
         "weak-lru-cache": "^1.2.2"
       }
     },
-    "lmdb-darwin-arm64": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.3.10.tgz",
-      "integrity": "sha512-LVXbH2MYu7/ZuQ8+P9rv+SwNyBKltxo7vHAGJS94HWyfwnCbKEYER9PImBvNBwzvgtaYk6x0RMX3oor6e6KdDQ==",
-      "optional": true
-    },
     "lmdb-darwin-x64": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/lmdb-darwin-x64/-/lmdb-darwin-x64-2.3.10.tgz",
-      "integrity": "sha512-gAc/1b/FZOb9yVOT+o0huA+hdW82oxLo5r22dFTLoRUFG1JMzxdTjmnW6ONVOHdqC9a5bt3vBCEY3jmXNqV26A==",
-      "optional": true
-    },
-    "lmdb-linux-arm": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/lmdb-linux-arm/-/lmdb-linux-arm-2.3.10.tgz",
-      "integrity": "sha512-Rb8+4JjsThuEcJ7GLLwFkCFnoiwv/3hAAbELWITz70buQFF+dCZvCWWgEgmDTxwn5r+wIkdUjmFv4dqqiKQFmQ==",
-      "optional": true
-    },
-    "lmdb-linux-arm64": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/lmdb-linux-arm64/-/lmdb-linux-arm64-2.3.10.tgz",
-      "integrity": "sha512-Ihr8mdICTK3jA4GXHxrXGK2oekn0mY6zuDSXQDNtyRSH19j3D2Y04A7SEI9S0EP/t5sjKSudYgZbiHDxRCsI5A==",
-      "optional": true
-    },
-    "lmdb-linux-x64": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/lmdb-linux-x64/-/lmdb-linux-x64-2.3.10.tgz",
-      "integrity": "sha512-E3l3pDiCA9uvnLf+t3qkmBGRO01dp1EHD0x0g0iRnfpAhV7wYbayJGfG93BUt22Tj3fnq4HDo4dQ6ZWaDI1nuw==",
+      "version": "2.3.7",
+      "resolved": "https://registry.yarnpkg.com/lmdb-darwin-x64/-/lmdb-darwin-x64-2.3.7.tgz",
+      "integrity": "sha1-bL3nOYQn/bNGo5ifqloPEK21CSI= sha512-KKq96InbgAprCEPNQSZjD5sKs95U9+jPrD5EimV22zv9W6VCuz2DQV1XAWxN/kQh9VWVU49CMZYrRZK38PNfXw==",
       "optional": true
     },
     "lmdb-store": {
@@ -40567,12 +40512,6 @@
         "ordered-binary": "^1.0.0",
         "weak-lru-cache": "^1.0.0"
       }
-    },
-    "lmdb-win32-x64": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/lmdb-win32-x64/-/lmdb-win32-x64-2.3.10.tgz",
-      "integrity": "sha512-gspWk34tDANhjn+brdqZstJMptGiwj4qFNVg0Zey9ds+BUlif+Lgf5szrfOVzZ8gVRkk1Lgbz7i78+V7YK7SCA==",
-      "optional": true
     },
     "load-bmfont": {
       "version": "1.4.1",
@@ -43997,6 +43936,14 @@
             }
           }
         },
+        "@types/chokidar": {
+          "version": "https://registry.npmjs.org/@types/chokidar/-/chokidar-2.1.3.tgz",
+          "integrity": "sha512-6qK3xoLLAhQVTucQGHTySwOVA1crHRXnJeLwqK6KIFkkKa2aoMFXh+WEi8PotxDtvN6MQJLyYN9ag9P6NLV81w==",
+          "extraneous": true,
+          "requires": {
+            "chokidar": "*"
+          }
+        },
         "@types/eslint": {
           "version": "8.4.1",
           "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
@@ -44023,10 +43970,26 @@
           "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
           "peer": true
         },
+        "@types/handlebars": {
+          "version": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.1.0.tgz",
+          "integrity": "sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==",
+          "extraneous": true,
+          "requires": {
+            "handlebars": "*"
+          }
+        },
         "@types/json-schema": {
           "version": "7.0.9",
           "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
           "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+        },
+        "@types/mkdirp": {
+          "version": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.1.tgz",
+          "integrity": "sha512-HkGSK7CGAXncr8Qn/0VqNtExEE+PHMWb+qlR1faHMao7ng6P3tAaoWWBMdva0gL5h4zprjIO89GJOLXsMcDm1Q==",
+          "extraneous": true,
+          "requires": {
+            "@types/node": "*"
+          }
         },
         "@types/node": {
           "version": "15.12.2",


### PR DESCRIPTION
Reverts AdobeDocs/commerce-php#14

Deploying the site after merging #14 to `main` seems to be responsible for rendering the meta at the top of the page as in production.

![Screen Shot 2022-06-06 at 1 01 03 PM](https://user-images.githubusercontent.com/13662379/172218721-23d95307-b224-4e1f-9c72-f3cca7d6e5d6.png)
