### PR TITLE
Adding note for Braintree deprecation

### DIFF
--- a/src/data/navigation/sections/development.js
+++ b/src/data/navigation/sections/development.js
@@ -361,12 +361,8 @@ module.exports = [
     },
     {
       title: "Payment Provider Gateway",
-      path: "/development/payments-integrations/payment-gateway/",
+      path: "/development/payments-integrations/",
       pages: [
-        {
-          title: "Introduction",
-          path: "/development/payments-integrations",
-        },
         {
           title: "Commerce payment provider gateway",
           path: "/development/payments-integrations/payment-gateway/",

--- a/src/pages/_includes/braintree-note.md
+++ b/src/pages/_includes/braintree-note.md
@@ -1,0 +1,3 @@
+<InlineAlert variant="warning" slots="text"/>
+
+The Payment Provider Gateway documentation uses the Magento 2.3 (now Adobe Commerce and Magento Open Source) of the Braintree module as a reference application. The Braintree module was removed in version 2.4.0. The concepts described in this guide are still applicable to version 2.4.x, but the code samples are not supported.

--- a/src/pages/development/payments-integrations/base-integration/admin-integration.md
+++ b/src/pages/development/payments-integrations/base-integration/admin-integration.md
@@ -3,6 +3,10 @@ title: Configure payment method by area
 description: Learn how to define payment method availability.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Configure payment method by area
 
 You can determine if the payment method is available for the [storefront](https://glossary.magento.com/storefront) and [checkout](https://glossary.magento.com/checkout) in the [payment method configuration in `config.xml`](payment-option-config.md):

--- a/src/pages/development/payments-integrations/base-integration/facade-configuration.md
+++ b/src/pages/development/payments-integrations/base-integration/facade-configuration.md
@@ -3,6 +3,10 @@ title: Payment method facade
 description: Learn how to process payment actions between Adobe Commerce Sales Management and the payment processor.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Payment method facade
 
 Payment facade is an instance of [Payment Adapter](https://github.com/magento/magento2/tree/2.4/app/code/Magento/Payment/Model/Method/Adapter.php) configured with virtual types. It allows you to process payment actions between Adobe Commerce Sales Management and the payment processor.

--- a/src/pages/development/payments-integrations/base-integration/formblocktype.md
+++ b/src/pages/development/payments-integrations/base-integration/formblocktype.md
@@ -3,6 +3,10 @@ title: Payment info rendering in Admin checkout
 description: Create a custom formBlockType to modify payment information form rendering.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Payment info rendering in Admin checkout
 
 The payment information form rendering in [Admin](https://glossary.magento.com/admin) order creation is defined by the block class, its template and [layout](https://glossary.magento.com/layout).

--- a/src/pages/development/payments-integrations/base-integration/get-payment-info.md
+++ b/src/pages/development/payments-integrations/base-integration/get-payment-info.md
@@ -3,6 +3,10 @@ title: Get payment information from frontend to backend
 description: Learn how to retrieve the payment details form.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Get payment information from frontend to backend
 
 To implement transaction [authorization](https://glossary.magento.com/authorization) our payment should receive some payment details from the payment form, like credit card details, and send received details to payment processor.

--- a/src/pages/development/payments-integrations/base-integration/index.md
+++ b/src/pages/development/payments-integrations/base-integration/index.md
@@ -3,6 +3,10 @@ title: Adding a new payment integration (payment method)
 description: This is an overview of how to add integrations to handle transactions with other payment providers.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Adding a new payment integration (payment method)
 
 Out-of-the-box Adobe Commerce implements integration with PayPal, Braintree, and Authorize.Net payment service providers. These integrations allow you to create and handle transactions based on order details.

--- a/src/pages/development/payments-integrations/base-integration/module-configuration.md
+++ b/src/pages/development/payments-integrations/base-integration/module-configuration.md
@@ -3,6 +3,10 @@ title: Payment method module configuration
 description: Learn how to create a custom payment integration module.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Payment method module configuration
 
 For the sake of compatibility, upgradability and easy maintenance, do not edit the default Adobe Commerce code; add your customizations in a separate [module](https://glossary.magento.com/module).

--- a/src/pages/development/payments-integrations/base-integration/payment-action.md
+++ b/src/pages/development/payments-integrations/base-integration/payment-action.md
@@ -3,6 +3,10 @@ title: Add a payment action
 description: Learn how to create a payment action and configure the command for that payment action.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Add a payment action
 
 For each payment action available for the payment method, you must implement the following:

--- a/src/pages/development/payments-integrations/base-integration/payment-option-config.md
+++ b/src/pages/development/payments-integrations/base-integration/payment-option-config.md
@@ -3,6 +3,10 @@ title: Payment method configuration
 description: Learn how to configure the payment method options.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Payment method configuration
 
 In the `config.xml` file in your `%Vendor_Module%/etc` directory, configure the options of your [payment method](https://glossary.magento.com/payment-method). The following table contains the default options available for any payment method.

--- a/src/pages/development/payments-integrations/index.md
+++ b/src/pages/development/payments-integrations/index.md
@@ -3,6 +3,10 @@ title: Payments Integrations
 description: This is an overview of how to integrate your stores with payment service providers, allowing you to create and handle transactions based on order details.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Payments Integrations
 
 Adobe Commerce payment provider gateway is a mechanism that allows you to integrate your stores with payment service providers. As a result, you can create and handle transactions based on order details.

--- a/src/pages/development/payments-integrations/payment-gateway/command-pool.md
+++ b/src/pages/development/payments-integrations/payment-gateway/command-pool.md
@@ -3,6 +3,10 @@ title: Gateway Command Pool
 description: Select the set of gateway commands available for integration with a payment provider.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Gateway Command Pool
 
 All [gateway commands](/gateway-command.md) implemented for a particular payment provider, should be added to a command pool for this provider. A command pool is a set of gateway commands available for integration with a particular payment provider. The pool is added to the configuration of the payment provider using [dependency injection](../../components/dependency-injection.md).

--- a/src/pages/development/payments-integrations/payment-gateway/error-code-mapper.md
+++ b/src/pages/development/payments-integrations/payment-gateway/error-code-mapper.md
@@ -3,6 +3,10 @@ title: Error Code Mapping
 description: Learn how to determine payment gateway error code routing.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Error Code Mapping
 
 A payment gateway has error codes or messages that need to be transformed to user-friendly messages. When an error occurs, Adobe Commerce delivers the message to the appropriate audience so that the customer or merchant can resolve any problems. You can set up each payment integration to map the native error codes and messages into sets of text strings. As a result, you can ensure that only the proper audience (merchants only, customers only, or all) sees each error message. By default, the standard error message (`An error occurred on the server. Please try to place the order again.`) displays if a payment operation fails and a specific mapped message cannot be found.

--- a/src/pages/development/payments-integrations/payment-gateway/gateway-client.md
+++ b/src/pages/development/payments-integrations/payment-gateway/gateway-client.md
@@ -3,6 +3,10 @@ title: Gateway Client
 description: Learn how to transfer the payload to the payment provider and get a response.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Gateway Client
 
 Gateway Client is a component of the Adobe Commerce [payment gateway](https://glossary.magento.com/payment-gateway) that transfers the payload to the payment provider and gets the response.

--- a/src/pages/development/payments-integrations/payment-gateway/gateway-command.md
+++ b/src/pages/development/payments-integrations/payment-gateway/gateway-command.md
@@ -3,6 +3,10 @@ title: Gateway Command
 description: Learn how provider responses are sent, received, and processed.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Gateway Command
 
 Gateway Command is a component of the Adobe Commerce [payment gateway](https://glossary.magento.com/payment-gateway) that takes the [payload](index.md#terms-used) required for a particular payment provider and sends, receives, and processes the provider's response.

--- a/src/pages/development/payments-integrations/payment-gateway/index.md
+++ b/src/pages/development/payments-integrations/payment-gateway/index.md
@@ -3,6 +3,10 @@ title: Commerce payment provider gateway
 description: This is an overview of how to create and handle transactions based on order details.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Commerce payment provider gateway
 
 ### What is Adobe Commerce payment provider gateway

--- a/src/pages/development/payments-integrations/payment-gateway/payment-gateway-structure.md
+++ b/src/pages/development/payments-integrations/payment-gateway/payment-gateway-structure.md
@@ -3,6 +3,10 @@ title: Payment provider gateway structure
 description: This is a structural overview of the basic components of the Adobe Commerce payment provider gateway.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Payment provider gateway structure
 
 The following diagram shows the basic components of the Adobe Commerce payment provider gateway:

--- a/src/pages/development/payments-integrations/payment-gateway/request-builder.md
+++ b/src/pages/development/payments-integrations/payment-gateway/request-builder.md
@@ -3,6 +3,10 @@ title: Request Builder
 description: Learn how to implement complex building strategies using builder composites.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Request Builder
 
 Request Builder is a component of the Adobe Commerce [payment gateway](https://glossary.magento.com/payment-gateway) responsible for building a request from several parts. It allows implementing complex, yet atomic and testable, building strategies. Each builder can have simple logic or contain builder composites.

--- a/src/pages/development/payments-integrations/payment-gateway/response-handler.md
+++ b/src/pages/development/payments-integrations/payment-gateway/response-handler.md
@@ -3,6 +3,10 @@ title: Response Handler
 description: Learn how to process payment provider responses.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Response Handler
 
 Response Handler is a component of the Adobe Commerce payment provider gateway, that processes payment provider responses.

--- a/src/pages/development/payments-integrations/payment-gateway/response-validator.md
+++ b/src/pages/development/payments-integrations/payment-gateway/response-validator.md
@@ -3,6 +3,10 @@ title: Response Validator
 description: Learn how to verify gateway response for formatting, security, and execution.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Response Validator
 
 Response Validator is a component of the Adobe Commerce payment provider gateway that performs gateway response verification. This may include low level data formatting, security verification, and even execution of some business logic required by the store configuration.

--- a/src/pages/development/payments-integrations/vault/admin-integration.md
+++ b/src/pages/development/payments-integrations/vault/admin-integration.md
@@ -3,6 +3,10 @@ title: Vault implementation for Admin
 description: Learn how to configure the fault to work with Adobe Commerce.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Vault implementation for Admin
 
 To be able to use vault in [Admin](https://glossary.magento.com/admin) order creation, you need to take at least the following steps:

--- a/src/pages/development/payments-integrations/vault/customer-stored-payments.md
+++ b/src/pages/development/payments-integrations/vault/customer-stored-payments.md
@@ -3,6 +3,10 @@ title: Display the stored information
 description: Learn how to display stored tokens in the customer account and allow customers to remove tokens.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Display the stored information
 
 This topic describes how to display stored tokens in the customer account and give customers ability to remove the tokens.

--- a/src/pages/development/payments-integrations/vault/enabler.md
+++ b/src/pages/development/payments-integrations/vault/enabler.md
@@ -3,6 +3,10 @@ title: Enable vault
 description: Learn how to add vault enabler and modify payment controls.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Enable vault
 
 Store customers must have the ability to enable and disable credit cards details storing.

--- a/src/pages/development/payments-integrations/vault/index.md
+++ b/src/pages/development/payments-integrations/vault/index.md
@@ -3,6 +3,10 @@ title: Adding vault integration
 description: This is an overview of adding vault as a payment method so customers can use previously saved credit card information.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Adding vault integration
 
 Vault as a [payment method](https://glossary.magento.com/payment-method) provides store customers with ability to use the previously saved credit card information for [checkout](https://glossary.magento.com/checkout). This information is stored safely on the side of trusted payments gateways (Braintree, PayPal). Not storing the sensitive credit card information is one of the [PCI compliance](https://www.pcisecuritystandards.org/) requirements.

--- a/src/pages/development/payments-integrations/vault/module-configuration.md
+++ b/src/pages/development/payments-integrations/vault/module-configuration.md
@@ -3,6 +3,10 @@ title: Add vault to module dependencies
 description: Learn how to add dependencies necessary for using the vault.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Add vault to module dependencies
 
 You need to add dependencies on the Magento_Vault module in the payment method's `composer.json` and `module.xml` files.

--- a/src/pages/development/payments-integrations/vault/payment-token.md
+++ b/src/pages/development/payments-integrations/vault/payment-token.md
@@ -3,6 +3,10 @@ title: Payment Token
 description: This is an overview of how payment tokens store data received from the payment provider.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Payment Token
 
 Adobe Commerce does not store any private credit card details. Commerce only stores the Payment Token, which is comprised of the following data received from the payment provider: the payment processor token and credit card details without sensitive data.

--- a/src/pages/development/payments-integrations/vault/token-ui-component-provider.md
+++ b/src/pages/development/payments-integrations/vault/token-ui-component-provider.md
@@ -3,6 +3,10 @@ title: Token UI component provider
 description: Learn how to create custom vault payment UI components that display stored tokens.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Token UI component provider
 
 This topic describes how to create custom vault payments UI components that are used to display stored tokens on [checkout](https://glossary.magento.com/checkout) page and order placing using vault.

--- a/src/pages/development/payments-integrations/vault/vault-di.md
+++ b/src/pages/development/payments-integrations/vault/vault-di.md
@@ -3,6 +3,10 @@ title: Vault DI configuration
 description: Learn how to configure vault payment method and create payment actions.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Vault DI configuration
 
 This section describes how to configure vault [payment method](https://glossary.magento.com/payment-method) and create payment actions, like authorize, and sale (authorize & capture).

--- a/src/pages/development/payments-integrations/vault/vault-payment-configuration.md
+++ b/src/pages/development/payments-integrations/vault/vault-payment-configuration.md
@@ -3,6 +3,10 @@ title: Vault payment configuration
 description: Learn about the parameters necessary to create vault payment.
 ---
 
+import Docs from '/src/pages/_includes/braintree-note.md'
+
+<Docs />
+
 # Vault payment configuration
 
 You need to configure the main parameters of the vault implementation in the `config.xml` file of your [payment method](https://glossary.magento.com/payment-method) module:


### PR DESCRIPTION
This PR adds a warning missing in https://github.com/AdobeDocs/commerce-php/pull/55.
It is added to every page in the `/payments-integrations/`, except `cardinal.md` as described [here](https://github.com/magento-commerce/devdocs/blob/cfc3f6bd3dce81f6f540ee6485bd0401b1f5c3f3/src/_includes/layout/page-header.html).

[Staged site](https://developer-stage.adobe.com/commerce/php/development/payments-integrations/payment-gateway/)

I also removed a redundancy in the left-nav.