### PR TITLE
Missing onCreate attribute in "table" node decription

### DIFF
--- a/src/pages/development/components/declarative-schema/configuration.md
+++ b/src/pages/development/components/declarative-schema/configuration.md
@@ -78,7 +78,8 @@ Attribute | Description
 `name` | The name of the table
 `engine` | SQL engine. This value must be `innodb` or `memory`.
 `resource` | The database shard on which to install the table. This value must be `default`, `checkout`, or `sales`.
-`comment` | Table comment
+`comment` | Table comment.
+`onCreate` | This is a DML trigger that allows you to move data from an existing table to a newly created table. This trigger works only when a table is created.
 
 A `table` node can contain three types of subnodes:
 


### PR DESCRIPTION
Fixes https://github.com/AdobeDocs/commerce-php/issues/194

## Purpose of this pull request

This pull request (PR) is in reference to this issue => https://github.com/AdobeDocs/commerce-php/issues/194

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-php/blob/main/.github/CONTRIBUTING.md) for more information.
-->
