### PR TITLE
Fix GitHub pages workflow

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -13,6 +13,7 @@ jobs:
         run: |
           yarn build
         env:
+          NODE_OPTIONS: "--max_old_space_size=4096"
           PREFIX_PATHS: true # works like --prefix-paths flag for 'gatsby build'
           PATH_PREFIX: ${{ github.event.repository.name }}
           ADOBE_LAUNCH_SRC: ${{ secrets.AIO_ADOBE_LAUNCH_SRC }}


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the memory allocation error in the GitHub Pages workflow.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

none
