### PR TITLE
Update URL of Magento Coding Standard repo

### DIFF
--- a/src/pages/best-practices/extensions/security.md
+++ b/src/pages/best-practices/extensions/security.md
@@ -15,7 +15,7 @@ You should make sure that your extension handles data with care in order to prev
 
   The Adobe Commerce and Magento Open Source applications are made up of a variety of components that work together to perform different business functions. We discourage the use of low-level functionality such as the PHP `curl_*` functions and encourage the use of high-level components such as [`\Magento\Framework\HTTP\Adapter\Curl`](https://github.com/magento/magento2/blob/2.4/lib/internal/Magento/Framework/HTTP/Adapter/Curl.php). The use of low-level functionality can make the applications behave in unexpected ways that effectively disable built-in protection mechanisms, introduce exploitable inconsistencies, or otherwise expose the application to attack.
 
-For a list of discouraged low-level functions, review the [`Magento2/Sniffs/Functions/DiscouragedFunctionSniff.php`](https://github.com/magento/magento-coding-standard/blob/develop/Magento2/Sniffs/Functions/DiscouragedFunctionSniff.php) file and the [Coding Standard](https://github.com/magento/-coding-standard).
+For a list of discouraged low-level functions, review the [`Magento2/Sniffs/Functions/DiscouragedFunctionSniff.php`](https://github.com/magento/magento-coding-standard/blob/develop/Magento2/Sniffs/Functions/DiscouragedFunctionSniff.php) file and the [Coding Standard](https://github.com/magento/magento-coding-standard).
 
 ## Use wrappers instead of superglobal variables
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) correct URL of Magento Coding Standard repo

## Affected pages

- https://developer.adobe.com/commerce/php/best-practices/extensions/security/
