### PR TITLE
Updating links to web api / getting started

### DIFF
--- a/src/pages/architecture/modules/index.md
+++ b/src/pages/architecture/modules/index.md
@@ -53,7 +53,7 @@ The Commerce framework has well-defined upgrade and versioning strategies that c
 
 Adobe or third-party services can be configured as a web [API](https://glossary.magento.com/api) (REST or SOAP) with some simple [XML](https://glossary.magento.com/xml). You can use these services to integrate your installation into third-party applications, such as CRM (Customer Relationship Management), ERP (Enterprise Resource Planning) back office systems, and [CMS](https://glossary.magento.com/cms) (Content Management Systems).
 
-See [Getting Started with web APIs](https://devdocs.magento.com/guides/v2.4/get-started/bk-get-started-api.html) for more information.
+See [Getting Started with web APIs](https://developer.adobe.com/commerce/webapi/get-started/) for more information.
 
 ### Flexible attribute types
 

--- a/src/pages/architecture/technical-vision/index.md
+++ b/src/pages/architecture/technical-vision/index.md
@@ -9,5 +9,5 @@ The technical vision is a collection of documents that describe the desired stat
 
 Each individual technical vision document relates to a set of modules that are logically grouped together. Individual documents typically describe a component's place in the system, its architecture, extension scenarios and a list of invariants that must be preserved at all times during component refactoring or extension to ensure consistency.
 
-Learn more about the [web API](https://devdocs.magento.com/guides/v2.4/get-started/bk-get-started-api.html).
+Learn more about the [web API](https://developer.adobe.com/commerce/webapi/get-started/).
 See the [Coding Standards](../coding-standards.md) for information about writing clean, readable code.

--- a/src/pages/best-practices/extensions/architecture.md
+++ b/src/pages/best-practices/extensions/architecture.md
@@ -15,7 +15,7 @@ If you feel that the application can be improved with your core code changes, pl
 
 ## Learn the architecture
 
-To create the optimum module, you should get to know the application architecture. Start off by familiarizing yourself with the [Admin Pattern Library](https://devdocs.magento.com/guides/v2.4/pattern-library/bk-pattern.html), the core [components](../../development/index.md), and our [service contracts](../../development/components/service-contracts/index.md) and [APIs](https://devdocs.magento.com/guides/v2.4/get-started/bk-get-started-api.html).
+To create the optimum module, you should get to know the application architecture. Start off by familiarizing yourself with the [Admin Pattern Library](https://devdocs.magento.com/guides/v2.4/pattern-library/bk-pattern.html), the core [components](../../development/index.md), and our [service contracts](../../development/components/service-contracts/index.md) and [APIs](https://developer.adobe.com/commerce/webapi/get-started/).
 
 ## Check your extension configurations
 

--- a/src/pages/development/components/attributes.md
+++ b/src/pages/development/components/attributes.md
@@ -227,7 +227,7 @@ searchCriteria[filter_groups][0][filters][0]
 
 ### Extension attribute authentication
 
-Individual fields that are defined as extension attributes can be restricted, based on existing permissions. This feature allows extension developers to restrict access to data. See [Web API authentication overview](https://devdocs.magento.com/guides/v2.4/get-started/authentication/gs-authentication.html) for general information about authentication in Magento.
+Individual fields that are defined as extension attributes can be restricted, based on existing permissions. This feature allows extension developers to restrict access to data. See [Web API authentication overview](https://developer.adobe.com/commerce/webapi/get-started/authentication/) for general information about authentication in Magento.
 
 The following [code sample](https://github.com/magento/magento2/blob/2.4/app/code/Magento/CatalogInventory/etc/extension_attributes.xml) defines `stock_item` as an extension attribute of the `CatalogInventory` module. `CatalogInventory` is treated as a "third-party extension". Access to the inventory data is restricted because the quantity of in-stock item may be competitive information.
 

--- a/src/pages/development/components/web-api/services.md
+++ b/src/pages/development/components/web-api/services.md
@@ -173,7 +173,7 @@ To define web API components, set these attributes on these XML elements in the
             <li>
                <inlineCode class="spectrum-Body--sizeS">ref</inlineCode>.
                   Required. Referenced resource. Valid values are self, anonymous, or a resource, such as <inlineCode class="spectrum-Body--sizeS">Magento_Customer::group</inlineCode>.
-               <strong>Note:</strong> The web API framework enables guest users to access resources that are configured with anonymous permission. Any user that the framework cannot authenticate through existing <a href="https://devdocs.magento.com/guides/v2.4/get-started/authentication/gs-authentication.html">authentication mechanisms</a> is considered a guest user.
+               <strong>Note:</strong> The web API framework enables guest users to access resources that are configured with anonymous permission. Any user that the framework cannot authenticate through existing <a href="https://developer.adobe.com/commerce/webapi/get-started/authentication/">authentication mechanisms</a> is considered a guest user.
             </li>
          </ul>
       </td>

--- a/src/pages/module-reference/module-integration.md
+++ b/src/pages/module-reference/module-integration.md
@@ -107,4 +107,4 @@ Cron group configuration can be set at `etc/crontab.xml`:
 
 More information can get at articles:
 - [Learn more about an Integration](https://docs.magento.com/user-guide/system/integrations.html)
-- [Lear how to create an Integration](https://devdocs.magento.com/guides/v2.4/get-started/create-integration.html)
+- [Lear how to create an Integration](https://developer.adobe.com/commerce/webapi/get-started/create-integration/)


### PR DESCRIPTION
Updating links to Getting started with Web APIs. 

Former location: https://devdocs.magento.com/guides/v2.4/get-started/bk-get-started-api.html
Current location: https://developer.adobe.com/commerce/webapi/get-started/

wait for current location link (above) to be active before merging this PR.