### PR TITLE
Remove broken site.data.var references

### DIFF
--- a/src/pages/tutorials/backend/create-custom-rest-api.md
+++ b/src/pages/tutorials/backend/create-custom-rest-api.md
@@ -10,7 +10,7 @@ keywords:
 
 # Create a custom REST API
 
-Although CE and EE provide numerous REST endpoints, you might need to create your own to manage custom data within your extension. This tutorial describes how you can create such a custom REST API.
+Although Adobe Commerce and Magento Open Source provide numerous REST endpoints, you might need to create your own to manage custom data within your extension. This tutorial describes how you can create such a custom REST API.
 
 In this tutorial, we will create two custom endpoints to read or modify the product information. `GET /V1/rest_dev/getProduct/{productId}` returns details about a specified product, and `PUT /V1/rest_dev/setDescription` modifies product description data.
 

--- a/src/pages/tutorials/backend/create-custom-rest-api.md
+++ b/src/pages/tutorials/backend/create-custom-rest-api.md
@@ -10,7 +10,7 @@ keywords:
 
 # Create a custom REST API
 
-Although {{site.data.var.ee}} and {{site.data.var.ce}} provide numerous REST endpoints, you might need to create your own to manage custom data within your extension. This tutorial describes how you can create such a custom REST API.
+Although CE and EE provide numerous REST endpoints, you might need to create your own to manage custom data within your extension. This tutorial describes how you can create such a custom REST API.
 
 In this tutorial, we will create two custom endpoints to read or modify the product information. `GET /V1/rest_dev/getProduct/{productId}` returns details about a specified product, and `PUT /V1/rest_dev/setDescription` modifies product description data.
 


### PR DESCRIPTION
## Purpose of this pull request

Removed broken references to `{{site.data.var.ce}}` and `{{site.data.var.ee}}` which were not working. Is there some new variable to reference or can I just use `CE` and `EE` directly? Let me know.

## Affected pages

https://developer.adobe.com/commerce/php/tutorials/backend/create-custom-rest-api/