### PR TITLE
ACP2E-2419: Document the updated behavior of isEmailAvailable endpoint in 2.4.7-b1

### DIFF
--- a/src/pages/development/backward-incompatible-changes/highlights.md
+++ b/src/pages/development/backward-incompatible-changes/highlights.md
@@ -57,7 +57,9 @@ The following module is affected by this change:
 
 ### `isEmailAvailable` API
 
-The default behavior of the [`isEmailAvailable`](https://developer.adobe.com/commerce/webapi/graphql/schema/customer/queries/is-email-available/) GraphQL query and ([`V1/customers/isEmailAvailable`](https://adobe-commerce.redoc.ly/2.4.6-admin/tag/customersisEmailAvailable/#operation/PostV1CustomersIsEmailAvailable)) REST endpoint has changed. By default, the API now always returns `false`. Merchants can enable the original behavior, which is to return `true` if the email does not exist in the database and `false` if it exists.
+The default behavior of the [`isEmailAvailable`](https://developer.adobe.com/commerce/webapi/graphql/schema/customer/queries/is-email-available/) GraphQL query and ([`V1/customers/isEmailAvailable`](https://adobe-commerce.redoc.ly/2.4.6-admin/tag/customersisEmailAvailable/#operation/PostV1CustomersIsEmailAvailable)) REST endpoint has changed. By default, the API now always returns `true` regardless of provided email address. 
+The new default behaviour also affects the checkout workflow for guests that do not realize they already have an account. Previously, by default, guests that do not realize they already have an account was prompted to sign in after entering their email address at the checkout page. Now, by default, guests are not offered to sing in even if they entered an email that is already belongs to an existing registered customer account.
+By setting the "Enable Guest Checkout Login" configuration option located at "Config > Sales > Checkout" to "Yes", merchants can enable the original behavior, which is to return `true` if the email does not exist in the database and `false` if it exists, and prompting guest users to sign in during the checkout if their email already belongs to a registered customer account. Setting this option to yes, however, comes at the cost of exposing information to unauthenticated users.
 
 ## 2.4.6
 

--- a/src/pages/development/backward-incompatible-changes/highlights.md
+++ b/src/pages/development/backward-incompatible-changes/highlights.md
@@ -59,8 +59,7 @@ The following module is affected by this change:
 
 The default behavior of the [`isEmailAvailable`](https://developer.adobe.com/commerce/webapi/graphql/schema/customer/queries/is-email-available/) GraphQL query and ([`V1/customers/isEmailAvailable`](https://adobe-commerce.redoc.ly/2.4.6-admin/tag/customersisEmailAvailable/#operation/PostV1CustomersIsEmailAvailable)) REST endpoint has changed. By default, the API now always returns `true`.
 The new default behaviour also affects the checkout workflow for guests that do not realize they already have an account. Previously, by default, when a guest supplied an email address that matched an existing customer account, they were prompted to sign in. Now, they are no longer prompted to sign in.
-By setting the "Enable Guest Checkout Login" configuration option located at "Config > Sales > Checkout" to "Yes", merchants can enable the original behavior, which is to return `true` if the email does not exist in the database and `false` if it exists, and prompting guest users to sign in during the checkout if their email already belongs to a registered customer account. Setting this option to yes, however, comes at the cost of exposing information to unauthenticated users.
-
+Merchants can restore the original default behavior of the `isEmailAvailable` API and checkout flow by setting the **Stores > Configuration > Sales > Checkout > Enable Guest Checkout Login field** to **Yes**. However, doing this can expose customer information to unauthenticated users.
 ## 2.4.6
 
 The following major backward-incompatible changes were introduced in the 2.4.6 Adobe Commerce and Magento Open Source releases:

--- a/src/pages/development/backward-incompatible-changes/highlights.md
+++ b/src/pages/development/backward-incompatible-changes/highlights.md
@@ -57,8 +57,8 @@ The following module is affected by this change:
 
 ### `isEmailAvailable` API
 
-The default behavior of the [`isEmailAvailable`](https://developer.adobe.com/commerce/webapi/graphql/schema/customer/queries/is-email-available/) GraphQL query and ([`V1/customers/isEmailAvailable`](https://adobe-commerce.redoc.ly/2.4.6-admin/tag/customersisEmailAvailable/#operation/PostV1CustomersIsEmailAvailable)) REST endpoint has changed. By default, the API now always returns `true` regardless of provided email address. 
-The new default behaviour also affects the checkout workflow for guests that do not realize they already have an account. Previously, by default, guests that do not realize they already have an account was prompted to sign in after entering their email address at the checkout page. Now, by default, guests are not offered to sing in even if they entered an email that is already belongs to an existing registered customer account.
+The default behavior of the [`isEmailAvailable`](https://developer.adobe.com/commerce/webapi/graphql/schema/customer/queries/is-email-available/) GraphQL query and ([`V1/customers/isEmailAvailable`](https://adobe-commerce.redoc.ly/2.4.6-admin/tag/customersisEmailAvailable/#operation/PostV1CustomersIsEmailAvailable)) REST endpoint has changed. By default, the API now always returns `true`.
+The new default behaviour also affects the checkout workflow for guests that do not realize they already have an account. Previously, by default, when a guest supplied an email address that matched an existing customer account, they were prompted to sign in. Now, they are no longer prompted to sign in.
 By setting the "Enable Guest Checkout Login" configuration option located at "Config > Sales > Checkout" to "Yes", merchants can enable the original behavior, which is to return `true` if the email does not exist in the database and `false` if it exists, and prompting guest users to sign in during the checkout if their email already belongs to a registered customer account. Setting this option to yes, however, comes at the cost of exposing information to unauthenticated users.
 
 ## 2.4.6

--- a/src/pages/development/backward-incompatible-changes/highlights.md
+++ b/src/pages/development/backward-incompatible-changes/highlights.md
@@ -59,7 +59,9 @@ The following module is affected by this change:
 
 The default behavior of the [`isEmailAvailable`](https://developer.adobe.com/commerce/webapi/graphql/schema/customer/queries/is-email-available/) GraphQL query and ([`V1/customers/isEmailAvailable`](https://adobe-commerce.redoc.ly/2.4.6-admin/tag/customersisEmailAvailable/#operation/PostV1CustomersIsEmailAvailable)) REST endpoint has changed. By default, the API now always returns `true`.
 The new default behaviour also affects the checkout workflow for guests that do not realize they already have an account. Previously, by default, when a guest supplied an email address that matched an existing customer account, they were prompted to sign in. Now, they are no longer prompted to sign in.
+
 Merchants can restore the original default behavior of the `isEmailAvailable` API and checkout flow by setting the **Stores > Configuration > Sales > Checkout > Enable Guest Checkout Login field** to **Yes**. However, doing this can expose customer information to unauthenticated users.
+
 ## 2.4.6
 
 The following major backward-incompatible changes were introduced in the 2.4.6 Adobe Commerce and Magento Open Source releases:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) corrects an error and adds more details about the new default behavior of the isEmailAvailable endpoints.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/php/development/backward-incompatible-changes/highlights/#isemailavailable-api

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-php/blob/main/.github/CONTRIBUTING.md) for more information.
-->
