### PR TITLE
path repositories support clarification

### DIFF
--- a/src/pages/development/build/composer-integration.md
+++ b/src/pages/development/build/composer-integration.md
@@ -13,7 +13,7 @@ We recommend you include `composer.json` in your component's root directory even
 
 <InlineAlert variant="info" slots="text"/>
 
-Adobe Commerce and Magento Open Source do not support the [`path`][3] repository.
+Adobe Commerce and Magento Open Source do not support the [`path`][3] repository pointing to a folder outside of the application's root directory.
 
 Here is an example of the `composer.json` file.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds a more accurate description on the support of the path repository type in composer.json

## Affected pages

- https://developer.adobe.com/commerce/php/development/build/composer-integration/

## Links to related PRs or Jira tickets

-  PR for the original Devdocs repository https://github.com/magento/devdocs/pull/9442

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My changes follow the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
