### PR TITLE
[Fix] DYNAMIC ROW SYSTEM CONFIGURATION: Broken URL

### DIFF
--- a/src/pages/tutorials/admin/create-dynamic-row-configuration.md
+++ b/src/pages/tutorials/admin/create-dynamic-row-configuration.md
@@ -252,4 +252,4 @@ The result is a new dynamic system row field in the Admin panel. If you have set
 
 ![Dynamic Rows System Config](../../_images/tutorials/dynamic-rows-config-result.png)
 
-[0]: https://github.com/magento/magento2/blob/2.4}/app/code/Magento/Config/Block/System/Config/Form/Field/FieldArray/AbstractFieldArray.php
+[0]: https://github.com/magento/magento2/blob/2.4/app/code/Magento/Config/Block/System/Config/Form/Field/FieldArray/AbstractFieldArray.php


### PR DESCRIPTION
## Purpose of this pull request

This pull request fixes a broken URL in the admin development tutorial: `Create a dynamic row system configuration`.

## Affected pages

-  https://developer.adobe.com/commerce/php/tutorials/admin/create-dynamic-row-configuration/

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My changes follow the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
