### PR TITLE
Fix "Indexer Status" table markdown formatting

### DIFF
--- a/src/pages/development/components/indexing/index.md
+++ b/src/pages/development/components/indexing/index.md
@@ -63,10 +63,11 @@ The following figure shows the logic for partial reindexing.
 
 Depending on whether index data is up to date, an indexer status value is one of the following:
 
-Database Status|Admin Status|Description
-`valid`|Ready|Data is synchronized, no reindex required
-`invalid`|Reindex Required|The original data was changed, the index should be updated
-`working`|Processing|Indexing is in progress
+| Database Status | Admin Status | Description |
+| --- | --- | --- |
+| `valid` | Ready | Data is synchronized, no reindex required |
+| `invalid` | Reindex Required | The original data was changed, the index should be updated |
+| `working` | Processing | Indexing is in progress |
 
 The database status can be seen when viewing the SQL table `indexer_state`.
 The admin status can be seen when viewing the indexer grid in Admin or when running the index status from the CLI.


### PR DESCRIPTION
## Purpose of this pull request
Fix broken "Indexer Status" table markdown.

## Affected pages
https://developer.adobe.com/commerce/php/development/components/indexing/#indexer-status

## Preview
### Before
![2023-08-19_11-42_1](https://github.com/AdobeDocs/commerce-php/assets/4603111/2092cd80-3e87-445d-902f-3c2a435465da)

### After
![2023-08-19_11-44](https://github.com/AdobeDocs/commerce-php/assets/4603111/6929a8e5-bd9e-451a-96ce-1ae8e251a487)
