### PR TITLE
Fix GH Pages workflow

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           yarn build
         env:
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          NODE_OPTIONS: "--max-old-space-size=8192"
           PREFIX_PATHS: true # works like --prefix-paths flag for 'gatsby build'
           PATH_PREFIX: ${{ github.event.repository.name }}
           ADOBE_LAUNCH_SRC: ${{ secrets.AIO_ADOBE_LAUNCH_SRC }}


### PR DESCRIPTION
Increase memory allocation

## Purpose of this pull request

This pull request (PR) attempts to fix the [heap limit allocation failure](https://github.com/commerce-docs/commerce-php/actions/runs/5195070095/jobs/9367419745#step:4:65) for the GitHub Pages workflow.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- none
