### PR TITLE
Add visibility to __construct method in example

### DIFF
--- a/src/pages/development/components/factories.md
+++ b/src/pages/development/components/factories.md
@@ -76,7 +76,7 @@ You can get the singleton instance of a factory for a specific model using [depe
 The following example shows a class getting the `BlockFactory` instance through the constructor:
 
 ```php
-function __construct ( \Magento\Cms\Model\BlockFactory $blockFactory) {
+public function __construct ( \Magento\Cms\Model\BlockFactory $blockFactory) {
     $this->blockFactory = $blockFactory;
 }
 ```


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) add the correct visibility for the example adding a factory in __construct method.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/php/development/components/factories/
