### PR TITLE
Update doc according to the changes introduced in ACP2E-2114

### DIFF
--- a/src/pages/development/backward-incompatible-changes/highlights.md
+++ b/src/pages/development/backward-incompatible-changes/highlights.md
@@ -7,6 +7,15 @@ description: Learn about major changes in Adobe Commerce and Magento Open Source
 
 This page highlights backward-incompatible changes between Adobe Commerce and Magento Open Source releases that have a major impact and require detailed explanation and special instructions to ensure third-party modules continue working. High-level reference information for all backward-incompatible changes in each release are documented in [Backward incompatible changes reference](reference.md).
 
+## 2.4.7-beta2
+
+The following major backward-incompatible changes were introduced in the 2.4.7-beta2 Adobe Commerce and Magento Open Source releases:
+
+* New SKU validation in inventory source items API
+
+### Sku validation in inventory source items API
+Payload containing SKU will now be validated for leading or trailing spaces in `rest/V1/inventory/source-items` API.
+
 ## 2.4.7-beta1
 
 The following major backward-incompatible changes were introduced in the 2.4.7-beta1 Adobe Commerce and Magento Open Source releases:

--- a/src/pages/development/backward-incompatible-changes/highlights.md
+++ b/src/pages/development/backward-incompatible-changes/highlights.md
@@ -14,7 +14,8 @@ The following major backward-incompatible changes were introduced in the 2.4.7-b
 * New SKU validation in inventory source items API
 
 ### Sku validation in inventory source items API
-Payload containing SKU will now be validated for leading or trailing spaces in `rest/V1/inventory/source-items` API.
+
+Payload containing SKU will now be validated for leading and trailing spaces in the `rest/V1/inventory/source-items` API.
 
 ## 2.4.7-beta1
 


### PR DESCRIPTION
## Purpose of this pull request

Payload containing SKU with leading or trailing spaces are now validated and will return an error message in case of failure.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

/pages/development/backward-incompatible-changes/highlights.md

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

[http://magento-l3/inventory#187](https://github.com/magento-l3/inventory/pull/187)

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-php/blob/main/.github/CONTRIBUTING.md) for more information.
-->
