### PR TITLE
Update development environment page to recommend using PHP 8

### DIFF
--- a/src/pages/development/build/development-environment.md
+++ b/src/pages/development/build/development-environment.md
@@ -39,7 +39,7 @@ The following is a list of the different ways you can install Adobe Commerce or 
 
 The following is a list of optimizations you can make on your local development machine
 
-*  We recommend installing and using the latest supported version of PHP 7 to increase performance.
+*  We recommend installing and using the latest supported version of PHP 8 to increase performance.
 *  Replace your MySQL database with [Percona](https://www.percona.com/software/mysql-database/percona-server).
 *  Make sure you install and enable [PHP OPcache](http://php.net/manual/en/intro.opcache.php).
 *  Xdebug is off by default. Enable this feature only when you need it because it requires a lot of memory and degrades performance.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is aims to update development environment page to recommend using PHP 8

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/php/development/build/development-environment/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

There are no links to Magento Open Source code in this pull request.

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-php/blob/main/.github/CONTRIBUTING.md) for more information.
-->
