### PR TITLE
Update BIC reference data

### DIFF
--- a/src/pages/_includes/backward-incompatible-changes/b2b/2.4.6-2.4.7-beta1.md
+++ b/src/pages/_includes/backward-incompatible-changes/b2b/2.4.6-2.4.7-beta1.md
@@ -1,0 +1,303 @@
+#### Class changes {#b2b-246-247-beta1-class}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\AdobeCommerceEventsClient\Event\EventInitializationException | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\AdobeConsoleConfiguration\OAuth | Class was added. |
+| Magento\AdobeIoEventsClient\Model\EventMetadataClient | Class was added. |
+| Magento\Authorization\Model\CompositeUserContext | Interface has been added. |
+| Magento\Authorization\Model\CompositeUserContext::\_resetState | [public] Method has been added. |
+| Magento\Bundle\Block\Catalog\Product\View\Type\Bundle | Interface has been added. |
+| Magento\Bundle\Block\Catalog\Product\View\Type\Bundle::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Indexer\Category\Product\AbstractAction | Interface has been added. |
+| Magento\Catalog\Model\Indexer\Category\Product\AbstractAction::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Layer | Interface has been added. |
+| Magento\Catalog\Model\Layer::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Layer\Resolver | Interface has been added. |
+| Magento\Catalog\Model\Layer\Resolver::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Product | Interface has been added. |
+| Magento\Catalog\Model\Product::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Product\Media\Config | Interface has been added. |
+| Magento\Catalog\Model\Product\Media\Config::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Product\Option\Type\DefaultType | Interface has been added. |
+| Magento\Catalog\Model\Product\Option\Type\DefaultType::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Product\Type\Price | Interface has been added. |
+| Magento\Catalog\Model\Product\Type\Price::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\ResourceModel\Product | Interface has been added. |
+| Magento\Config\App\Config\Type\System::\_\_debugInfo | [public] Method has been added. |
+| Magento\Config\App\Config\Type\System::cleanAndWarmDefaultScopeData | [public] Method has been added. |
+| Magento\Config\App\Config\Type\System::loadDefaultScopeData | [private] Removed last method parameter(s). |
+| Magento\Config\Model\ResourceModel\Config::\_construct | [protected] Added optional parameter(s). |
+| Magento\ConfigurableProduct\Model\Product\Type\Configurable | Interface has been added. |
+| Magento\ConfigurableProduct\Model\Product\Type\Configurable::\_resetState | [public] Method has been added. |
+| Magento\ConfigurableProduct\Model\Product\VariationHandler | Interface has been added. |
+| Magento\ConfigurableProduct\Model\Product\VariationHandler::\_resetState | [public] Method has been added. |
+| Magento\Customer\Helper\Address | Interface has been added. |
+| Magento\Customer\Helper\Address::\_resetState | [public] Method has been added. |
+| Magento\Customer\Model\Address\AbstractAddress | Interface has been added. |
+| Magento\Customer\Model\Address\AbstractAddress::\_resetState | [public] Method has been added. |
+| Magento\Customer\Model\CustomerRegistry | Interface has been added. |
+| Magento\Customer\Model\CustomerRegistry::\_resetState | [public] Method has been added. |
+| Magento\DataExporter\Model\Indexer\FeedIndexer | Class was added. |
+| Magento\Directory\Helper\Data | Interface has been added. |
+| Magento\Directory\Helper\Data::\_resetState | [public] Method has been added. |
+| Magento\Directory\Model\Country::\_resetState | [public] Method has been added. |
+| Magento\Directory\Model\ResourceModel\Currency | Interface has been added. |
+| Magento\Directory\Model\ResourceModel\Currency::\_resetState | [public] Method has been added. |
+| Magento\Eav\Model\Config | Interface has been added. |
+| Magento\Eav\Model\Config::\_resetState | [public] Method has been added. |
+| Magento\Eav\Model\Entity\AbstractEntity | Interface has been added. |
+| Magento\Eav\Model\Entity\AbstractEntity::\_resetState | [public] Method has been added. |
+| Magento\Eav\Model\Entity\Attribute\AbstractAttribute | Interface has been added. |
+| Magento\Eav\Model\Entity\Attribute\AbstractAttribute::\_resetState | [public] Method has been added. |
+| Magento\Eav\Model\Entity\Attribute\Source\Table | Interface has been added. |
+| Magento\Eav\Model\Entity\Attribute\Source\Table::\_resetState | [public] Method has been added. |
+| Magento\Framework\Acl\Builder | Interface has been added. |
+| Magento\Framework\Acl\Builder::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\ActionFlag | Interface has been added. |
+| Magento\Framework\App\ActionFlag::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\AreaList | Interface has been added. |
+| Magento\Framework\App\AreaList::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\DeploymentConfig::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\App\Http\Context | Interface has been added. |
+| Magento\Framework\App\Http\Context::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\Request\Http | Interface has been added. |
+| Magento\Framework\App\Request\Http::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\ResourceConnection | Interface has been added. |
+| Magento\Framework\App\ResourceConnection::\_resetState | [public] Method has been added. |
+| Magento\Framework\Config\Data::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\DB\Adapter\Pdo\Mysql | Interface has been added. |
+| Magento\Framework\DB\Adapter\Pdo\Mysql::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\DB\Adapter\Pdo\Mysql::\_resetState | [public] Method has been added. |
+| Magento\Framework\DataObject::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\Data\Collection | Interface has been added. |
+| Magento\Framework\Data\Collection::\_resetState | [public] Method has been added. |
+| Magento\Framework\Filesystem\DirectoryList::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\Filesystem\Directory\Read::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\GraphQl\Query\Resolver\BatchResponse | Interface has been added. |
+| Magento\Framework\GraphQl\Query\Resolver\BatchResponse::\_resetState | [public] Method has been added. |
+| Magento\Framework\Logger\Handler\Base::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\Pricing\Price\Collection | Interface has been added. |
+| Magento\Framework\Pricing\Price\Collection::\_resetState | [public] Method has been added. |
+| Magento\Framework\Registry | Interface has been added. |
+| Magento\Framework\Registry::\_resetState | [public] Method has been added. |
+| Magento\Framework\Search\Request\Builder | Interface has been added. |
+| Magento\Framework\Search\Request\Builder::\_resetState | [public] Method has been added. |
+| Magento\Framework\Validator | Interface has been added. |
+| Magento\Framework\Validator\AbstractValidator | Interface has been added. |
+| Magento\Framework\Validator\AbstractValidator::\_resetState | [public] Method has been added. |
+| Magento\Framework\View\Asset\Minification | Interface has been added. |
+| Magento\Framework\View\Asset\Minification::\_resetState | [public] Method has been added. |
+| Magento\Framework\View\Asset\Repository | Interface has been added. |
+| Magento\Framework\View\Asset\Repository::\_resetState | [public] Method has been added. |
+| Magento\Framework\Webapi\Exception::HTTP\_TOO\_MANY\_REQUESTS | Constant has been added. |
+| Magento\FunctionalTestingFramework\Module\MagentoWebDriver::\_getCurrentUri | [public] Method return typing changed. |
+| Magento\GraphQlServer\Model\UrlProvider | Class was added. |
+| Magento\NegotiableQuote\Block\Adminhtml\Quote\Create\Form | Class was added. |
+| Magento\NegotiableQuote\Block\Adminhtml\Quote\Create\Store\Select | Class was added. |
+| Magento\NegotiableQuote\Block\Quote\Item\Actions\Note | Class was added. |
+| Magento\PaymentServicesBase\Block\Adminhtml\System\Config\Fieldset\Child | Class was added. |
+| Magento\PaymentServicesBase\Block\Adminhtml\System\Config\Fieldset\Payment | Class was added. |
+| Magento\PaymentServicesDashboard\Block\Adminhtml\Index | Class was added. |
+| Magento\PaymentServicesDashboard\Block\Adminhtml\System\Config\MagentoPaymentsButton | Class was added. |
+| Magento\PaymentServicesDashboard\Block\Adminhtml\System\Config\MagentoPaymentsRedirect | Class was added. |
+| Magento\PaymentServicesPaypal\Block\Cart\ValidationMessages | Class was added. |
+| Magento\PaymentServicesPaypal\Block\Customer\CardRenderer | Class was added. |
+| Magento\PaymentServicesPaypal\Block\Info | Class was added. |
+| Magento\PaymentServicesPaypal\Block\Message | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtons | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtonsCart | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtonsProduct | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtons\Review | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtons\Review\Details | Class was added. |
+| Magento\SaaSCommon\Model\ResyncManager | Class was added. |
+| Magento\ServicesIdLayout\Block\Adminhtml\Index | Class was added. |
+| Magento\Store\Model\App\Emulation::\_resetState | [public] Method has been added. |
+| Magento\Store\Model\Store | Interface has been added. |
+| Magento\Store\Model\Store::\_resetState | [public] Method has been added. |
+| Magento\TargetRule\Block\Catalog\Product\ProductList\Related::getExcludeProductIds | [public] Method has been removed. |
+| Magento\TargetRule\Block\Catalog\Product\ProductList\Upsell::getExcludeProductIds | [public] Method has been removed. |
+| Magento\UrlRewrite\Model\UrlRewrite | Interface has been added. |
+| Magento\UrlRewrite\Model\UrlRewrite::\_resetState | [public] Method has been added. |
+
+#### Interface changes {#b2b-246-247-beta1-interface}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\AdobeCommerceEventsClient\Event\EventRetrieverInterface | Interface was added. |
+| Magento\AdobeCommerceEventsClient\Event\Rule\RuleInterface | Interface was added. |
+| Magento\Framework\ObjectManager\ResetAfterRequestInterface | Interface was added. |
+| Magento\NegotiableQuote\Api\Data\ItemNoteInterface | Interface was added. |
+| Magento\NegotiableQuote\Api\Data\ItemNoteSearchResultsInterface | Interface was added. |
+| Magento\NegotiableQuote\Api\Data\NegotiableQuoteInterface::STATUS\_DRAFT\_BY\_ADMIN | Constant has been added. |
+| Magento\NegotiableQuote\Api\Data\NegotiableQuoteItemInterface::NEGOTIATED\_PRICE\_TYPE | Constant has been added. |
+| Magento\NegotiableQuote\Api\Data\NegotiableQuoteItemInterface::NEGOTIATED\_PRICE\_TYPE\_AMOUNT\_DISCOUNT | Constant has been added. |
+| Magento\NegotiableQuote\Api\Data\NegotiableQuoteItemInterface::NEGOTIATED\_PRICE\_TYPE\_PERCENTAGE\_DISCOUNT | Constant has been added. |
+| Magento\NegotiableQuote\Api\Data\NegotiableQuoteItemInterface::NEGOTIATED\_PRICE\_TYPE\_PROPOSED\_TOTAL | Constant has been added. |
+| Magento\NegotiableQuote\Api\Data\NegotiableQuoteItemInterface::NEGOTIATED\_PRICE\_VALUE | Constant has been added. |
+| Magento\NegotiableQuote\Api\ItemNoteRepositoryInterface | Interface was added. |
+| Magento\NegotiableQuote\Api\NegotiableQuoteDraftManagementInterface | Interface was added. |
+| Magento\NegotiableQuote\Model\Restriction\RestrictionInterface::ACTION\_VIEW | Constant has been added. |
+| Magento\SaaSCommon\Model\Http\ConverterInterface | Interface was added. |
+| Magento\ServicesId\Model\ServicesClientInterface | Interface was added. |
+| Magento\ServicesId\Model\ServicesConfigInterface | Interface was added. |
+| Magento\SharedCatalog\Api\AssignTierPriceInterface | Interface was added. |
+| Magento\SharedCatalog\Api\ResetTierPriceInterface | Interface was added. |
+
+#### Database changes {#b2b-246-247-beta1-database}
+
+| What changed | How it changed |
+| --- | --- |
+| data\_exporter\_uuid | Table was added |
+| event\_data/info | Column was added |
+| event\_data/priority | Column was added |
+| event\_data/updated\_at | Column was added |
+| negotiable\_quote\_item/negotiated\_price\_type | Column was added |
+| negotiable\_quote\_item/negotiated\_price\_value | Column was added |
+| negotiable\_quote\_item\_note | Table was added |
+| payment\_services\_order\_data\_production\_submitted\_hash | Table was added |
+| payment\_services\_order\_data\_sandbox\_submitted\_hash | Table was added |
+| payment\_services\_order\_status\_data\_production\_submitted\_hash | Table was added |
+| payment\_services\_order\_status\_data\_sandbox\_submitted\_hash | Table was added |
+| payment\_services\_store\_data\_production\_submitted\_hash | Table was added |
+| payment\_services\_store\_data\_sandbox\_submitted\_hash | Table was added |
+| sales\_data\_exporter\_order\_statuses | Table was added |
+| sales\_data\_exporter\_orders | Table was added |
+| stores\_data\_exporter | Table was added |
+
+#### System changes {#b2b-246-247-beta1-system}
+
+| What changed | How it changed |
+| --- | --- |
+| adobe\_io\_events/integration/authorization\_type | A field-node was added |
+| checkout/options/enable\_guest\_checkout\_login | A field-node was added |
+| payment | A section-node was added |
+| payment/recommended\_solutions | A group-node was added |
+| payment/recommended\_solutions/magento\_payments | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_color | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_height | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_height\_use\_default | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_label | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_layout | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_shape | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_tagline | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/active | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/method | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/production\_merchant\_id | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/sandbox\_merchant\_id | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/soft\_descriptor | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/debug | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/display\_on\_checkout | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/magento\_payments\_button | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/payment\_action | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/three\_ds | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/title | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/vault\_active | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/vault\_active\_admin | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/legacy\_admin\_enabled | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/debug | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_buttons\_cart | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_buttons\_checkout | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_buttons\_minicart | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_buttons\_product\_detail | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_paylater\_message | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/funding\_applepay | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/funding\_card | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/funding\_paypal\_credit | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/funding\_venmo | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/magento\_payments\_button | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/payment\_action | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/title | A field-node was added |
+| sales | A section-node was added |
+| sales/backpressure | A group-node was added |
+| sales/backpressure/enabled | A field-node was added |
+| sales/backpressure/guest\_limit | A field-node was added |
+| sales/backpressure/limit | A field-node was added |
+| sales/backpressure/period | A field-node was added |
+| sales\_email/quote/new\_quote\_by\_seller\_template | A field-node was added |
+| services\_connector | A section-node was added |
+| services\_connector/services\_connector\_integration | A group-node was added |
+| services\_connector/services\_connector\_integration/production\_api\_key | A field-node was added |
+| services\_connector/services\_connector\_integration/production\_private\_key | A field-node was added |
+| services\_connector/services\_connector\_integration/sandbox\_api\_key | A field-node was added |
+| services\_connector/services\_connector\_integration/sandbox\_private\_key | A field-node was added |
+| services\_connector/services\_id\_onboarding | A group-node was added |
+| services\_connector/services\_id\_onboarding/initiate\_onboarding | A field-node was added |
+
+#### Xsd changes {#b2b-246-247-beta1-xsd}
+
+| What changed | How it changed |
+| --- | --- |
+| app/code/module-adobe-commerce-events-client/etc/io\_events.xsd | A schema declaration was added |
+| app/code/module-adobe-commerce-events-client/etc/io\_events.xsd | A schema declaration was removed |
+| app/code/module-data-exporter/etc/et\_schema.xsd | A schema declaration was added |
+| app/code/module-query-xml/etc/query.xsd | A schema declaration was added |
+
+#### EtSchema changes {#b2b-246-247-beta1-etSchema}
+
+| What changed | How it changed |
+| --- | --- |
+| CreditMemo | Added a new declaration for record CreditMemo. |
+| Export | Added a new declaration for record Export. |
+| Invoice | Added a new declaration for record Invoice. |
+| Order | Added a new declaration for record Order. |
+| OrderItem | Added a new declaration for record OrderItem. |
+| OrderStatus | Added a new declaration for record OrderStatus. |
+| Transaction | Added a new declaration for record Transaction. |
+
+#### Class API membership changes {#b2b-246-247-beta1-class-api-membership}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\AdobeCommerceEventsClient\Event\Converter\EventDataConverter | Class was added. |
+| Magento\AdobeCommerceEventsClient\Event\Event | Class was added. |
+| Magento\AdobeCommerceEventsClient\Event\EventList | Class was added. |
+| Magento\AdobeCommerceEventsClient\Event\EventStorageWriter | Class was added. |
+| Magento\AdobeCommerceEventsClient\Event\InvalidConfigurationException | Class was added. |
+| Magento\AdobeCommerceEventsClient\Event\Validator\ValidatorException | Class was added. |
+| Magento\AdobeCommerceEventsClient\Model\EventException | Class was added. |
+| Magento\AdobeCommerceEventsClient\Util\EventCodeConverter | Class was added. |
+| Magento\AdobeIoEventsClient\Model\AdobeIOConfigurationProvider | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\AdobeConsoleConfiguration\AdobeConsoleConfiguration | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\AdobeConsoleConfiguration\Credentials | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\AdobeConsoleConfiguration\JWT | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\AdobeConsoleConfiguration\Organization | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\AdobeConsoleConfiguration\Project | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\AdobeConsoleConfiguration\Runtime | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\AdobeConsoleConfiguration\RuntimeNamespace | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\AdobeConsoleConfiguration\Workspace | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\AdobeConsoleConfiguration\WorkspaceDetails | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\EventMetadata | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\EventProvider | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\PrivateKey | Class was added. |
+| Magento\Framework\Api\AbstractSimpleObjectBuilder | Class was added. |
+| Magento\Framework\Cache\Frontend\Decorator\Bare | Class was added. |
+| Magento\Framework\Data\Structure | Class was added. |
+| Magento\Framework\HTTP\PhpEnvironment\Request | Class was added. |
+| Magento\Framework\HTTP\PhpEnvironment\Response | Class was added. |
+| Magento\Framework\Locale\Resolver | Class was added. |
+| Magento\Framework\ObjectManager\ObjectManager | Class was added. |
+| Magento\Framework\Session\SessionManager | Class was added. |
+| Magento\Framework\Url | Class was added. |
+| Magento\Framework\Webapi\Request | Class was added. |
+| Magento\SalesRule\Model\Validator | Class was added. |
+
+#### Interface API membership changes {#b2b-246-247-beta1-interface-api-membership}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\AdobeCommerceEventsClient\Api\Data\EventInterface | Interface was added. |
+| Magento\AdobeCommerceEventsClient\Api\EventRepositoryInterface | Interface was added. |
+| Magento\AdobeCommerceEventsClient\Event\EventSubscriberInterface | Interface was added. |
+| Magento\AdobeCommerceEventsClient\Event\Operator\OperatorInterface | Interface was added. |
+| Magento\AdobeIoEventsClient\Api\AccessTokenProviderInterface | Interface was added. |
+| Magento\AdobeIoEventsClient\Api\ConfigurationCheckInterface | Interface was added. |
+| Magento\AdobeIoEventsClient\Api\ConfigurationCheckResultInterface | Interface was added. |
+| Magento\AdobeIoEventsClient\Api\EventMetadataInterface | Interface was added. |
+| Magento\AdobeIoEventsClient\Api\EventMetadataRegistryInterface | Interface was added. |
+| Magento\AdobeIoEventsClient\Api\EventProviderInterface | Interface was added. |

--- a/src/pages/_includes/backward-incompatible-changes/commerce/2.4.6-2.4.7-beta1.md
+++ b/src/pages/_includes/backward-incompatible-changes/commerce/2.4.6-2.4.7-beta1.md
@@ -1,0 +1,283 @@
+#### Class changes {#ee-246-247-beta1-class}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\AdobeCommerceEventsClient\Event\EventInitializationException | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\AdobeConsoleConfiguration\OAuth | Class was added. |
+| Magento\AdobeIoEventsClient\Model\EventMetadataClient | Class was added. |
+| Magento\Authorization\Model\CompositeUserContext | Interface has been added. |
+| Magento\Authorization\Model\CompositeUserContext::\_resetState | [public] Method has been added. |
+| Magento\Bundle\Block\Catalog\Product\View\Type\Bundle | Interface has been added. |
+| Magento\Bundle\Block\Catalog\Product\View\Type\Bundle::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Indexer\Category\Product\AbstractAction | Interface has been added. |
+| Magento\Catalog\Model\Indexer\Category\Product\AbstractAction::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Layer | Interface has been added. |
+| Magento\Catalog\Model\Layer::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Layer\Resolver | Interface has been added. |
+| Magento\Catalog\Model\Layer\Resolver::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Product | Interface has been added. |
+| Magento\Catalog\Model\Product::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Product\Media\Config | Interface has been added. |
+| Magento\Catalog\Model\Product\Media\Config::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Product\Option\Type\DefaultType | Interface has been added. |
+| Magento\Catalog\Model\Product\Option\Type\DefaultType::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Product\Type\Price | Interface has been added. |
+| Magento\Catalog\Model\Product\Type\Price::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\ResourceModel\Product | Interface has been added. |
+| Magento\Config\App\Config\Type\System::\_\_debugInfo | [public] Method has been added. |
+| Magento\Config\App\Config\Type\System::cleanAndWarmDefaultScopeData | [public] Method has been added. |
+| Magento\Config\App\Config\Type\System::loadDefaultScopeData | [private] Removed last method parameter(s). |
+| Magento\Config\Model\ResourceModel\Config::\_construct | [protected] Added optional parameter(s). |
+| Magento\ConfigurableProduct\Model\Product\Type\Configurable | Interface has been added. |
+| Magento\ConfigurableProduct\Model\Product\Type\Configurable::\_resetState | [public] Method has been added. |
+| Magento\ConfigurableProduct\Model\Product\VariationHandler | Interface has been added. |
+| Magento\ConfigurableProduct\Model\Product\VariationHandler::\_resetState | [public] Method has been added. |
+| Magento\Customer\Helper\Address | Interface has been added. |
+| Magento\Customer\Helper\Address::\_resetState | [public] Method has been added. |
+| Magento\Customer\Model\Address\AbstractAddress | Interface has been added. |
+| Magento\Customer\Model\Address\AbstractAddress::\_resetState | [public] Method has been added. |
+| Magento\Customer\Model\CustomerRegistry | Interface has been added. |
+| Magento\Customer\Model\CustomerRegistry::\_resetState | [public] Method has been added. |
+| Magento\DataExporter\Model\Indexer\FeedIndexer | Class was added. |
+| Magento\Directory\Helper\Data | Interface has been added. |
+| Magento\Directory\Helper\Data::\_resetState | [public] Method has been added. |
+| Magento\Directory\Model\Country::\_resetState | [public] Method has been added. |
+| Magento\Directory\Model\ResourceModel\Currency | Interface has been added. |
+| Magento\Directory\Model\ResourceModel\Currency::\_resetState | [public] Method has been added. |
+| Magento\Eav\Model\Config | Interface has been added. |
+| Magento\Eav\Model\Config::\_resetState | [public] Method has been added. |
+| Magento\Eav\Model\Entity\AbstractEntity | Interface has been added. |
+| Magento\Eav\Model\Entity\AbstractEntity::\_resetState | [public] Method has been added. |
+| Magento\Eav\Model\Entity\Attribute\AbstractAttribute | Interface has been added. |
+| Magento\Eav\Model\Entity\Attribute\AbstractAttribute::\_resetState | [public] Method has been added. |
+| Magento\Eav\Model\Entity\Attribute\Source\Table | Interface has been added. |
+| Magento\Eav\Model\Entity\Attribute\Source\Table::\_resetState | [public] Method has been added. |
+| Magento\Framework\Acl\Builder | Interface has been added. |
+| Magento\Framework\Acl\Builder::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\ActionFlag | Interface has been added. |
+| Magento\Framework\App\ActionFlag::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\AreaList | Interface has been added. |
+| Magento\Framework\App\AreaList::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\DeploymentConfig::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\App\Http\Context | Interface has been added. |
+| Magento\Framework\App\Http\Context::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\Request\Http | Interface has been added. |
+| Magento\Framework\App\Request\Http::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\ResourceConnection | Interface has been added. |
+| Magento\Framework\App\ResourceConnection::\_resetState | [public] Method has been added. |
+| Magento\Framework\Config\Data::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\DB\Adapter\Pdo\Mysql | Interface has been added. |
+| Magento\Framework\DB\Adapter\Pdo\Mysql::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\DB\Adapter\Pdo\Mysql::\_resetState | [public] Method has been added. |
+| Magento\Framework\DataObject::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\Data\Collection | Interface has been added. |
+| Magento\Framework\Data\Collection::\_resetState | [public] Method has been added. |
+| Magento\Framework\Filesystem\DirectoryList::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\Filesystem\Directory\Read::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\GraphQl\Query\Resolver\BatchResponse | Interface has been added. |
+| Magento\Framework\GraphQl\Query\Resolver\BatchResponse::\_resetState | [public] Method has been added. |
+| Magento\Framework\Logger\Handler\Base::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\Pricing\Price\Collection | Interface has been added. |
+| Magento\Framework\Pricing\Price\Collection::\_resetState | [public] Method has been added. |
+| Magento\Framework\Registry | Interface has been added. |
+| Magento\Framework\Registry::\_resetState | [public] Method has been added. |
+| Magento\Framework\Search\Request\Builder | Interface has been added. |
+| Magento\Framework\Search\Request\Builder::\_resetState | [public] Method has been added. |
+| Magento\Framework\Validator | Interface has been added. |
+| Magento\Framework\Validator\AbstractValidator | Interface has been added. |
+| Magento\Framework\Validator\AbstractValidator::\_resetState | [public] Method has been added. |
+| Magento\Framework\View\Asset\Minification | Interface has been added. |
+| Magento\Framework\View\Asset\Minification::\_resetState | [public] Method has been added. |
+| Magento\Framework\View\Asset\Repository | Interface has been added. |
+| Magento\Framework\View\Asset\Repository::\_resetState | [public] Method has been added. |
+| Magento\Framework\Webapi\Exception::HTTP\_TOO\_MANY\_REQUESTS | Constant has been added. |
+| Magento\FunctionalTestingFramework\Module\MagentoWebDriver::\_getCurrentUri | [public] Method return typing changed. |
+| Magento\GraphQlServer\Model\UrlProvider | Class was added. |
+| Magento\PaymentServicesBase\Block\Adminhtml\System\Config\Fieldset\Child | Class was added. |
+| Magento\PaymentServicesBase\Block\Adminhtml\System\Config\Fieldset\Payment | Class was added. |
+| Magento\PaymentServicesDashboard\Block\Adminhtml\Index | Class was added. |
+| Magento\PaymentServicesDashboard\Block\Adminhtml\System\Config\MagentoPaymentsButton | Class was added. |
+| Magento\PaymentServicesDashboard\Block\Adminhtml\System\Config\MagentoPaymentsRedirect | Class was added. |
+| Magento\PaymentServicesPaypal\Block\Cart\ValidationMessages | Class was added. |
+| Magento\PaymentServicesPaypal\Block\Customer\CardRenderer | Class was added. |
+| Magento\PaymentServicesPaypal\Block\Info | Class was added. |
+| Magento\PaymentServicesPaypal\Block\Message | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtons | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtonsCart | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtonsProduct | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtons\Review | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtons\Review\Details | Class was added. |
+| Magento\SaaSCommon\Model\ResyncManager | Class was added. |
+| Magento\ServicesIdLayout\Block\Adminhtml\Index | Class was added. |
+| Magento\Store\Model\App\Emulation::\_resetState | [public] Method has been added. |
+| Magento\Store\Model\Store | Interface has been added. |
+| Magento\Store\Model\Store::\_resetState | [public] Method has been added. |
+| Magento\TargetRule\Block\Catalog\Product\ProductList\Related::getExcludeProductIds | [public] Method has been removed. |
+| Magento\TargetRule\Block\Catalog\Product\ProductList\Upsell::getExcludeProductIds | [public] Method has been removed. |
+| Magento\UrlRewrite\Model\UrlRewrite | Interface has been added. |
+| Magento\UrlRewrite\Model\UrlRewrite::\_resetState | [public] Method has been added. |
+
+#### Interface changes {#ee-246-247-beta1-interface}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\AdobeCommerceEventsClient\Event\EventRetrieverInterface | Interface was added. |
+| Magento\AdobeCommerceEventsClient\Event\Rule\RuleInterface | Interface was added. |
+| Magento\Framework\ObjectManager\ResetAfterRequestInterface | Interface was added. |
+| Magento\SaaSCommon\Model\Http\ConverterInterface | Interface was added. |
+| Magento\ServicesId\Model\ServicesClientInterface | Interface was added. |
+| Magento\ServicesId\Model\ServicesConfigInterface | Interface was added. |
+
+#### Database changes {#ee-246-247-beta1-database}
+
+| What changed | How it changed |
+| --- | --- |
+| data\_exporter\_uuid | Table was added |
+| event\_data/info | Column was added |
+| event\_data/priority | Column was added |
+| event\_data/updated\_at | Column was added |
+| payment\_services\_order\_data\_production\_submitted\_hash | Table was added |
+| payment\_services\_order\_data\_sandbox\_submitted\_hash | Table was added |
+| payment\_services\_order\_status\_data\_production\_submitted\_hash | Table was added |
+| payment\_services\_order\_status\_data\_sandbox\_submitted\_hash | Table was added |
+| payment\_services\_store\_data\_production\_submitted\_hash | Table was added |
+| payment\_services\_store\_data\_sandbox\_submitted\_hash | Table was added |
+| sales\_data\_exporter\_order\_statuses | Table was added |
+| sales\_data\_exporter\_orders | Table was added |
+| stores\_data\_exporter | Table was added |
+
+#### System changes {#ee-246-247-beta1-system}
+
+| What changed | How it changed |
+| --- | --- |
+| adobe\_io\_events/integration/authorization\_type | A field-node was added |
+| checkout/options/enable\_guest\_checkout\_login | A field-node was added |
+| payment | A section-node was added |
+| payment/recommended\_solutions | A group-node was added |
+| payment/recommended\_solutions/magento\_payments | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_color | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_height | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_height\_use\_default | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_label | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_layout | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_shape | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_tagline | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/active | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/method | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/production\_merchant\_id | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/sandbox\_merchant\_id | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/soft\_descriptor | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/debug | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/display\_on\_checkout | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/magento\_payments\_button | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/payment\_action | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/three\_ds | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/title | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/vault\_active | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/vault\_active\_admin | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/legacy\_admin\_enabled | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/debug | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_buttons\_cart | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_buttons\_checkout | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_buttons\_minicart | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_buttons\_product\_detail | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_paylater\_message | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/funding\_applepay | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/funding\_card | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/funding\_paypal\_credit | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/funding\_venmo | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/magento\_payments\_button | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/payment\_action | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/title | A field-node was added |
+| sales | A section-node was added |
+| sales/backpressure | A group-node was added |
+| sales/backpressure/enabled | A field-node was added |
+| sales/backpressure/guest\_limit | A field-node was added |
+| sales/backpressure/limit | A field-node was added |
+| sales/backpressure/period | A field-node was added |
+| services\_connector | A section-node was added |
+| services\_connector/services\_connector\_integration | A group-node was added |
+| services\_connector/services\_connector\_integration/production\_api\_key | A field-node was added |
+| services\_connector/services\_connector\_integration/production\_private\_key | A field-node was added |
+| services\_connector/services\_connector\_integration/sandbox\_api\_key | A field-node was added |
+| services\_connector/services\_connector\_integration/sandbox\_private\_key | A field-node was added |
+| services\_connector/services\_id\_onboarding | A group-node was added |
+| services\_connector/services\_id\_onboarding/initiate\_onboarding | A field-node was added |
+
+#### Xsd changes {#ee-246-247-beta1-xsd}
+
+| What changed | How it changed |
+| --- | --- |
+| app/code/module-adobe-commerce-events-client/etc/io\_events.xsd | A schema declaration was added |
+| app/code/module-adobe-commerce-events-client/etc/io\_events.xsd | A schema declaration was removed |
+| app/code/module-data-exporter/etc/et\_schema.xsd | A schema declaration was added |
+| app/code/module-query-xml/etc/query.xsd | A schema declaration was added |
+
+#### EtSchema changes {#ee-246-247-beta1-etSchema}
+
+| What changed | How it changed |
+| --- | --- |
+| CreditMemo | Added a new declaration for record CreditMemo. |
+| Export | Added a new declaration for record Export. |
+| Invoice | Added a new declaration for record Invoice. |
+| Order | Added a new declaration for record Order. |
+| OrderItem | Added a new declaration for record OrderItem. |
+| OrderStatus | Added a new declaration for record OrderStatus. |
+| Transaction | Added a new declaration for record Transaction. |
+
+#### Class API membership changes {#ee-246-247-beta1-class-api-membership}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\AdobeCommerceEventsClient\Event\Converter\EventDataConverter | Class was added. |
+| Magento\AdobeCommerceEventsClient\Event\Event | Class was added. |
+| Magento\AdobeCommerceEventsClient\Event\EventList | Class was added. |
+| Magento\AdobeCommerceEventsClient\Event\EventStorageWriter | Class was added. |
+| Magento\AdobeCommerceEventsClient\Event\InvalidConfigurationException | Class was added. |
+| Magento\AdobeCommerceEventsClient\Event\Validator\ValidatorException | Class was added. |
+| Magento\AdobeCommerceEventsClient\Model\EventException | Class was added. |
+| Magento\AdobeCommerceEventsClient\Util\EventCodeConverter | Class was added. |
+| Magento\AdobeIoEventsClient\Model\AdobeIOConfigurationProvider | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\AdobeConsoleConfiguration\AdobeConsoleConfiguration | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\AdobeConsoleConfiguration\Credentials | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\AdobeConsoleConfiguration\JWT | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\AdobeConsoleConfiguration\Organization | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\AdobeConsoleConfiguration\Project | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\AdobeConsoleConfiguration\Runtime | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\AdobeConsoleConfiguration\RuntimeNamespace | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\AdobeConsoleConfiguration\Workspace | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\AdobeConsoleConfiguration\WorkspaceDetails | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\EventMetadata | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\EventProvider | Class was added. |
+| Magento\AdobeIoEventsClient\Model\Data\PrivateKey | Class was added. |
+| Magento\Framework\Api\AbstractSimpleObjectBuilder | Class was added. |
+| Magento\Framework\Cache\Frontend\Decorator\Bare | Class was added. |
+| Magento\Framework\Data\Structure | Class was added. |
+| Magento\Framework\HTTP\PhpEnvironment\Request | Class was added. |
+| Magento\Framework\HTTP\PhpEnvironment\Response | Class was added. |
+| Magento\Framework\Locale\Resolver | Class was added. |
+| Magento\Framework\ObjectManager\ObjectManager | Class was added. |
+| Magento\Framework\Session\SessionManager | Class was added. |
+| Magento\Framework\Url | Class was added. |
+| Magento\Framework\Webapi\Request | Class was added. |
+| Magento\SalesRule\Model\Validator | Class was added. |
+
+#### Interface API membership changes {#ee-246-247-beta1-interface-api-membership}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\AdobeCommerceEventsClient\Api\Data\EventInterface | Interface was added. |
+| Magento\AdobeCommerceEventsClient\Api\EventRepositoryInterface | Interface was added. |
+| Magento\AdobeCommerceEventsClient\Event\EventSubscriberInterface | Interface was added. |
+| Magento\AdobeCommerceEventsClient\Event\Operator\OperatorInterface | Interface was added. |
+| Magento\AdobeIoEventsClient\Api\AccessTokenProviderInterface | Interface was added. |
+| Magento\AdobeIoEventsClient\Api\ConfigurationCheckInterface | Interface was added. |
+| Magento\AdobeIoEventsClient\Api\ConfigurationCheckResultInterface | Interface was added. |
+| Magento\AdobeIoEventsClient\Api\EventMetadataInterface | Interface was added. |
+| Magento\AdobeIoEventsClient\Api\EventMetadataRegistryInterface | Interface was added. |
+| Magento\AdobeIoEventsClient\Api\EventProviderInterface | Interface was added. |

--- a/src/pages/_includes/backward-incompatible-changes/open-source/2.4.6-2.4.7-beta1.md
+++ b/src/pages/_includes/backward-incompatible-changes/open-source/2.4.6-2.4.7-beta1.md
@@ -1,0 +1,239 @@
+#### Class changes {#ce-246-247-beta1-class}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\Authorization\Model\CompositeUserContext | Interface has been added. |
+| Magento\Authorization\Model\CompositeUserContext::\_resetState | [public] Method has been added. |
+| Magento\Bundle\Block\Catalog\Product\View\Type\Bundle | Interface has been added. |
+| Magento\Bundle\Block\Catalog\Product\View\Type\Bundle::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Indexer\Category\Product\AbstractAction | Interface has been added. |
+| Magento\Catalog\Model\Indexer\Category\Product\AbstractAction::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Layer | Interface has been added. |
+| Magento\Catalog\Model\Layer::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Layer\Resolver | Interface has been added. |
+| Magento\Catalog\Model\Layer\Resolver::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Product | Interface has been added. |
+| Magento\Catalog\Model\Product::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Product\Media\Config | Interface has been added. |
+| Magento\Catalog\Model\Product\Media\Config::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Product\Option\Type\DefaultType | Interface has been added. |
+| Magento\Catalog\Model\Product\Option\Type\DefaultType::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Product\Type\Price | Interface has been added. |
+| Magento\Catalog\Model\Product\Type\Price::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\ResourceModel\Product | Interface has been added. |
+| Magento\Config\App\Config\Type\System::\_\_debugInfo | [public] Method has been added. |
+| Magento\Config\App\Config\Type\System::cleanAndWarmDefaultScopeData | [public] Method has been added. |
+| Magento\Config\App\Config\Type\System::loadDefaultScopeData | [private] Removed last method parameter(s). |
+| Magento\Config\Model\ResourceModel\Config::\_construct | [protected] Added optional parameter(s). |
+| Magento\ConfigurableProduct\Model\Product\Type\Configurable | Interface has been added. |
+| Magento\ConfigurableProduct\Model\Product\Type\Configurable::\_resetState | [public] Method has been added. |
+| Magento\ConfigurableProduct\Model\Product\VariationHandler | Interface has been added. |
+| Magento\ConfigurableProduct\Model\Product\VariationHandler::\_resetState | [public] Method has been added. |
+| Magento\Customer\Helper\Address | Interface has been added. |
+| Magento\Customer\Helper\Address::\_resetState | [public] Method has been added. |
+| Magento\Customer\Model\Address\AbstractAddress | Interface has been added. |
+| Magento\Customer\Model\Address\AbstractAddress::\_resetState | [public] Method has been added. |
+| Magento\Customer\Model\CustomerRegistry | Interface has been added. |
+| Magento\Customer\Model\CustomerRegistry::\_resetState | [public] Method has been added. |
+| Magento\DataExporter\Model\Indexer\FeedIndexer | Class was added. |
+| Magento\Directory\Helper\Data | Interface has been added. |
+| Magento\Directory\Helper\Data::\_resetState | [public] Method has been added. |
+| Magento\Directory\Model\Country::\_resetState | [public] Method has been added. |
+| Magento\Directory\Model\ResourceModel\Currency | Interface has been added. |
+| Magento\Directory\Model\ResourceModel\Currency::\_resetState | [public] Method has been added. |
+| Magento\Eav\Model\Config | Interface has been added. |
+| Magento\Eav\Model\Config::\_resetState | [public] Method has been added. |
+| Magento\Eav\Model\Entity\AbstractEntity | Interface has been added. |
+| Magento\Eav\Model\Entity\AbstractEntity::\_resetState | [public] Method has been added. |
+| Magento\Eav\Model\Entity\Attribute\AbstractAttribute | Interface has been added. |
+| Magento\Eav\Model\Entity\Attribute\AbstractAttribute::\_resetState | [public] Method has been added. |
+| Magento\Eav\Model\Entity\Attribute\Source\Table | Interface has been added. |
+| Magento\Eav\Model\Entity\Attribute\Source\Table::\_resetState | [public] Method has been added. |
+| Magento\Framework\Acl\Builder | Interface has been added. |
+| Magento\Framework\Acl\Builder::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\ActionFlag | Interface has been added. |
+| Magento\Framework\App\ActionFlag::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\AreaList | Interface has been added. |
+| Magento\Framework\App\AreaList::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\DeploymentConfig::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\App\Http\Context | Interface has been added. |
+| Magento\Framework\App\Http\Context::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\Request\Http | Interface has been added. |
+| Magento\Framework\App\Request\Http::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\ResourceConnection | Interface has been added. |
+| Magento\Framework\App\ResourceConnection::\_resetState | [public] Method has been added. |
+| Magento\Framework\Config\Data::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\DB\Adapter\Pdo\Mysql | Interface has been added. |
+| Magento\Framework\DB\Adapter\Pdo\Mysql::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\DB\Adapter\Pdo\Mysql::\_resetState | [public] Method has been added. |
+| Magento\Framework\DataObject::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\Data\Collection | Interface has been added. |
+| Magento\Framework\Data\Collection::\_resetState | [public] Method has been added. |
+| Magento\Framework\Filesystem\DirectoryList::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\Filesystem\Directory\Read::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\ForeignKey\Migration\AbstractCommand | Class was added. |
+| Magento\Framework\GraphQl\Query\Resolver\BatchResponse | Interface has been added. |
+| Magento\Framework\GraphQl\Query\Resolver\BatchResponse::\_resetState | [public] Method has been added. |
+| Magento\Framework\Logger\Handler\Base::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\Pricing\Price\Collection | Interface has been added. |
+| Magento\Framework\Pricing\Price\Collection::\_resetState | [public] Method has been added. |
+| Magento\Framework\Registry | Interface has been added. |
+| Magento\Framework\Registry::\_resetState | [public] Method has been added. |
+| Magento\Framework\Search\Request\Builder | Interface has been added. |
+| Magento\Framework\Search\Request\Builder::\_resetState | [public] Method has been added. |
+| Magento\Framework\Validator | Interface has been added. |
+| Magento\Framework\Validator\AbstractValidator | Interface has been added. |
+| Magento\Framework\Validator\AbstractValidator::\_resetState | [public] Method has been added. |
+| Magento\Framework\View\Asset\Minification | Interface has been added. |
+| Magento\Framework\View\Asset\Minification::\_resetState | [public] Method has been added. |
+| Magento\Framework\View\Asset\Repository | Interface has been added. |
+| Magento\Framework\View\Asset\Repository::\_resetState | [public] Method has been added. |
+| Magento\Framework\Webapi\Exception::HTTP\_TOO\_MANY\_REQUESTS | Constant has been added. |
+| Magento\FunctionalTestingFramework\Module\MagentoWebDriver::\_getCurrentUri | [public] Method return typing changed. |
+| Magento\GraphQlServer\Model\UrlProvider | Class was added. |
+| Magento\PaymentServicesBase\Block\Adminhtml\System\Config\Fieldset\Child | Class was added. |
+| Magento\PaymentServicesBase\Block\Adminhtml\System\Config\Fieldset\Payment | Class was added. |
+| Magento\PaymentServicesDashboard\Block\Adminhtml\Index | Class was added. |
+| Magento\PaymentServicesDashboard\Block\Adminhtml\System\Config\MagentoPaymentsButton | Class was added. |
+| Magento\PaymentServicesDashboard\Block\Adminhtml\System\Config\MagentoPaymentsRedirect | Class was added. |
+| Magento\PaymentServicesPaypal\Block\Cart\ValidationMessages | Class was added. |
+| Magento\PaymentServicesPaypal\Block\Customer\CardRenderer | Class was added. |
+| Magento\PaymentServicesPaypal\Block\Info | Class was added. |
+| Magento\PaymentServicesPaypal\Block\Message | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtons | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtonsCart | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtonsProduct | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtons\Review | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtons\Review\Details | Class was added. |
+| Magento\SaaSCommon\Model\ResyncManager | Class was added. |
+| Magento\ServicesIdLayout\Block\Adminhtml\Index | Class was added. |
+| Magento\Store\Model\App\Emulation::\_resetState | [public] Method has been added. |
+| Magento\Store\Model\Store | Interface has been added. |
+| Magento\Store\Model\Store::\_resetState | [public] Method has been added. |
+| Magento\UrlRewrite\Model\UrlRewrite | Interface has been added. |
+| Magento\UrlRewrite\Model\UrlRewrite::\_resetState | [public] Method has been added. |
+
+#### Interface changes {#ce-246-247-beta1-interface}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\Framework\ForeignKey\ConfigInterface | Interface was added. |
+| Magento\Framework\ForeignKey\ConstraintInterface | Interface was added. |
+| Magento\Framework\ForeignKey\StrategyInterface | Interface was added. |
+| Magento\Framework\ObjectManager\ResetAfterRequestInterface | Interface was added. |
+| Magento\SaaSCommon\Model\Http\ConverterInterface | Interface was added. |
+| Magento\ServicesId\Model\ServicesClientInterface | Interface was added. |
+| Magento\ServicesId\Model\ServicesConfigInterface | Interface was added. |
+
+#### Database changes {#ce-246-247-beta1-database}
+
+| What changed | How it changed |
+| --- | --- |
+| data\_exporter\_uuid | Table was added |
+| payment\_services\_order\_data\_production\_submitted\_hash | Table was added |
+| payment\_services\_order\_data\_sandbox\_submitted\_hash | Table was added |
+| payment\_services\_order\_status\_data\_production\_submitted\_hash | Table was added |
+| payment\_services\_order\_status\_data\_sandbox\_submitted\_hash | Table was added |
+| payment\_services\_store\_data\_production\_submitted\_hash | Table was added |
+| payment\_services\_store\_data\_sandbox\_submitted\_hash | Table was added |
+| sales\_data\_exporter\_order\_statuses | Table was added |
+| sales\_data\_exporter\_orders | Table was added |
+| stores\_data\_exporter | Table was added |
+
+#### System changes {#ce-246-247-beta1-system}
+
+| What changed | How it changed |
+| --- | --- |
+| checkout/options/enable\_guest\_checkout\_login | A field-node was added |
+| payment | A section-node was added |
+| payment/recommended\_solutions | A group-node was added |
+| payment/recommended\_solutions/magento\_payments | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_color | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_height | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_height\_use\_default | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_label | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_layout | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_shape | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_tagline | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/active | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/method | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/production\_merchant\_id | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/sandbox\_merchant\_id | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/soft\_descriptor | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/debug | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/display\_on\_checkout | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/magento\_payments\_button | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/payment\_action | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/three\_ds | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/title | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/vault\_active | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/vault\_active\_admin | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/legacy\_admin\_enabled | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/debug | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_buttons\_cart | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_buttons\_checkout | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_buttons\_minicart | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_buttons\_product\_detail | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_paylater\_message | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/funding\_applepay | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/funding\_card | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/funding\_paypal\_credit | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/funding\_venmo | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/magento\_payments\_button | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/payment\_action | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/title | A field-node was added |
+| sales | A section-node was added |
+| sales/backpressure | A group-node was added |
+| sales/backpressure/enabled | A field-node was added |
+| sales/backpressure/guest\_limit | A field-node was added |
+| sales/backpressure/limit | A field-node was added |
+| sales/backpressure/period | A field-node was added |
+| services\_connector | A section-node was added |
+| services\_connector/services\_connector\_integration | A group-node was added |
+| services\_connector/services\_connector\_integration/production\_api\_key | A field-node was added |
+| services\_connector/services\_connector\_integration/production\_private\_key | A field-node was added |
+| services\_connector/services\_connector\_integration/sandbox\_api\_key | A field-node was added |
+| services\_connector/services\_connector\_integration/sandbox\_private\_key | A field-node was added |
+| services\_connector/services\_id\_onboarding | A group-node was added |
+| services\_connector/services\_id\_onboarding/initiate\_onboarding | A field-node was added |
+
+#### Xsd changes {#ce-246-247-beta1-xsd}
+
+| What changed | How it changed |
+| --- | --- |
+| app/code/framework-foreign-key/etc/constraints.xsd | A schema declaration was added |
+| app/code/module-data-exporter/etc/et\_schema.xsd | A schema declaration was added |
+| app/code/module-query-xml/etc/query.xsd | A schema declaration was added |
+
+#### EtSchema changes {#ce-246-247-beta1-etSchema}
+
+| What changed | How it changed |
+| --- | --- |
+| CreditMemo | Added a new declaration for record CreditMemo. |
+| Export | Added a new declaration for record Export. |
+| Invoice | Added a new declaration for record Invoice. |
+| Order | Added a new declaration for record Order. |
+| OrderItem | Added a new declaration for record OrderItem. |
+| OrderStatus | Added a new declaration for record OrderStatus. |
+| Transaction | Added a new declaration for record Transaction. |
+
+#### Class API membership changes {#ce-246-247-beta1-class-api-membership}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\Framework\Api\AbstractSimpleObjectBuilder | Class was added. |
+| Magento\Framework\Cache\Frontend\Decorator\Bare | Class was added. |
+| Magento\Framework\Data\Structure | Class was added. |
+| Magento\Framework\HTTP\PhpEnvironment\Request | Class was added. |
+| Magento\Framework\HTTP\PhpEnvironment\Response | Class was added. |
+| Magento\Framework\Locale\Resolver | Class was added. |
+| Magento\Framework\ObjectManager\ObjectManager | Class was added. |
+| Magento\Framework\Session\SessionManager | Class was added. |
+| Magento\Framework\Url | Class was added. |
+| Magento\Framework\Webapi\Request | Class was added. |
+| Magento\SalesRule\Model\Validator | Class was added. |

--- a/src/pages/development/backward-incompatible-changes/reference.md
+++ b/src/pages/development/backward-incompatible-changes/reference.md
@@ -25,6 +25,26 @@ To view changes in functional tests, refer to [Backward incompatible changes in 
 
 Patch releases are primarily focused on delivering security and quality enhancements on a regular basis to help you keep your sites performing at their peak. On an exceptional basis, breaking changes or additional patches or hotfixes may be released to address security or compliance issues and high-impact quality issues. On the module level, these are mostly PATCH-level changes; sometimes MINOR-level changes. See [Release policy](https://experienceleague.adobe.com/docs/commerce-operations/release/policy.html).
 
+## 2.4.6 - 2.4.7-beta1
+
+### Adobe Commerce
+
+import Ac247b1 from '/src/pages/_includes/backward-incompatible-changes/commerce/2.4.6-2.4.7-beta1.md'
+
+<Ac247b1 />
+
+### B2B for Adobe Commerce
+
+import B2b247b1 from '/src/pages/_includes/backward-incompatible-changes/b2b/2.4.6-2.4.7-beta1.md'
+
+<B2b247b1 />
+
+### Magento Open Source
+
+import Os247b1 from '/src/pages/_includes/backward-incompatible-changes/open-source/2.4.6-2.4.7-beta1.md'
+
+<Os247b1 />
+
 ## 2.4.5 - 2.4.6
 
 ### Adobe Commerce


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the reference documentation on backward incompatible changes for 2.4.6-2.4.7-beta1 versions delta.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/php/development/backward-incompatible-changes/reference/

## Preview

https://commerce-docs.github.io/commerce-php/development/backward-incompatible-changes/reference/#246---247-beta1

whatsnew
Added the reference documentation on backward incompatible changes for [2.4.6-2.4.7-beta1](https://developer.adobe.com/commerce/php/development/backward-incompatible-changes/reference/#246---247-beta1) versions delta.