### PR TITLE
Update add-shipping-carrier.md

### DIFF
--- a/src/pages/tutorials/frontend/custom-checkout/add-shipping-carrier.md
+++ b/src/pages/tutorials/frontend/custom-checkout/add-shipping-carrier.md
@@ -25,6 +25,8 @@ The example module for use here is `Vendor_CustomShipping`.
 ```php
 <?php
 
+declare(strict_types=1);
+
 use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(
@@ -39,10 +41,10 @@ ComponentRegistrar::register(
 
 ```json
 {
-    "name": "vendor/custom-shipping",
+    "name": "vendor/module-custom-shipping",
     "description": "Custom shipping module",
     "require": {
-        "php": "~7.2.0||~7.3.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "102.0.*",
         "magento/module-backend": "101.0.*",
         "magento/module-catalog": "103.0.*",
@@ -66,8 +68,7 @@ ComponentRegistrar::register(
         "psr-4": {
             "Vendor\\CustomShipping\\": ""
         }
-    },
-    "version": "1.0.0"
+    }
 }
 ```
 
@@ -75,15 +76,9 @@ ComponentRegistrar::register(
 
 ```xml
 <?xml version="1.0"?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Vendor_CustomShipping" >
-        <sequence>
-            <module name="Magento_Store"/>
-            <module name="Magento_Sales"/>
-            <module name="Magento_Quote"/>
-            <module name="Magento_SalesRule"/>
-        </sequence>
-    </module>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Vendor_CustomShipping"/>
 </config>
 ```
 
@@ -106,41 +101,42 @@ The `system.xml` source code declares custom shipping module options:
 
 ```xml
 <?xml version="1.0"?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
-        <section id="carriers" translate="label" type="text" sortOrder="320" showInDefault="1" showInWebsite="1" showInStore="1">
-            <group id="customshipping" translate="label" type="text" sortOrder="900" showInDefault="1" showInWebsite="1" showInStore="1">
+        <section id="carriers">
+            <group id="customshipping" translate="label" type="text" sortOrder="0" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Custom Shipping Module</label>
-                <field id="active" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+                <field id="active" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Enabled</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="title" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="title" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Title</label>
                 </field>
-                <field id="name" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="name" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Method Name</label>
                 </field>
-                <field id="shipping_cost" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="0" >
+                <field id="shipping_cost" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Shipping Cost</label>
                     <validate>validate-number validate-zero-or-greater</validate>
                 </field>
-                <field id="sallowspecific" translate="label" type="select" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+                <field id="sallowspecific" translate="label" type="select" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Ship to Applicable Countries</label>
                     <frontend_class>shipping-applicable-country</frontend_class>
                     <source_model>Magento\Shipping\Model\Config\Source\Allspecificcountries</source_model>
                 </field>
-                <field id="specificcountry" translate="label" type="multiselect" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="specificcountry" translate="label" type="multiselect" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Ship to Specific Countries</label>
                     <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
                     <can_be_empty>1</can_be_empty>
                 </field>
-                <field id="showmethod" translate="label" type="select" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="0">
-                    <label>Show Method if Not Applicable</label>
+                <field id="showmethod" translate="label" type="select" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Show Method if not applicable</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <frontend_class>shipping-skip-hide</frontend_class>
                 </field>
-                <field id="sort_order" translate="label" type="text" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="sort_order" translate="label" type="text" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Sort Order</label>
                 </field>
             </group>
@@ -155,7 +151,8 @@ The `config.xml` file specifies default values for custom shipping module option
 
 ```xml
 <?xml version="1.0"?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
     <default>
         <carriers>
             <customshipping>
@@ -183,51 +180,37 @@ The carrier class implements the `CarrierInterface` interface and retrieves all 
 ```php
 <?php
 
+declare(strict_types=1);
+
 namespace Vendor\CustomShipping\Model\Carrier;
 
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Quote\Model\Quote\Address\RateRequest;
+use Magento\Quote\Model\Quote\Address\RateResult\Method;
+use Magento\Quote\Model\Quote\Address\RateResult\MethodFactory;
+use Magento\Quote\Model\Quote\Address\RateResult\ErrorFactory;
 use Magento\Shipping\Model\Carrier\AbstractCarrier;
 use Magento\Shipping\Model\Carrier\CarrierInterface;
+use Magento\Shipping\Model\Rate\Result;
+use Magento\Shipping\Model\Rate\ResultFactory;
+use Psr\Log\LoggerInterface;
 
-/**
- * Custom shipping model
- */
 class Customshipping extends AbstractCarrier implements CarrierInterface
 {
-    /**
-     * @var string
-     */
-    protected $_code = 'customshipping';
+    protected string $_code = 'customshipping';
 
-    /**
-     * @var bool
-     */
-    protected $_isFixed = true;
+    protected bool $_isFixed = true;
 
-    /**
-     * @var \Magento\Shipping\Model\Rate\ResultFactory
-     */
-    private $rateResultFactory;
+    private ResultFactory $rateResultFactory;
 
-    /**
-     * @var \Magento\Quote\Model\Quote\Address\RateResult\MethodFactory
-     */
-    private $rateMethodFactory;
+    private MethodFactory $rateMethodFactory;
 
-    /**
-     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
-     * @param \Magento\Quote\Model\Quote\Address\RateResult\ErrorFactory $rateErrorFactory
-     * @param \Psr\Log\LoggerInterface $logger
-     * @param \Magento\Shipping\Model\Rate\ResultFactory $rateResultFactory
-     * @param \Magento\Quote\Model\Quote\Address\RateResult\MethodFactory $rateMethodFactory
-     * @param array $data
-     */
     public function __construct(
-        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
-        \Magento\Quote\Model\Quote\Address\RateResult\ErrorFactory $rateErrorFactory,
-        \Psr\Log\LoggerInterface $logger,
-        \Magento\Shipping\Model\Rate\ResultFactory $rateResultFactory,
-        \Magento\Quote\Model\Quote\Address\RateResult\MethodFactory $rateMethodFactory,
+        ScopeConfigInterface $scopeConfig,
+        ErrorFactory $rateErrorFactory,
+        LoggerInterface $logger,
+        ResultFactory $rateResultFactory,
+        MethodFactory $rateMethodFactory,
         array $data = []
     ) {
         parent::__construct($scopeConfig, $rateErrorFactory, $logger, $data);
@@ -248,10 +231,7 @@ class Customshipping extends AbstractCarrier implements CarrierInterface
             return false;
         }
 
-        /** @var \Magento\Shipping\Model\Rate\Result $result */
-        $result = $this->rateResultFactory->create();
-
-        /** @var \Magento\Quote\Model\Quote\Address\RateResult\Method $method */
+        /** @var Method $method */
         $method = $this->rateMethodFactory->create();
 
         $method->setCarrier($this->_code);
@@ -260,20 +240,18 @@ class Customshipping extends AbstractCarrier implements CarrierInterface
         $method->setMethod($this->_code);
         $method->setMethodTitle($this->getConfigData('name'));
 
-        $shippingCost = (float)$this->getConfigData('shipping_cost');
-
+        $shippingCost = (float) $this->getConfigData('shipping_cost');
         $method->setPrice($shippingCost);
         $method->setCost($shippingCost);
 
+        /** @var Result $result */
+        $result = $this->rateResultFactory->create();
         $result->append($method);
 
         return $result;
     }
 
-    /**
-     * @return array
-     */
-    public function getAllowedMethods()
+    public function getAllowedMethods(): array
     {
         return [$this->_code => $this->getConfigData('name')];
     }
@@ -286,10 +264,6 @@ Run the commands below to register `Vendor_CustomShipping` module:
 
 ```bash
 bin/magento module:enable Vendor_CustomShipping
-```
-
-```bash
-bin/magento setup:upgrade
 ```
 
 ## Screenshots


### PR DESCRIPTION
## Purpose of this pull request

- update PHP Versions in composer.json - prior to, EOL PHP version was provided as an example
- enable strict types on `registration.php`
- eliminate `<sequence>` XML node from `module.xml`. This is not necessary as we are only appending additional information here, as opposed to attempting to override any configs.
- eliminate additional attributes on the `<section>` node of `adminhtml.xml` beyond `id`. There is no need for them. They are already defined by Magento natively and we're not aiming to change values of the section's existing config.
- add `canRestore` attribute to configs, we have defaults, may as well allow the option to restore to them.
- revise `showInStore` to `1` on the `<field>` nodes of `adminhtml.xml`
- enable strict types on `CustomShipping.php`
- make more use of aliasing class names with a `use` statement in `CustomShipping.php`
- eliminate redundant phpdoc in `CustomShipping.php` when it did not provide any additional information beyond what the code itself is already providing us in a concise manner.
- add return type to method signature of `CustomShipping::getAlloweMethods()`
- minor re-org of code within `CustomShipping::collectRates()`
- remove `version` from `composer.json`


## Affected pages

-  https://developer.adobe.com/commerce/php/tutorials/frontend/custom-checkout/add-shipping-carrier/

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My changes follow the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
