### PR TITLE
Make add-to-project-board a reusable workflow

### DIFF
--- a/.github/workflows/add-to-project-board.yml
+++ b/.github/workflows/add-to-project-board.yml
@@ -1,4 +1,3 @@
----
 ##### Aggregate Commerce PRs and Issues into a respective Organizational Project #####
 
 name: Add pull requests and issues to projects
@@ -12,20 +11,6 @@ on:
       - opened
 
 jobs:
-  add-to-project:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Add to Commerce PR project
-        if: github.event_name == 'pull_request_target'
-        uses: actions/add-to-project@v0.4.0
-        with:
-          project-url: https://github.com/orgs/AdobeDocs/projects/5 # The organizational project for pull requests
-          github-token: ${{ secrets.COMMERCE_PROJECT_AUTOMATION }}
-      
-      - name: Add to Commerce Issue project
-        if: github.event_name == 'issues'
-        uses: actions/add-to-project@v0.4.0
-        with:
-          project-url: https://github.com/orgs/AdobeDocs/projects/6 # The organizational project for issues
-          github-token: ${{ secrets.COMMERCE_PROJECT_AUTOMATION }}
+  call-workflow-add-to-project:
+    uses: AdobeDocs/commerce-php/.github/workflows/add-to-project_job.yml@main
+    secrets: inherit

--- a/.github/workflows/add-to-project_job.yml
+++ b/.github/workflows/add-to-project_job.yml
@@ -1,0 +1,23 @@
+name: Add to project job
+
+on:
+  workflow_call
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add to Commerce PR project
+        if: github.event_name == 'pull_request_target'
+        uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: https://github.com/orgs/AdobeDocs/projects/5 # The organizational project for pull requests
+          github-token: ${{ secrets.COMMERCE_PROJECT_AUTOMATION }}
+      
+      - name: Add to Commerce Issue project
+        if: github.event_name == 'issues'
+        uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: https://github.com/orgs/AdobeDocs/projects/6 # The organizational project for issues
+          github-token: ${{ secrets.COMMERCE_PROJECT_AUTOMATION }}


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) reimplements the add-to-project-board to a [reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows). This will allow keeping the core job (`.github/workflows/add-to-project_job.yml`) in one place to avoid code duplication in other repositories that use it.

## Testing

I tested this in my personal fork. [Here](https://github.com/dshevtsov/commerce-php/actions/runs/5027214333/jobs/9016455666) is the expected result with bad credentials failure (I used fake credentials), which means that the workflow works.

## Additional information

Internal ticket: COMDOX-515