### PR TITLE
Fixed syntax error

### DIFF
--- a/src/pages/development/cli-commands/custom.md
+++ b/src/pages/development/cli-commands/custom.md
@@ -139,7 +139,7 @@ Following is a summary of the process:
                  $output->writeln(sprintf(
                      '<error>%s</error>',
                      $e->getMessage()
-                 );
+                 ));
                  $exitCode = 1;
              }
              


### PR DESCRIPTION
The custom command class example was having a syntax error. For the writeln function, one of the curly braces was not present.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Added closing curly brace for the writeln function that was missing in the custom command class example.

## Related Issue


## Motivation and Context

Whenever anyone is using the code of the custom command class as a reference, they may face a syntax error.

## How Has This Been Tested?


## Screenshots (if appropriate):

## Types of changes


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:


- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
