### PR TITLE
Fix unsigned attribute in declarative schema example

### DIFF
--- a/src/pages/development/components/declarative-schema/configuration.md
+++ b/src/pages/development/components/declarative-schema/configuration.md
@@ -24,7 +24,7 @@ The following example, extracted from the `Catalog/etc/db_schema.xml` file, defi
 ```xml
 <table name="catalog_product_entity_datetime" resource="default" engine="innodb"
            comment="Catalog Product Datetime Attribute Backend Table">
-    <column xsi:type="int" name="value_id" unsigned="false" nullable="false" identity="true" comment="Value ID"/>
+    <column xsi:type="int" name="value_id" unsigned="true" nullable="false" identity="true" comment="Value ID"/>
     <column xsi:type="smallint" name="attribute_id" unsigned="true" nullable="false" identity="false" default="0" comment="Attribute ID"/>
     <column xsi:type="smallint" name="store_id" unsigned="true" nullable="false" identity="false" default="0" comment="Store ID"/>
     <column xsi:type="int" name="entity_id" unsigned="true" nullable="false" identity="false" default="0" comment="Entity ID"/>


### PR DESCRIPTION
The primary key's `unsigned` attribute in the preliminary example is defined as `unsigned="false"`. That results in a table with signed primary keys which is pretty unusual. Copying the example could easily lead to unwanted effects for developers.

## Purpose of this pull request

This pull request (PR) prevents developers from accidental mistakes when defining tables wit declarative schema.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- <https://developer.adobe.com/commerce/php/development/components/declarative-schema/configuration/>