### PR TITLE
Update Backward incompatible changes reference docs

### DIFF
--- a/src/_includes/backward-incompatible-changes/b2b/2.4.6-2.4.7-beta2.md
+++ b/src/_includes/backward-incompatible-changes/b2b/2.4.6-2.4.7-beta2.md
@@ -1,0 +1,423 @@
+#### Class changes {#b2b-246-247-beta2-class}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\Authorization\Model\CompositeUserContext | Interface has been added. |
+| Magento\Authorization\Model\CompositeUserContext::\_resetState | [public] Method has been added. |
+| Magento\Bundle\Block\Catalog\Product\View\Type\Bundle | Interface has been added. |
+| Magento\Bundle\Block\Catalog\Product\View\Type\Bundle::\_resetState | [public] Method has been added. |
+| Magento\CatalogImportExport\Model\Export\Product::$\_storeIdToCode | [protected] Property has been removed. |
+| Magento\Catalog\Helper\Product\Flat\Indexer | Interface has been added. |
+| Magento\Catalog\Helper\Product\Flat\Indexer::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Config::$\_storeManager | [protected] Property has been removed. |
+| Magento\Catalog\Model\Indexer\Category\Product\AbstractAction | Interface has been added. |
+| Magento\Catalog\Model\Indexer\Category\Product\AbstractAction::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Layer | Interface has been added. |
+| Magento\Catalog\Model\Layer::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Layer\Resolver | Interface has been added. |
+| Magento\Catalog\Model\Layer\Resolver::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Product | Interface has been added. |
+| Magento\Catalog\Model\Product::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Product\Media\Config | Interface has been added. |
+| Magento\Catalog\Model\Product\Media\Config::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Product\Option\Type\DefaultType | Interface has been added. |
+| Magento\Catalog\Model\Product\Option\Type\DefaultType::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Product\Type\Price | Interface has been added. |
+| Magento\Catalog\Model\Product\Type\Price::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\ResourceModel\Product | Interface has been added. |
+| Magento\Config\App\Config\Type\System::\_\_debugInfo | [public] Method has been added. |
+| Magento\Config\App\Config\Type\System::cleanAndWarmDefaultScopeData | [public] Method has been added. |
+| Magento\Config\App\Config\Type\System::loadDefaultScopeData | [private] Removed last method parameter(s). |
+| Magento\Config\Model\ResourceModel\Config::\_construct | [protected] Added optional parameter(s). |
+| Magento\ConfigurableProduct\Model\Product\Type\Configurable | Interface has been added. |
+| Magento\ConfigurableProduct\Model\Product\Type\Configurable::\_resetState | [public] Method has been added. |
+| Magento\ConfigurableProduct\Model\Product\VariationHandler | Interface has been added. |
+| Magento\ConfigurableProduct\Model\Product\VariationHandler::\_resetState | [public] Method has been added. |
+| Magento\CustomerSegment\Model\Customer | Interface has been added. |
+| Magento\CustomerSegment\Model\Customer::\_resetState | [public] Method has been added. |
+| Magento\Customer\Helper\Address | Interface has been added. |
+| Magento\Customer\Helper\Address::\_resetState | [public] Method has been added. |
+| Magento\Customer\Model\Address\AbstractAddress | Interface has been added. |
+| Magento\Customer\Model\Address\AbstractAddress::\_resetState | [public] Method has been added. |
+| Magento\Customer\Model\Customer | Interface has been added. |
+| Magento\Customer\Model\Customer::\_resetState | [public] Method has been added. |
+| Magento\Customer\Model\CustomerRegistry | Interface has been added. |
+| Magento\Customer\Model\CustomerRegistry::\_resetState | [public] Method has been added. |
+| Magento\DataExporter\Model\Indexer\FeedIndexer | Class was added. |
+| Magento\Directory\Helper\Data | Interface has been added. |
+| Magento\Directory\Helper\Data::\_resetState | [public] Method has been added. |
+| Magento\Directory\Model\Country::\_resetState | [public] Method has been added. |
+| Magento\Directory\Model\Currency | Interface has been added. |
+| Magento\Directory\Model\Currency::\_resetState | [public] Method has been added. |
+| Magento\Directory\Model\ResourceModel\Currency | Interface has been added. |
+| Magento\Directory\Model\ResourceModel\Currency::\_resetState | [public] Method has been added. |
+| Magento\Eav\Model\Config | Interface has been added. |
+| Magento\Eav\Model\Config::$\_storeManager | [protected] Property has been added. |
+| Magento\Eav\Model\Config::\_resetState | [public] Method has been added. |
+| Magento\Eav\Model\Config::getWebsiteId | Method visibility has been changed to higher lever from [private] to [public] |
+| Magento\Eav\Model\Config::getWebsiteId | [public] Removed last method parameter(s). |
+| Magento\Eav\Model\Entity\AbstractEntity | Interface has been added. |
+| Magento\Eav\Model\Entity\AbstractEntity::\_resetState | [public] Method has been added. |
+| Magento\Eav\Model\Entity\Attribute\AbstractAttribute | Interface has been added. |
+| Magento\Eav\Model\Entity\Attribute\AbstractAttribute::\_resetState | [public] Method has been added. |
+| Magento\Eav\Model\Entity\Attribute\Source\Table | Interface has been added. |
+| Magento\Eav\Model\Entity\Attribute\Source\Table::\_resetState | [public] Method has been added. |
+| Magento\Elasticsearch\ElasticAdapter\SearchAdapter\Mapper | Class was added. |
+| Magento\Elasticsearch\ElasticAdapter\SearchAdapter\Query\Builder | Class was added. |
+| Magento\Elasticsearch\Elasticsearch5\SearchAdapter\Mapper | Class was removed. |
+| Magento\Elasticsearch\Elasticsearch5\SearchAdapter\Query\Builder | Class was removed. |
+| Magento\Elasticsearch\SearchAdapter\Mapper | Class was removed. |
+| Magento\Framework\Acl\Builder | Interface has been added. |
+| Magento\Framework\Acl\Builder::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\ActionFlag | Interface has been added. |
+| Magento\Framework\App\ActionFlag::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\AreaList | Interface has been added. |
+| Magento\Framework\App\AreaList::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\DeploymentConfig::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\App\Http\Context | Interface has been added. |
+| Magento\Framework\App\Http\Context::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\Request\Http | Interface has been added. |
+| Magento\Framework\App\Request\Http::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\ResourceConnection | Interface has been added. |
+| Magento\Framework\App\ResourceConnection::\_resetState | [public] Method has been added. |
+| Magento\Framework\Config\ConfigOptionsListConstants::STORE\_KEY\_ENCODED\_RANDOM\_STRING\_PREFIX | Constant has been added. |
+| Magento\Framework\Config\Data::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\Config\Data\Scoped::$\_cache | [protected] Property has been removed. |
+| Magento\Framework\Config\Data\Scoped::$\_cacheId | [protected] Property has been removed. |
+| Magento\Framework\Config\Data\Scoped::$\_reader | [protected] Property has been removed. |
+| Magento\Framework\DB\Adapter\Pdo\Mysql | Interface has been added. |
+| Magento\Framework\DB\Adapter\Pdo\Mysql::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\DB\Adapter\Pdo\Mysql::\_resetState | [public] Method has been added. |
+| Magento\Framework\DataObject::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\Data\Collection | Interface has been added. |
+| Magento\Framework\Data\Collection::\_resetState | [public] Method has been added. |
+| Magento\Framework\Filesystem\DirectoryList::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\Filesystem\Directory\Read::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException | Interface has been added. |
+| Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException::getExtensions | [public] Method has been added. |
+| Magento\Framework\GraphQl\Query\Resolver\BatchResponse | Interface has been added. |
+| Magento\Framework\GraphQl\Query\Resolver\BatchResponse::\_resetState | [public] Method has been added. |
+| Magento\Framework\Logger\Handler\Base::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\Math\Random::getRandomBytes | [public] Method has been added. |
+| Magento\Framework\Pricing\Price\Collection | Interface has been added. |
+| Magento\Framework\Pricing\Price\Collection::\_resetState | [public] Method has been added. |
+| Magento\Framework\Registry | Interface has been added. |
+| Magento\Framework\Registry::\_resetState | [public] Method has been added. |
+| Magento\Framework\Search\Request\Builder | Interface has been added. |
+| Magento\Framework\Search\Request\Builder::\_resetState | [public] Method has been added. |
+| Magento\Framework\Validator | Interface has been added. |
+| Magento\Framework\Validator\AbstractValidator | Interface has been added. |
+| Magento\Framework\Validator\AbstractValidator::\_resetState | [public] Method has been added. |
+| Magento\Framework\View\Asset\Minification | Interface has been added. |
+| Magento\Framework\View\Asset\Minification::\_resetState | [public] Method has been added. |
+| Magento\Framework\View\Asset\Repository | Interface has been added. |
+| Magento\Framework\View\Asset\Repository::\_resetState | [public] Method has been added. |
+| Magento\Framework\Webapi\Exception::HTTP\_TOO\_MANY\_REQUESTS | Constant has been added. |
+| Magento\Framework\Webapi\ServiceInputProcessor | Interface has been added. |
+| Magento\Framework\Webapi\ServiceInputProcessor::\_resetState | [public] Method has been added. |
+| Magento\GraphQlServer\Model\UrlProvider | Class was added. |
+| Magento\ImportExport\Model\Export\Entity\AbstractEntity::$\_storeIdToCode | [protected] Property has been added. |
+| Magento\NegotiableQuote\Block\Adminhtml\Quote\Create\Form | Class was added. |
+| Magento\NegotiableQuote\Block\Adminhtml\Quote\Create\Store\Select | Class was added. |
+| Magento\NegotiableQuote\Block\Quote\Item\Actions\Note | Class was added. |
+| Magento\PaymentServicesBase\Block\Adminhtml\System\Config\Fieldset\Child | Class was added. |
+| Magento\PaymentServicesBase\Block\Adminhtml\System\Config\Fieldset\Payment | Class was added. |
+| Magento\PaymentServicesDashboard\Block\Adminhtml\Index | Class was added. |
+| Magento\PaymentServicesDashboard\Block\Adminhtml\System\Config\MagentoPaymentsButton | Class was added. |
+| Magento\PaymentServicesDashboard\Block\Adminhtml\System\Config\MagentoPaymentsRedirect | Class was added. |
+| Magento\PaymentServicesPaypal\Block\Cart\ValidationMessages | Class was added. |
+| Magento\PaymentServicesPaypal\Block\Customer\CardRenderer | Class was added. |
+| Magento\PaymentServicesPaypal\Block\Info | Class was added. |
+| Magento\PaymentServicesPaypal\Block\Message | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtons | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtonsCart | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtonsProduct | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtons\Review | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtons\Review\Details | Class was added. |
+| Magento\QuickCheckoutAdminPanel\Block\Adminhtml\Index | Class was removed. |
+| Magento\QuickCheckout\Block\Adminhtml\Payment\Form | Class was removed. |
+| Magento\QuickCheckout\Block\Adminhtml\System\Config\ConfigureCallbackUrl | Class was removed. |
+| Magento\QuickCheckout\Block\Adminhtml\System\Config\Fieldset\Custom | Class was removed. |
+| Magento\QuickCheckout\Block\Adminhtml\System\Config\Fieldset\Head | Class was removed. |
+| Magento\QuickCheckout\Block\Adminhtml\System\Config\ValidateCredentials | Class was removed. |
+| Magento\QuickCheckout\Block\Sdk | Class was removed. |
+| Magento\Quote\Model\Quote\Address::setBaseDiscountAmount | [public] Method has been added. |
+| Magento\SaaSCommon\Model\ResyncManager | Class was added. |
+| Magento\SalesRule\Model\Rule::getSimpleAction | [public] Method has been added. |
+| Magento\SalesSequence\Model\Builder | Interface has been added. |
+| Magento\SalesSequence\Model\Builder::\_resetState | [public] Method has been added. |
+| Magento\ServicesIdLayout\Block\Adminhtml\Index | Class was added. |
+| Magento\Shipping\Model\Carrier\AbstractCarrier::$\_result | [protected] Property has been added. |
+| Magento\Store\Model\App\Emulation | Interface has been added. |
+| Magento\Store\Model\App\Emulation::\_resetState | [public] Method has been added. |
+| Magento\Store\Model\Store | Interface has been added. |
+| Magento\Store\Model\Store::\_resetState | [public] Method has been added. |
+| Magento\TargetRule\Block\Catalog\Product\ProductList\Related::getExcludeProductIds | [public] Method has been removed. |
+| Magento\TargetRule\Block\Catalog\Product\ProductList\Upsell::getExcludeProductIds | [public] Method has been removed. |
+| Magento\Weee\Helper\Data | Interface has been added. |
+| Magento\Weee\Helper\Data::\_resetState | [public] Method has been added. |
+
+#### Interface changes {#b2b-246-247-beta2-interface}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\CommerceBackendUix\Api\Data\MassActionInterface | Interface was added. |
+| Magento\CommerceBackendUix\Api\MassActionRepositoryInterface | Interface was added. |
+| Magento\Framework\ObjectManager\ResetAfterRequestInterface | Interface was added. |
+| Magento\ImportJsonApi\Api\Data\SourceDataInterface | Interface was added. |
+| Magento\ImportJsonApi\Api\StartImportInterface | Interface was added. |
+| Magento\NegotiableQuote\Api\Data\ItemNoteInterface | Interface was added. |
+| Magento\NegotiableQuote\Api\Data\ItemNoteSearchResultsInterface | Interface was added. |
+| Magento\NegotiableQuote\Api\Data\NegotiableQuoteInterface::STATUS\_DRAFT\_BY\_ADMIN | Constant has been added. |
+| Magento\NegotiableQuote\Api\Data\NegotiableQuoteItemInterface::NEGOTIATED\_PRICE\_TYPE | Constant has been added. |
+| Magento\NegotiableQuote\Api\Data\NegotiableQuoteItemInterface::NEGOTIATED\_PRICE\_TYPE\_AMOUNT\_DISCOUNT | Constant has been added. |
+| Magento\NegotiableQuote\Api\Data\NegotiableQuoteItemInterface::NEGOTIATED\_PRICE\_TYPE\_PERCENTAGE\_DISCOUNT | Constant has been added. |
+| Magento\NegotiableQuote\Api\Data\NegotiableQuoteItemInterface::NEGOTIATED\_PRICE\_TYPE\_PROPOSED\_TOTAL | Constant has been added. |
+| Magento\NegotiableQuote\Api\Data\NegotiableQuoteItemInterface::NEGOTIATED\_PRICE\_VALUE | Constant has been added. |
+| Magento\NegotiableQuote\Api\ItemNoteRepositoryInterface | Interface was added. |
+| Magento\NegotiableQuote\Api\NegotiableQuoteDraftManagementInterface | Interface was added. |
+| Magento\NegotiableQuote\Model\Restriction\RestrictionInterface::ACTION\_VIEW | Constant has been added. |
+| Magento\QuickCheckout\Api\AccountRepositoryInterface | Interface was removed. |
+| Magento\QuickCheckout\Api\Data\AccountInterface | Interface was removed. |
+| Magento\QuickCheckout\Api\Data\AddressInterface | Interface was removed. |
+| Magento\QuickCheckout\Api\Data\PaymentMethodInterface | Interface was removed. |
+| Magento\QuickCheckout\Api\StorefrontAccountRepositoryInterface | Interface was removed. |
+| Magento\SaaSCommon\Model\Http\ConverterInterface | Interface was added. |
+| Magento\ServicesId\Model\ServicesClientInterface | Interface was added. |
+| Magento\ServicesId\Model\ServicesConfigInterface | Interface was added. |
+| Magento\SharedCatalog\Api\AssignTierPriceInterface | Interface was added. |
+| Magento\SharedCatalog\Api\ResetTierPriceInterface | Interface was added. |
+| Magento\Vault\Api\Data\PaymentTokenInterface::WEBSITE\_ID | Constant has been added. |
+| Magento\Vault\Api\Data\PaymentTokenInterface::getWebsiteId | [public] Method has been added. |
+| Magento\Vault\Api\Data\PaymentTokenInterface::setWebsiteId | [public] Method has been added. |
+
+#### Database changes {#b2b-246-247-beta2-database}
+
+| What changed | How it changed |
+| --- | --- |
+| admin\_ui\_sdk\_mass\_actions | Table was added |
+| data\_exporter\_uuid | Table was added |
+| negotiable\_quote\_item/negotiated\_price\_type | Column was added |
+| negotiable\_quote\_item/negotiated\_price\_value | Column was added |
+| negotiable\_quote\_item\_note | Table was added |
+| payment\_services\_order\_data\_production\_submitted\_hash | Table was added |
+| payment\_services\_order\_data\_sandbox\_submitted\_hash | Table was added |
+| payment\_services\_order\_status\_data\_production\_submitted\_hash | Table was added |
+| payment\_services\_order\_status\_data\_sandbox\_submitted\_hash | Table was added |
+| payment\_services\_store\_data\_production\_submitted\_hash | Table was added |
+| payment\_services\_store\_data\_sandbox\_submitted\_hash | Table was added |
+| sales\_data\_exporter\_order\_statuses | Table was added |
+| sales\_data\_exporter\_orders | Table was added |
+| stores\_data\_exporter | Table was added |
+| vault\_payment\_token/website\_id | Column was added |
+
+#### Di changes {#b2b-246-247-beta2-di}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\Elasticsearch\Elasticsearch5\Model\Client\ElasticsearchFactory | Virtual Type was removed |
+| Magento\Elasticsearch\Setup\InstallConfig | Virtual Type was removed |
+| Magento\QuickCheckout\Gateway\Http\BoltServiceClient | Virtual Type was removed |
+| Magento\QuickCheckout\Gateway\Request\AuthorizationAndCaptureRequest | Virtual Type was removed |
+| Magento\QuickCheckout\Model\AddressValidator\Billing | Virtual Type was removed |
+| Magento\QuickCheckout\Model\AddressValidator\Shipping | Virtual Type was removed |
+| QuickCheckoutAuthorizationAndCaptureRequest | Virtual Type was removed |
+| QuickCheckoutAuthorizationRequest | Virtual Type was removed |
+| QuickCheckoutAuthorizationResponseHandlerComposite | Virtual Type was removed |
+| QuickCheckoutAuthorizeAndCaptureCommand | Virtual Type was removed |
+| QuickCheckoutAuthorizeCommand | Virtual Type was removed |
+| QuickCheckoutCaptureCommand | Virtual Type was removed |
+| QuickCheckoutCaptureRequest | Virtual Type was removed |
+| QuickCheckoutCaptureResponseHandlerComposite | Virtual Type was removed |
+| QuickCheckoutCommandPool | Virtual Type was removed |
+| QuickCheckoutConfig | Virtual Type was removed |
+| QuickCheckoutConfigGuard | Virtual Type was removed |
+| QuickCheckoutConfigValueHandler | Virtual Type was removed |
+| QuickCheckoutFacade | Virtual Type was removed |
+| QuickCheckoutLogger | Virtual Type was removed |
+| QuickCheckoutRefundCommand | Virtual Type was removed |
+| QuickCheckoutRefundRequest | Virtual Type was removed |
+| QuickCheckoutRefundResponseHandlerComposite | Virtual Type was removed |
+| QuickCheckoutValueHandlerPool | Virtual Type was removed |
+| QuickCheckoutVoidCommand | Virtual Type was removed |
+| QuickCheckoutVoidRequest | Virtual Type was removed |
+| QuickCheckoutVoidResponseHandlerComposite | Virtual Type was removed |
+| elasticsearch5CategoryPermissionsCompositeFieldProvider | Virtual Type was removed |
+| elasticsearch5CategoryPermissionsDynamicFieldsProvider | Virtual Type was removed |
+| elasticsearch5DynamicFieldProvider | Virtual Type was removed |
+| elasticsearch5FieldNameDefaultResolver | Virtual Type was removed |
+| elasticsearch5FieldNameResolver | Virtual Type was removed |
+| elasticsearch5FieldProvider | Virtual Type was removed |
+| elasticsearch5FieldTypeDateTimeResolver | Virtual Type was removed |
+| elasticsearch5FieldTypeDefaultResolver | Virtual Type was removed |
+| elasticsearch5FieldTypeFloatResolver | Virtual Type was removed |
+| elasticsearch5StaticFieldProvider | Virtual Type was removed |
+| type | Virtual Type was changed |
+
+#### Layout changes {#b2b-246-247-beta2-layout}
+
+| What changed | How it changed |
+| --- | --- |
+| bolt.embed.js | Block was removed |
+| quickCheckoutTracking | Block was removed |
+| quickcheckoutadminpanel.index | Block was removed |
+
+#### System changes {#b2b-246-247-beta2-system}
+
+| What changed | How it changed |
+| --- | --- |
+| admin\_ui\_sdk | A section-node was added |
+| admin\_ui\_sdk/general\_config | A group-node was added |
+| admin\_ui\_sdk/general\_config/enable\_admin\_ui\_sdk | A field-node was added |
+| admin\_ui\_sdk/local\_testing | A group-node was added |
+| admin\_ui\_sdk/local\_testing/base\_url | A field-node was added |
+| admin\_ui\_sdk/local\_testing/enable\_local\_service | A field-node was added |
+| admin\_ui\_sdk/local\_testing/ims\_org\_id | A field-node was added |
+| admin\_ui\_sdk/local\_testing/ims\_token | A field-node was added |
+| carriers/fedex/api\_key | A field-node was added |
+| carriers/fedex/dropoff | A field-node was removed |
+| carriers/fedex/key | A field-node was removed |
+| carriers/fedex/meter\_number | A field-node was removed |
+| carriers/fedex/password | A field-node was removed |
+| carriers/fedex/pickup\_type | A field-node was added |
+| carriers/fedex/secret\_key | A field-node was added |
+| carriers/ups/access\_license\_number | A field-node was removed |
+| carriers/ups/gateway\_xml\_url | A field-node was removed |
+| carriers/ups/tracking\_url | A field-node was added |
+| carriers/ups/tracking\_xml\_url | A field-node was removed |
+| carriers/ups/type | A field-node was removed |
+| catalog/search/elasticsearch5\_enable\_auth | A field-node was removed |
+| catalog/search/elasticsearch5\_index\_prefix | A field-node was removed |
+| catalog/search/elasticsearch5\_minimum\_should\_match | A field-node was removed |
+| catalog/search/elasticsearch5\_password | A field-node was removed |
+| catalog/search/elasticsearch5\_server\_hostname | A field-node was removed |
+| catalog/search/elasticsearch5\_server\_port | A field-node was removed |
+| catalog/search/elasticsearch5\_server\_timeout | A field-node was removed |
+| catalog/search/elasticsearch5\_test\_connect\_wizard | A field-node was removed |
+| catalog/search/elasticsearch5\_username | A field-node was removed |
+| checkout/options/enable\_guest\_checkout\_login | A field-node was added |
+| checkout/quick\_checkout | A group-node was removed |
+| checkout/quick\_checkout/credentials | A group-node was removed |
+| checkout/quick\_checkout/credentials/api\_key | A field-node was removed |
+| checkout/quick\_checkout/credentials/configure\_callback\_url | A field-node was removed |
+| checkout/quick\_checkout/credentials/publishable\_key | A field-node was removed |
+| checkout/quick\_checkout/credentials/signing\_secret | A field-node was removed |
+| checkout/quick\_checkout/credentials/validate\_credentials | A field-node was removed |
+| checkout/quick\_checkout/general | A group-node was removed |
+| checkout/quick\_checkout/general/active | A field-node was removed |
+| checkout/quick\_checkout/general/method | A field-node was removed |
+| checkout/quick\_checkout/settings | A group-node was removed |
+| checkout/quick\_checkout/settings/auto\_login\_network | A field-node was removed |
+| checkout/quick\_checkout/settings/checkout\_tracking | A field-node was removed |
+| checkout/quick\_checkout/settings/debug | A field-node was removed |
+| checkout/quick\_checkout/settings/enable\_auto\_login | A field-node was removed |
+| checkout/quick\_checkout/settings/next\_stage\_after\_login | A field-node was removed |
+| checkout/quick\_checkout/settings/payment\_action | A field-node was removed |
+| checkout/quick\_checkout/settings/title | A field-node was removed |
+| payment | A section-node was added |
+| payment/recommended\_solutions | A group-node was added |
+| payment/recommended\_solutions/magento\_payments | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay/debug | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay/display\_buttons\_cart | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay/display\_buttons\_checkout | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay/display\_buttons\_minicart | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay/display\_buttons\_product\_detail | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay/payment\_action | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay/sort\_order | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay/title | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_color | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_height | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_height\_use\_default | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_label | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_layout | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_shape | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_tagline | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/active | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/method | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/production\_merchant\_id | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/sandbox\_merchant\_id | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/soft\_descriptor | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/debug | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/display\_on\_checkout | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/magento\_payments\_button | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/payment\_action | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/sort\_order | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/three\_ds | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/title | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/vault\_active | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/vault\_active\_admin | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/legacy\_admin\_enabled | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/debug | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_buttons\_cart | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_buttons\_checkout | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_buttons\_minicart | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_buttons\_product\_detail | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_paylater\_message | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/funding\_card | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/funding\_paypal\_credit | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/funding\_venmo | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/magento\_payments\_button | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/payment\_action | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/sort\_order | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/title | A field-node was added |
+| sales | A section-node was added |
+| sales/backpressure | A group-node was added |
+| sales/backpressure/enabled | A field-node was added |
+| sales/backpressure/guest\_limit | A field-node was added |
+| sales/backpressure/limit | A field-node was added |
+| sales/backpressure/period | A field-node was added |
+| sales/cancellation | A group-node was added |
+| sales/cancellation/enabled | A field-node was added |
+| sales/cancellation/reasons | A field-node was added |
+| sales\_email/quote/new\_quote\_by\_seller\_template | A field-node was added |
+| services\_connector | A section-node was added |
+| services\_connector/services\_connector\_integration | A group-node was added |
+| services\_connector/services\_connector\_integration/production\_api\_key | A field-node was added |
+| services\_connector/services\_connector\_integration/production\_private\_key | A field-node was added |
+| services\_connector/services\_connector\_integration/sandbox\_api\_key | A field-node was added |
+| services\_connector/services\_connector\_integration/sandbox\_private\_key | A field-node was added |
+| services\_connector/services\_id\_onboarding | A group-node was added |
+| services\_connector/services\_id\_onboarding/initiate\_onboarding | A field-node was added |
+| system/full\_page\_cache/handles\_size | A field-node was added |
+
+#### Xsd changes {#b2b-246-247-beta2-xsd}
+
+| What changed | How it changed |
+| --- | --- |
+| app/code/module-data-exporter/etc/et\_schema.xsd | A schema declaration was added |
+| app/code/module-query-xml/etc/query.xsd | A schema declaration was added |
+
+#### EtSchema changes {#b2b-246-247-beta2-etSchema}
+
+| What changed | How it changed |
+| --- | --- |
+| CreditMemo | Added a new declaration for record CreditMemo. |
+| Export | Added a new declaration for record Export. |
+| Invoice | Added a new declaration for record Invoice. |
+| Order | Added a new declaration for record Order. |
+| OrderItem | Added a new declaration for record OrderItem. |
+| OrderStatus | Added a new declaration for record OrderStatus. |
+| Transaction | Added a new declaration for record Transaction. |
+
+#### Class API membership changes {#b2b-246-247-beta2-class-api-membership}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\Catalog\Block\Adminhtml\Category\Tab\Product | Class was added. |
+| Magento\Framework\Api\AbstractSimpleObjectBuilder | Class was added. |
+| Magento\Framework\Cache\Frontend\Decorator\Bare | Class was added. |
+| Magento\Framework\Data\Structure | Class was added. |
+| Magento\Framework\HTTP\PhpEnvironment\Request | Class was added. |
+| Magento\Framework\HTTP\PhpEnvironment\Response | Class was added. |
+| Magento\Framework\Locale\Resolver | Class was added. |
+| Magento\Framework\ObjectManager\ObjectManager | Class was added. |
+| Magento\Framework\Session\SessionManager | Class was added. |
+| Magento\Framework\Url | Class was added. |
+| Magento\Framework\Webapi\Request | Class was added. |
+| Magento\SalesRule\Model\Validator | Class was added. |

--- a/src/_includes/backward-incompatible-changes/commerce/2.4.6-2.4.7-beta2.md
+++ b/src/_includes/backward-incompatible-changes/commerce/2.4.6-2.4.7-beta2.md
@@ -1,0 +1,403 @@
+#### Class changes {#ee-246-247-beta2-class}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\Authorization\Model\CompositeUserContext | Interface has been added. |
+| Magento\Authorization\Model\CompositeUserContext::\_resetState | [public] Method has been added. |
+| Magento\Bundle\Block\Catalog\Product\View\Type\Bundle | Interface has been added. |
+| Magento\Bundle\Block\Catalog\Product\View\Type\Bundle::\_resetState | [public] Method has been added. |
+| Magento\CatalogImportExport\Model\Export\Product::$\_storeIdToCode | [protected] Property has been removed. |
+| Magento\Catalog\Helper\Product\Flat\Indexer | Interface has been added. |
+| Magento\Catalog\Helper\Product\Flat\Indexer::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Config::$\_storeManager | [protected] Property has been removed. |
+| Magento\Catalog\Model\Indexer\Category\Product\AbstractAction | Interface has been added. |
+| Magento\Catalog\Model\Indexer\Category\Product\AbstractAction::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Layer | Interface has been added. |
+| Magento\Catalog\Model\Layer::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Layer\Resolver | Interface has been added. |
+| Magento\Catalog\Model\Layer\Resolver::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Product | Interface has been added. |
+| Magento\Catalog\Model\Product::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Product\Media\Config | Interface has been added. |
+| Magento\Catalog\Model\Product\Media\Config::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Product\Option\Type\DefaultType | Interface has been added. |
+| Magento\Catalog\Model\Product\Option\Type\DefaultType::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Product\Type\Price | Interface has been added. |
+| Magento\Catalog\Model\Product\Type\Price::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\ResourceModel\Product | Interface has been added. |
+| Magento\Config\App\Config\Type\System::\_\_debugInfo | [public] Method has been added. |
+| Magento\Config\App\Config\Type\System::cleanAndWarmDefaultScopeData | [public] Method has been added. |
+| Magento\Config\App\Config\Type\System::loadDefaultScopeData | [private] Removed last method parameter(s). |
+| Magento\Config\Model\ResourceModel\Config::\_construct | [protected] Added optional parameter(s). |
+| Magento\ConfigurableProduct\Model\Product\Type\Configurable | Interface has been added. |
+| Magento\ConfigurableProduct\Model\Product\Type\Configurable::\_resetState | [public] Method has been added. |
+| Magento\ConfigurableProduct\Model\Product\VariationHandler | Interface has been added. |
+| Magento\ConfigurableProduct\Model\Product\VariationHandler::\_resetState | [public] Method has been added. |
+| Magento\CustomerSegment\Model\Customer | Interface has been added. |
+| Magento\CustomerSegment\Model\Customer::\_resetState | [public] Method has been added. |
+| Magento\Customer\Helper\Address | Interface has been added. |
+| Magento\Customer\Helper\Address::\_resetState | [public] Method has been added. |
+| Magento\Customer\Model\Address\AbstractAddress | Interface has been added. |
+| Magento\Customer\Model\Address\AbstractAddress::\_resetState | [public] Method has been added. |
+| Magento\Customer\Model\Customer | Interface has been added. |
+| Magento\Customer\Model\Customer::\_resetState | [public] Method has been added. |
+| Magento\Customer\Model\CustomerRegistry | Interface has been added. |
+| Magento\Customer\Model\CustomerRegistry::\_resetState | [public] Method has been added. |
+| Magento\DataExporter\Model\Indexer\FeedIndexer | Class was added. |
+| Magento\Directory\Helper\Data | Interface has been added. |
+| Magento\Directory\Helper\Data::\_resetState | [public] Method has been added. |
+| Magento\Directory\Model\Country::\_resetState | [public] Method has been added. |
+| Magento\Directory\Model\Currency | Interface has been added. |
+| Magento\Directory\Model\Currency::\_resetState | [public] Method has been added. |
+| Magento\Directory\Model\ResourceModel\Currency | Interface has been added. |
+| Magento\Directory\Model\ResourceModel\Currency::\_resetState | [public] Method has been added. |
+| Magento\Eav\Model\Config | Interface has been added. |
+| Magento\Eav\Model\Config::$\_storeManager | [protected] Property has been added. |
+| Magento\Eav\Model\Config::\_resetState | [public] Method has been added. |
+| Magento\Eav\Model\Config::getWebsiteId | Method visibility has been changed to higher lever from [private] to [public] |
+| Magento\Eav\Model\Config::getWebsiteId | [public] Removed last method parameter(s). |
+| Magento\Eav\Model\Entity\AbstractEntity | Interface has been added. |
+| Magento\Eav\Model\Entity\AbstractEntity::\_resetState | [public] Method has been added. |
+| Magento\Eav\Model\Entity\Attribute\AbstractAttribute | Interface has been added. |
+| Magento\Eav\Model\Entity\Attribute\AbstractAttribute::\_resetState | [public] Method has been added. |
+| Magento\Eav\Model\Entity\Attribute\Source\Table | Interface has been added. |
+| Magento\Eav\Model\Entity\Attribute\Source\Table::\_resetState | [public] Method has been added. |
+| Magento\Elasticsearch\ElasticAdapter\SearchAdapter\Mapper | Class was added. |
+| Magento\Elasticsearch\ElasticAdapter\SearchAdapter\Query\Builder | Class was added. |
+| Magento\Elasticsearch\Elasticsearch5\SearchAdapter\Mapper | Class was removed. |
+| Magento\Elasticsearch\Elasticsearch5\SearchAdapter\Query\Builder | Class was removed. |
+| Magento\Elasticsearch\SearchAdapter\Mapper | Class was removed. |
+| Magento\Framework\Acl\Builder | Interface has been added. |
+| Magento\Framework\Acl\Builder::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\ActionFlag | Interface has been added. |
+| Magento\Framework\App\ActionFlag::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\AreaList | Interface has been added. |
+| Magento\Framework\App\AreaList::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\DeploymentConfig::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\App\Http\Context | Interface has been added. |
+| Magento\Framework\App\Http\Context::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\Request\Http | Interface has been added. |
+| Magento\Framework\App\Request\Http::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\ResourceConnection | Interface has been added. |
+| Magento\Framework\App\ResourceConnection::\_resetState | [public] Method has been added. |
+| Magento\Framework\Config\ConfigOptionsListConstants::STORE\_KEY\_ENCODED\_RANDOM\_STRING\_PREFIX | Constant has been added. |
+| Magento\Framework\Config\Data::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\Config\Data\Scoped::$\_cache | [protected] Property has been removed. |
+| Magento\Framework\Config\Data\Scoped::$\_cacheId | [protected] Property has been removed. |
+| Magento\Framework\Config\Data\Scoped::$\_reader | [protected] Property has been removed. |
+| Magento\Framework\DB\Adapter\Pdo\Mysql | Interface has been added. |
+| Magento\Framework\DB\Adapter\Pdo\Mysql::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\DB\Adapter\Pdo\Mysql::\_resetState | [public] Method has been added. |
+| Magento\Framework\DataObject::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\Data\Collection | Interface has been added. |
+| Magento\Framework\Data\Collection::\_resetState | [public] Method has been added. |
+| Magento\Framework\Filesystem\DirectoryList::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\Filesystem\Directory\Read::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException | Interface has been added. |
+| Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException::getExtensions | [public] Method has been added. |
+| Magento\Framework\GraphQl\Query\Resolver\BatchResponse | Interface has been added. |
+| Magento\Framework\GraphQl\Query\Resolver\BatchResponse::\_resetState | [public] Method has been added. |
+| Magento\Framework\Logger\Handler\Base::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\Math\Random::getRandomBytes | [public] Method has been added. |
+| Magento\Framework\Pricing\Price\Collection | Interface has been added. |
+| Magento\Framework\Pricing\Price\Collection::\_resetState | [public] Method has been added. |
+| Magento\Framework\Registry | Interface has been added. |
+| Magento\Framework\Registry::\_resetState | [public] Method has been added. |
+| Magento\Framework\Search\Request\Builder | Interface has been added. |
+| Magento\Framework\Search\Request\Builder::\_resetState | [public] Method has been added. |
+| Magento\Framework\Validator | Interface has been added. |
+| Magento\Framework\Validator\AbstractValidator | Interface has been added. |
+| Magento\Framework\Validator\AbstractValidator::\_resetState | [public] Method has been added. |
+| Magento\Framework\View\Asset\Minification | Interface has been added. |
+| Magento\Framework\View\Asset\Minification::\_resetState | [public] Method has been added. |
+| Magento\Framework\View\Asset\Repository | Interface has been added. |
+| Magento\Framework\View\Asset\Repository::\_resetState | [public] Method has been added. |
+| Magento\Framework\Webapi\Exception::HTTP\_TOO\_MANY\_REQUESTS | Constant has been added. |
+| Magento\Framework\Webapi\ServiceInputProcessor | Interface has been added. |
+| Magento\Framework\Webapi\ServiceInputProcessor::\_resetState | [public] Method has been added. |
+| Magento\GraphQlServer\Model\UrlProvider | Class was added. |
+| Magento\ImportExport\Model\Export\Entity\AbstractEntity::$\_storeIdToCode | [protected] Property has been added. |
+| Magento\PaymentServicesBase\Block\Adminhtml\System\Config\Fieldset\Child | Class was added. |
+| Magento\PaymentServicesBase\Block\Adminhtml\System\Config\Fieldset\Payment | Class was added. |
+| Magento\PaymentServicesDashboard\Block\Adminhtml\Index | Class was added. |
+| Magento\PaymentServicesDashboard\Block\Adminhtml\System\Config\MagentoPaymentsButton | Class was added. |
+| Magento\PaymentServicesDashboard\Block\Adminhtml\System\Config\MagentoPaymentsRedirect | Class was added. |
+| Magento\PaymentServicesPaypal\Block\Cart\ValidationMessages | Class was added. |
+| Magento\PaymentServicesPaypal\Block\Customer\CardRenderer | Class was added. |
+| Magento\PaymentServicesPaypal\Block\Info | Class was added. |
+| Magento\PaymentServicesPaypal\Block\Message | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtons | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtonsCart | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtonsProduct | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtons\Review | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtons\Review\Details | Class was added. |
+| Magento\QuickCheckoutAdminPanel\Block\Adminhtml\Index | Class was removed. |
+| Magento\QuickCheckout\Block\Adminhtml\Payment\Form | Class was removed. |
+| Magento\QuickCheckout\Block\Adminhtml\System\Config\ConfigureCallbackUrl | Class was removed. |
+| Magento\QuickCheckout\Block\Adminhtml\System\Config\Fieldset\Custom | Class was removed. |
+| Magento\QuickCheckout\Block\Adminhtml\System\Config\Fieldset\Head | Class was removed. |
+| Magento\QuickCheckout\Block\Adminhtml\System\Config\ValidateCredentials | Class was removed. |
+| Magento\QuickCheckout\Block\Sdk | Class was removed. |
+| Magento\Quote\Model\Quote\Address::setBaseDiscountAmount | [public] Method has been added. |
+| Magento\SaaSCommon\Model\ResyncManager | Class was added. |
+| Magento\SalesRule\Model\Rule::getSimpleAction | [public] Method has been added. |
+| Magento\SalesSequence\Model\Builder | Interface has been added. |
+| Magento\SalesSequence\Model\Builder::\_resetState | [public] Method has been added. |
+| Magento\ServicesIdLayout\Block\Adminhtml\Index | Class was added. |
+| Magento\Shipping\Model\Carrier\AbstractCarrier::$\_result | [protected] Property has been added. |
+| Magento\Store\Model\App\Emulation | Interface has been added. |
+| Magento\Store\Model\App\Emulation::\_resetState | [public] Method has been added. |
+| Magento\Store\Model\Store | Interface has been added. |
+| Magento\Store\Model\Store::\_resetState | [public] Method has been added. |
+| Magento\TargetRule\Block\Catalog\Product\ProductList\Related::getExcludeProductIds | [public] Method has been removed. |
+| Magento\TargetRule\Block\Catalog\Product\ProductList\Upsell::getExcludeProductIds | [public] Method has been removed. |
+| Magento\Weee\Helper\Data | Interface has been added. |
+| Magento\Weee\Helper\Data::\_resetState | [public] Method has been added. |
+
+#### Interface changes {#ee-246-247-beta2-interface}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\CommerceBackendUix\Api\Data\MassActionInterface | Interface was added. |
+| Magento\CommerceBackendUix\Api\MassActionRepositoryInterface | Interface was added. |
+| Magento\Framework\ObjectManager\ResetAfterRequestInterface | Interface was added. |
+| Magento\ImportJsonApi\Api\Data\SourceDataInterface | Interface was added. |
+| Magento\ImportJsonApi\Api\StartImportInterface | Interface was added. |
+| Magento\QuickCheckout\Api\AccountRepositoryInterface | Interface was removed. |
+| Magento\QuickCheckout\Api\Data\AccountInterface | Interface was removed. |
+| Magento\QuickCheckout\Api\Data\AddressInterface | Interface was removed. |
+| Magento\QuickCheckout\Api\Data\PaymentMethodInterface | Interface was removed. |
+| Magento\QuickCheckout\Api\StorefrontAccountRepositoryInterface | Interface was removed. |
+| Magento\SaaSCommon\Model\Http\ConverterInterface | Interface was added. |
+| Magento\ServicesId\Model\ServicesClientInterface | Interface was added. |
+| Magento\ServicesId\Model\ServicesConfigInterface | Interface was added. |
+| Magento\Vault\Api\Data\PaymentTokenInterface::WEBSITE\_ID | Constant has been added. |
+| Magento\Vault\Api\Data\PaymentTokenInterface::getWebsiteId | [public] Method has been added. |
+| Magento\Vault\Api\Data\PaymentTokenInterface::setWebsiteId | [public] Method has been added. |
+
+#### Database changes {#ee-246-247-beta2-database}
+
+| What changed | How it changed |
+| --- | --- |
+| admin\_ui\_sdk\_mass\_actions | Table was added |
+| data\_exporter\_uuid | Table was added |
+| payment\_services\_order\_data\_production\_submitted\_hash | Table was added |
+| payment\_services\_order\_data\_sandbox\_submitted\_hash | Table was added |
+| payment\_services\_order\_status\_data\_production\_submitted\_hash | Table was added |
+| payment\_services\_order\_status\_data\_sandbox\_submitted\_hash | Table was added |
+| payment\_services\_store\_data\_production\_submitted\_hash | Table was added |
+| payment\_services\_store\_data\_sandbox\_submitted\_hash | Table was added |
+| sales\_data\_exporter\_order\_statuses | Table was added |
+| sales\_data\_exporter\_orders | Table was added |
+| stores\_data\_exporter | Table was added |
+| vault\_payment\_token/website\_id | Column was added |
+
+#### Di changes {#ee-246-247-beta2-di}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\Elasticsearch\Elasticsearch5\Model\Client\ElasticsearchFactory | Virtual Type was removed |
+| Magento\Elasticsearch\Setup\InstallConfig | Virtual Type was removed |
+| Magento\QuickCheckout\Gateway\Http\BoltServiceClient | Virtual Type was removed |
+| Magento\QuickCheckout\Gateway\Request\AuthorizationAndCaptureRequest | Virtual Type was removed |
+| Magento\QuickCheckout\Model\AddressValidator\Billing | Virtual Type was removed |
+| Magento\QuickCheckout\Model\AddressValidator\Shipping | Virtual Type was removed |
+| QuickCheckoutAuthorizationAndCaptureRequest | Virtual Type was removed |
+| QuickCheckoutAuthorizationRequest | Virtual Type was removed |
+| QuickCheckoutAuthorizationResponseHandlerComposite | Virtual Type was removed |
+| QuickCheckoutAuthorizeAndCaptureCommand | Virtual Type was removed |
+| QuickCheckoutAuthorizeCommand | Virtual Type was removed |
+| QuickCheckoutCaptureCommand | Virtual Type was removed |
+| QuickCheckoutCaptureRequest | Virtual Type was removed |
+| QuickCheckoutCaptureResponseHandlerComposite | Virtual Type was removed |
+| QuickCheckoutCommandPool | Virtual Type was removed |
+| QuickCheckoutConfig | Virtual Type was removed |
+| QuickCheckoutConfigGuard | Virtual Type was removed |
+| QuickCheckoutConfigValueHandler | Virtual Type was removed |
+| QuickCheckoutFacade | Virtual Type was removed |
+| QuickCheckoutLogger | Virtual Type was removed |
+| QuickCheckoutRefundCommand | Virtual Type was removed |
+| QuickCheckoutRefundRequest | Virtual Type was removed |
+| QuickCheckoutRefundResponseHandlerComposite | Virtual Type was removed |
+| QuickCheckoutValueHandlerPool | Virtual Type was removed |
+| QuickCheckoutVoidCommand | Virtual Type was removed |
+| QuickCheckoutVoidRequest | Virtual Type was removed |
+| QuickCheckoutVoidResponseHandlerComposite | Virtual Type was removed |
+| elasticsearch5CategoryPermissionsCompositeFieldProvider | Virtual Type was removed |
+| elasticsearch5CategoryPermissionsDynamicFieldsProvider | Virtual Type was removed |
+| elasticsearch5DynamicFieldProvider | Virtual Type was removed |
+| elasticsearch5FieldNameDefaultResolver | Virtual Type was removed |
+| elasticsearch5FieldNameResolver | Virtual Type was removed |
+| elasticsearch5FieldProvider | Virtual Type was removed |
+| elasticsearch5FieldTypeDateTimeResolver | Virtual Type was removed |
+| elasticsearch5FieldTypeDefaultResolver | Virtual Type was removed |
+| elasticsearch5FieldTypeFloatResolver | Virtual Type was removed |
+| elasticsearch5StaticFieldProvider | Virtual Type was removed |
+| type | Virtual Type was changed |
+
+#### Layout changes {#ee-246-247-beta2-layout}
+
+| What changed | How it changed |
+| --- | --- |
+| bolt.embed.js | Block was removed |
+| quickCheckoutTracking | Block was removed |
+| quickcheckoutadminpanel.index | Block was removed |
+
+#### System changes {#ee-246-247-beta2-system}
+
+| What changed | How it changed |
+| --- | --- |
+| admin\_ui\_sdk | A section-node was added |
+| admin\_ui\_sdk/general\_config | A group-node was added |
+| admin\_ui\_sdk/general\_config/enable\_admin\_ui\_sdk | A field-node was added |
+| admin\_ui\_sdk/local\_testing | A group-node was added |
+| admin\_ui\_sdk/local\_testing/base\_url | A field-node was added |
+| admin\_ui\_sdk/local\_testing/enable\_local\_service | A field-node was added |
+| admin\_ui\_sdk/local\_testing/ims\_org\_id | A field-node was added |
+| admin\_ui\_sdk/local\_testing/ims\_token | A field-node was added |
+| carriers/fedex/api\_key | A field-node was added |
+| carriers/fedex/dropoff | A field-node was removed |
+| carriers/fedex/key | A field-node was removed |
+| carriers/fedex/meter\_number | A field-node was removed |
+| carriers/fedex/password | A field-node was removed |
+| carriers/fedex/pickup\_type | A field-node was added |
+| carriers/fedex/secret\_key | A field-node was added |
+| carriers/ups/access\_license\_number | A field-node was removed |
+| carriers/ups/gateway\_xml\_url | A field-node was removed |
+| carriers/ups/tracking\_url | A field-node was added |
+| carriers/ups/tracking\_xml\_url | A field-node was removed |
+| carriers/ups/type | A field-node was removed |
+| catalog/search/elasticsearch5\_enable\_auth | A field-node was removed |
+| catalog/search/elasticsearch5\_index\_prefix | A field-node was removed |
+| catalog/search/elasticsearch5\_minimum\_should\_match | A field-node was removed |
+| catalog/search/elasticsearch5\_password | A field-node was removed |
+| catalog/search/elasticsearch5\_server\_hostname | A field-node was removed |
+| catalog/search/elasticsearch5\_server\_port | A field-node was removed |
+| catalog/search/elasticsearch5\_server\_timeout | A field-node was removed |
+| catalog/search/elasticsearch5\_test\_connect\_wizard | A field-node was removed |
+| catalog/search/elasticsearch5\_username | A field-node was removed |
+| checkout/options/enable\_guest\_checkout\_login | A field-node was added |
+| checkout/quick\_checkout | A group-node was removed |
+| checkout/quick\_checkout/credentials | A group-node was removed |
+| checkout/quick\_checkout/credentials/api\_key | A field-node was removed |
+| checkout/quick\_checkout/credentials/configure\_callback\_url | A field-node was removed |
+| checkout/quick\_checkout/credentials/publishable\_key | A field-node was removed |
+| checkout/quick\_checkout/credentials/signing\_secret | A field-node was removed |
+| checkout/quick\_checkout/credentials/validate\_credentials | A field-node was removed |
+| checkout/quick\_checkout/general | A group-node was removed |
+| checkout/quick\_checkout/general/active | A field-node was removed |
+| checkout/quick\_checkout/general/method | A field-node was removed |
+| checkout/quick\_checkout/settings | A group-node was removed |
+| checkout/quick\_checkout/settings/auto\_login\_network | A field-node was removed |
+| checkout/quick\_checkout/settings/checkout\_tracking | A field-node was removed |
+| checkout/quick\_checkout/settings/debug | A field-node was removed |
+| checkout/quick\_checkout/settings/enable\_auto\_login | A field-node was removed |
+| checkout/quick\_checkout/settings/next\_stage\_after\_login | A field-node was removed |
+| checkout/quick\_checkout/settings/payment\_action | A field-node was removed |
+| checkout/quick\_checkout/settings/title | A field-node was removed |
+| payment | A section-node was added |
+| payment/recommended\_solutions | A group-node was added |
+| payment/recommended\_solutions/magento\_payments | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay/debug | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay/display\_buttons\_cart | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay/display\_buttons\_checkout | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay/display\_buttons\_minicart | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay/display\_buttons\_product\_detail | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay/payment\_action | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay/sort\_order | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay/title | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_color | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_height | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_height\_use\_default | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_label | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_layout | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_shape | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_tagline | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/active | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/method | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/production\_merchant\_id | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/sandbox\_merchant\_id | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/soft\_descriptor | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/debug | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/display\_on\_checkout | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/magento\_payments\_button | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/payment\_action | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/sort\_order | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/three\_ds | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/title | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/vault\_active | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/vault\_active\_admin | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/legacy\_admin\_enabled | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/debug | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_buttons\_cart | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_buttons\_checkout | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_buttons\_minicart | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_buttons\_product\_detail | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_paylater\_message | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/funding\_card | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/funding\_paypal\_credit | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/funding\_venmo | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/magento\_payments\_button | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/payment\_action | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/sort\_order | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/title | A field-node was added |
+| sales | A section-node was added |
+| sales/backpressure | A group-node was added |
+| sales/backpressure/enabled | A field-node was added |
+| sales/backpressure/guest\_limit | A field-node was added |
+| sales/backpressure/limit | A field-node was added |
+| sales/backpressure/period | A field-node was added |
+| sales/cancellation | A group-node was added |
+| sales/cancellation/enabled | A field-node was added |
+| sales/cancellation/reasons | A field-node was added |
+| services\_connector | A section-node was added |
+| services\_connector/services\_connector\_integration | A group-node was added |
+| services\_connector/services\_connector\_integration/production\_api\_key | A field-node was added |
+| services\_connector/services\_connector\_integration/production\_private\_key | A field-node was added |
+| services\_connector/services\_connector\_integration/sandbox\_api\_key | A field-node was added |
+| services\_connector/services\_connector\_integration/sandbox\_private\_key | A field-node was added |
+| services\_connector/services\_id\_onboarding | A group-node was added |
+| services\_connector/services\_id\_onboarding/initiate\_onboarding | A field-node was added |
+| system/full\_page\_cache/handles\_size | A field-node was added |
+
+#### Xsd changes {#ee-246-247-beta2-xsd}
+
+| What changed | How it changed |
+| --- | --- |
+| app/code/module-data-exporter/etc/et\_schema.xsd | A schema declaration was added |
+| app/code/module-query-xml/etc/query.xsd | A schema declaration was added |
+
+#### EtSchema changes {#ee-246-247-beta2-etSchema}
+
+| What changed | How it changed |
+| --- | --- |
+| CreditMemo | Added a new declaration for record CreditMemo. |
+| Export | Added a new declaration for record Export. |
+| Invoice | Added a new declaration for record Invoice. |
+| Order | Added a new declaration for record Order. |
+| OrderItem | Added a new declaration for record OrderItem. |
+| OrderStatus | Added a new declaration for record OrderStatus. |
+| Transaction | Added a new declaration for record Transaction. |
+
+#### Class API membership changes {#ee-246-247-beta2-class-api-membership}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\Catalog\Block\Adminhtml\Category\Tab\Product | Class was added. |
+| Magento\Framework\Api\AbstractSimpleObjectBuilder | Class was added. |
+| Magento\Framework\Cache\Frontend\Decorator\Bare | Class was added. |
+| Magento\Framework\Data\Structure | Class was added. |
+| Magento\Framework\HTTP\PhpEnvironment\Request | Class was added. |
+| Magento\Framework\HTTP\PhpEnvironment\Response | Class was added. |
+| Magento\Framework\Locale\Resolver | Class was added. |
+| Magento\Framework\ObjectManager\ObjectManager | Class was added. |
+| Magento\Framework\Session\SessionManager | Class was added. |
+| Magento\Framework\Url | Class was added. |
+| Magento\Framework\Webapi\Request | Class was added. |
+| Magento\SalesRule\Model\Validator | Class was added. |

--- a/src/_includes/backward-incompatible-changes/open-source/2.4.6-2.4.7-beta2.md
+++ b/src/_includes/backward-incompatible-changes/open-source/2.4.6-2.4.7-beta2.md
@@ -1,0 +1,320 @@
+#### Class changes {#ce-246-247-beta2-class}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\Authorization\Model\CompositeUserContext | Interface has been added. |
+| Magento\Authorization\Model\CompositeUserContext::\_resetState | [public] Method has been added. |
+| Magento\Bundle\Block\Catalog\Product\View\Type\Bundle | Interface has been added. |
+| Magento\Bundle\Block\Catalog\Product\View\Type\Bundle::\_resetState | [public] Method has been added. |
+| Magento\CatalogImportExport\Model\Export\Product::$\_storeIdToCode | [protected] Property has been removed. |
+| Magento\Catalog\Helper\Product\Flat\Indexer | Interface has been added. |
+| Magento\Catalog\Helper\Product\Flat\Indexer::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Config::$\_storeManager | [protected] Property has been removed. |
+| Magento\Catalog\Model\Indexer\Category\Product\AbstractAction | Interface has been added. |
+| Magento\Catalog\Model\Indexer\Category\Product\AbstractAction::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Layer | Interface has been added. |
+| Magento\Catalog\Model\Layer::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Layer\Resolver | Interface has been added. |
+| Magento\Catalog\Model\Layer\Resolver::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Product | Interface has been added. |
+| Magento\Catalog\Model\Product::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Product\Media\Config | Interface has been added. |
+| Magento\Catalog\Model\Product\Media\Config::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Product\Option\Type\DefaultType | Interface has been added. |
+| Magento\Catalog\Model\Product\Option\Type\DefaultType::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\Product\Type\Price | Interface has been added. |
+| Magento\Catalog\Model\Product\Type\Price::\_resetState | [public] Method has been added. |
+| Magento\Catalog\Model\ResourceModel\Product | Interface has been added. |
+| Magento\Config\App\Config\Type\System::\_\_debugInfo | [public] Method has been added. |
+| Magento\Config\App\Config\Type\System::cleanAndWarmDefaultScopeData | [public] Method has been added. |
+| Magento\Config\App\Config\Type\System::loadDefaultScopeData | [private] Removed last method parameter(s). |
+| Magento\Config\Model\ResourceModel\Config::\_construct | [protected] Added optional parameter(s). |
+| Magento\ConfigurableProduct\Model\Product\Type\Configurable | Interface has been added. |
+| Magento\ConfigurableProduct\Model\Product\Type\Configurable::\_resetState | [public] Method has been added. |
+| Magento\ConfigurableProduct\Model\Product\VariationHandler | Interface has been added. |
+| Magento\ConfigurableProduct\Model\Product\VariationHandler::\_resetState | [public] Method has been added. |
+| Magento\Customer\Helper\Address | Interface has been added. |
+| Magento\Customer\Helper\Address::\_resetState | [public] Method has been added. |
+| Magento\Customer\Model\Address\AbstractAddress | Interface has been added. |
+| Magento\Customer\Model\Address\AbstractAddress::\_resetState | [public] Method has been added. |
+| Magento\Customer\Model\Customer | Interface has been added. |
+| Magento\Customer\Model\Customer::\_resetState | [public] Method has been added. |
+| Magento\Customer\Model\CustomerRegistry | Interface has been added. |
+| Magento\Customer\Model\CustomerRegistry::\_resetState | [public] Method has been added. |
+| Magento\DataExporter\Model\Indexer\FeedIndexer | Class was added. |
+| Magento\Directory\Helper\Data | Interface has been added. |
+| Magento\Directory\Helper\Data::\_resetState | [public] Method has been added. |
+| Magento\Directory\Model\Country::\_resetState | [public] Method has been added. |
+| Magento\Directory\Model\Currency | Interface has been added. |
+| Magento\Directory\Model\Currency::\_resetState | [public] Method has been added. |
+| Magento\Directory\Model\ResourceModel\Currency | Interface has been added. |
+| Magento\Directory\Model\ResourceModel\Currency::\_resetState | [public] Method has been added. |
+| Magento\Eav\Model\Config | Interface has been added. |
+| Magento\Eav\Model\Config::$\_storeManager | [protected] Property has been added. |
+| Magento\Eav\Model\Config::\_resetState | [public] Method has been added. |
+| Magento\Eav\Model\Config::getWebsiteId | Method visibility has been changed to higher lever from [private] to [public] |
+| Magento\Eav\Model\Config::getWebsiteId | [public] Removed last method parameter(s). |
+| Magento\Eav\Model\Entity\AbstractEntity | Interface has been added. |
+| Magento\Eav\Model\Entity\AbstractEntity::\_resetState | [public] Method has been added. |
+| Magento\Eav\Model\Entity\Attribute\AbstractAttribute | Interface has been added. |
+| Magento\Eav\Model\Entity\Attribute\AbstractAttribute::\_resetState | [public] Method has been added. |
+| Magento\Eav\Model\Entity\Attribute\Source\Table | Interface has been added. |
+| Magento\Eav\Model\Entity\Attribute\Source\Table::\_resetState | [public] Method has been added. |
+| Magento\Elasticsearch\ElasticAdapter\SearchAdapter\Mapper | Class was added. |
+| Magento\Elasticsearch\ElasticAdapter\SearchAdapter\Query\Builder | Class was added. |
+| Magento\Elasticsearch\Elasticsearch5\SearchAdapter\Mapper | Class was removed. |
+| Magento\Elasticsearch\Elasticsearch5\SearchAdapter\Query\Builder | Class was removed. |
+| Magento\Elasticsearch\SearchAdapter\Mapper | Class was removed. |
+| Magento\Framework\Acl\Builder | Interface has been added. |
+| Magento\Framework\Acl\Builder::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\ActionFlag | Interface has been added. |
+| Magento\Framework\App\ActionFlag::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\AreaList | Interface has been added. |
+| Magento\Framework\App\AreaList::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\DeploymentConfig::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\App\Http\Context | Interface has been added. |
+| Magento\Framework\App\Http\Context::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\Request\Http | Interface has been added. |
+| Magento\Framework\App\Request\Http::\_resetState | [public] Method has been added. |
+| Magento\Framework\App\ResourceConnection | Interface has been added. |
+| Magento\Framework\App\ResourceConnection::\_resetState | [public] Method has been added. |
+| Magento\Framework\Config\ConfigOptionsListConstants::STORE\_KEY\_ENCODED\_RANDOM\_STRING\_PREFIX | Constant has been added. |
+| Magento\Framework\Config\Data::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\Config\Data\Scoped::$\_cache | [protected] Property has been removed. |
+| Magento\Framework\Config\Data\Scoped::$\_cacheId | [protected] Property has been removed. |
+| Magento\Framework\Config\Data\Scoped::$\_reader | [protected] Property has been removed. |
+| Magento\Framework\DB\Adapter\Pdo\Mysql | Interface has been added. |
+| Magento\Framework\DB\Adapter\Pdo\Mysql::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\DB\Adapter\Pdo\Mysql::\_resetState | [public] Method has been added. |
+| Magento\Framework\DataObject::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\Data\Collection | Interface has been added. |
+| Magento\Framework\Data\Collection::\_resetState | [public] Method has been added. |
+| Magento\Framework\Filesystem\DirectoryList::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\Filesystem\Directory\Read::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException | Interface has been added. |
+| Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException::getExtensions | [public] Method has been added. |
+| Magento\Framework\GraphQl\Query\Resolver\BatchResponse | Interface has been added. |
+| Magento\Framework\GraphQl\Query\Resolver\BatchResponse::\_resetState | [public] Method has been added. |
+| Magento\Framework\Logger\Handler\Base::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\Math\Random::getRandomBytes | [public] Method has been added. |
+| Magento\Framework\Pricing\Price\Collection | Interface has been added. |
+| Magento\Framework\Pricing\Price\Collection::\_resetState | [public] Method has been added. |
+| Magento\Framework\Registry | Interface has been added. |
+| Magento\Framework\Registry::\_resetState | [public] Method has been added. |
+| Magento\Framework\Search\Request\Builder | Interface has been added. |
+| Magento\Framework\Search\Request\Builder::\_resetState | [public] Method has been added. |
+| Magento\Framework\Validator | Interface has been added. |
+| Magento\Framework\Validator\AbstractValidator | Interface has been added. |
+| Magento\Framework\Validator\AbstractValidator::\_resetState | [public] Method has been added. |
+| Magento\Framework\View\Asset\Minification | Interface has been added. |
+| Magento\Framework\View\Asset\Minification::\_resetState | [public] Method has been added. |
+| Magento\Framework\View\Asset\Repository | Interface has been added. |
+| Magento\Framework\View\Asset\Repository::\_resetState | [public] Method has been added. |
+| Magento\Framework\Webapi\Exception::HTTP\_TOO\_MANY\_REQUESTS | Constant has been added. |
+| Magento\Framework\Webapi\ServiceInputProcessor | Interface has been added. |
+| Magento\Framework\Webapi\ServiceInputProcessor::\_resetState | [public] Method has been added. |
+| Magento\GraphQlServer\Model\UrlProvider | Class was added. |
+| Magento\ImportExport\Model\Export\Entity\AbstractEntity::$\_storeIdToCode | [protected] Property has been added. |
+| Magento\PaymentServicesBase\Block\Adminhtml\System\Config\Fieldset\Child | Class was added. |
+| Magento\PaymentServicesBase\Block\Adminhtml\System\Config\Fieldset\Payment | Class was added. |
+| Magento\PaymentServicesDashboard\Block\Adminhtml\Index | Class was added. |
+| Magento\PaymentServicesDashboard\Block\Adminhtml\System\Config\MagentoPaymentsButton | Class was added. |
+| Magento\PaymentServicesDashboard\Block\Adminhtml\System\Config\MagentoPaymentsRedirect | Class was added. |
+| Magento\PaymentServicesPaypal\Block\Cart\ValidationMessages | Class was added. |
+| Magento\PaymentServicesPaypal\Block\Customer\CardRenderer | Class was added. |
+| Magento\PaymentServicesPaypal\Block\Info | Class was added. |
+| Magento\PaymentServicesPaypal\Block\Message | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtons | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtonsCart | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtonsProduct | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtons\Review | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtons\Review\Details | Class was added. |
+| Magento\Quote\Model\Quote\Address::setBaseDiscountAmount | [public] Method has been added. |
+| Magento\SaaSCommon\Model\ResyncManager | Class was added. |
+| Magento\SalesRule\Model\Rule::getSimpleAction | [public] Method has been added. |
+| Magento\SalesSequence\Model\Builder | Interface has been added. |
+| Magento\SalesSequence\Model\Builder::\_resetState | [public] Method has been added. |
+| Magento\ServicesIdLayout\Block\Adminhtml\Index | Class was added. |
+| Magento\Shipping\Model\Carrier\AbstractCarrier::$\_result | [protected] Property has been added. |
+| Magento\Store\Model\App\Emulation | Interface has been added. |
+| Magento\Store\Model\App\Emulation::\_resetState | [public] Method has been added. |
+| Magento\Store\Model\Store | Interface has been added. |
+| Magento\Store\Model\Store::\_resetState | [public] Method has been added. |
+| Magento\Weee\Helper\Data | Interface has been added. |
+| Magento\Weee\Helper\Data::\_resetState | [public] Method has been added. |
+
+#### Interface changes {#ce-246-247-beta2-interface}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\Framework\ObjectManager\ResetAfterRequestInterface | Interface was added. |
+| Magento\SaaSCommon\Model\Http\ConverterInterface | Interface was added. |
+| Magento\ServicesId\Model\ServicesClientInterface | Interface was added. |
+| Magento\ServicesId\Model\ServicesConfigInterface | Interface was added. |
+| Magento\Vault\Api\Data\PaymentTokenInterface::WEBSITE\_ID | Constant has been added. |
+| Magento\Vault\Api\Data\PaymentTokenInterface::getWebsiteId | [public] Method has been added. |
+| Magento\Vault\Api\Data\PaymentTokenInterface::setWebsiteId | [public] Method has been added. |
+
+#### Database changes {#ce-246-247-beta2-database}
+
+| What changed | How it changed |
+| --- | --- |
+| data\_exporter\_uuid | Table was added |
+| payment\_services\_order\_data\_production\_submitted\_hash | Table was added |
+| payment\_services\_order\_data\_sandbox\_submitted\_hash | Table was added |
+| payment\_services\_order\_status\_data\_production\_submitted\_hash | Table was added |
+| payment\_services\_order\_status\_data\_sandbox\_submitted\_hash | Table was added |
+| payment\_services\_store\_data\_production\_submitted\_hash | Table was added |
+| payment\_services\_store\_data\_sandbox\_submitted\_hash | Table was added |
+| sales\_data\_exporter\_order\_statuses | Table was added |
+| sales\_data\_exporter\_orders | Table was added |
+| stores\_data\_exporter | Table was added |
+| vault\_payment\_token/website\_id | Column was added |
+
+#### Di changes {#ce-246-247-beta2-di}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\Elasticsearch\Elasticsearch5\Model\Client\ElasticsearchFactory | Virtual Type was removed |
+| Magento\Elasticsearch\Setup\InstallConfig | Virtual Type was removed |
+| elasticsearch5DynamicFieldProvider | Virtual Type was removed |
+| elasticsearch5FieldNameDefaultResolver | Virtual Type was removed |
+| elasticsearch5FieldNameResolver | Virtual Type was removed |
+| elasticsearch5FieldProvider | Virtual Type was removed |
+| elasticsearch5FieldTypeDateTimeResolver | Virtual Type was removed |
+| elasticsearch5FieldTypeDefaultResolver | Virtual Type was removed |
+| elasticsearch5FieldTypeFloatResolver | Virtual Type was removed |
+| elasticsearch5StaticFieldProvider | Virtual Type was removed |
+| type | Virtual Type was changed |
+
+#### System changes {#ce-246-247-beta2-system}
+
+| What changed | How it changed |
+| --- | --- |
+| carriers/fedex/api\_key | A field-node was added |
+| carriers/fedex/dropoff | A field-node was removed |
+| carriers/fedex/key | A field-node was removed |
+| carriers/fedex/meter\_number | A field-node was removed |
+| carriers/fedex/password | A field-node was removed |
+| carriers/fedex/pickup\_type | A field-node was added |
+| carriers/fedex/secret\_key | A field-node was added |
+| carriers/ups/access\_license\_number | A field-node was removed |
+| carriers/ups/gateway\_xml\_url | A field-node was removed |
+| carriers/ups/tracking\_url | A field-node was added |
+| carriers/ups/tracking\_xml\_url | A field-node was removed |
+| carriers/ups/type | A field-node was removed |
+| catalog/search/elasticsearch5\_enable\_auth | A field-node was removed |
+| catalog/search/elasticsearch5\_index\_prefix | A field-node was removed |
+| catalog/search/elasticsearch5\_minimum\_should\_match | A field-node was removed |
+| catalog/search/elasticsearch5\_password | A field-node was removed |
+| catalog/search/elasticsearch5\_server\_hostname | A field-node was removed |
+| catalog/search/elasticsearch5\_server\_port | A field-node was removed |
+| catalog/search/elasticsearch5\_server\_timeout | A field-node was removed |
+| catalog/search/elasticsearch5\_test\_connect\_wizard | A field-node was removed |
+| catalog/search/elasticsearch5\_username | A field-node was removed |
+| checkout/options/enable\_guest\_checkout\_login | A field-node was added |
+| payment | A section-node was added |
+| payment/recommended\_solutions | A group-node was added |
+| payment/recommended\_solutions/magento\_payments | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay/debug | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay/display\_buttons\_cart | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay/display\_buttons\_checkout | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay/display\_buttons\_minicart | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay/display\_buttons\_product\_detail | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay/payment\_action | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay/sort\_order | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/apple\_pay/title | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_color | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_height | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_height\_use\_default | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_label | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_layout | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_shape | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/button\_style/style\_tagline | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/active | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/method | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/production\_merchant\_id | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/sandbox\_merchant\_id | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/soft\_descriptor | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/debug | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/display\_on\_checkout | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/magento\_payments\_button | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/payment\_action | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/sort\_order | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/three\_ds | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/title | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/vault\_active | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/hosted\_fields/vault\_active\_admin | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/legacy\_admin\_enabled | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons | A group-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/debug | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_buttons\_cart | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_buttons\_checkout | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_buttons\_minicart | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_buttons\_product\_detail | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/display\_paylater\_message | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/funding\_card | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/funding\_paypal\_credit | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/funding\_venmo | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/magento\_payments\_button | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/payment\_action | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/sort\_order | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/smart\_buttons/title | A field-node was added |
+| sales | A section-node was added |
+| sales/backpressure | A group-node was added |
+| sales/backpressure/enabled | A field-node was added |
+| sales/backpressure/guest\_limit | A field-node was added |
+| sales/backpressure/limit | A field-node was added |
+| sales/backpressure/period | A field-node was added |
+| sales/cancellation | A group-node was added |
+| sales/cancellation/enabled | A field-node was added |
+| sales/cancellation/reasons | A field-node was added |
+| services\_connector | A section-node was added |
+| services\_connector/services\_connector\_integration | A group-node was added |
+| services\_connector/services\_connector\_integration/production\_api\_key | A field-node was added |
+| services\_connector/services\_connector\_integration/production\_private\_key | A field-node was added |
+| services\_connector/services\_connector\_integration/sandbox\_api\_key | A field-node was added |
+| services\_connector/services\_connector\_integration/sandbox\_private\_key | A field-node was added |
+| services\_connector/services\_id\_onboarding | A group-node was added |
+| services\_connector/services\_id\_onboarding/initiate\_onboarding | A field-node was added |
+| system/full\_page\_cache/handles\_size | A field-node was added |
+
+#### Xsd changes {#ce-246-247-beta2-xsd}
+
+| What changed | How it changed |
+| --- | --- |
+| app/code/module-data-exporter/etc/et\_schema.xsd | A schema declaration was added |
+| app/code/module-query-xml/etc/query.xsd | A schema declaration was added |
+
+#### EtSchema changes {#ce-246-247-beta2-etSchema}
+
+| What changed | How it changed |
+| --- | --- |
+| CreditMemo | Added a new declaration for record CreditMemo. |
+| Export | Added a new declaration for record Export. |
+| Invoice | Added a new declaration for record Invoice. |
+| Order | Added a new declaration for record Order. |
+| OrderItem | Added a new declaration for record OrderItem. |
+| OrderStatus | Added a new declaration for record OrderStatus. |
+| Transaction | Added a new declaration for record Transaction. |
+
+#### Class API membership changes {#ce-246-247-beta2-class-api-membership}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\Framework\Api\AbstractSimpleObjectBuilder | Class was added. |
+| Magento\Framework\Cache\Frontend\Decorator\Bare | Class was added. |
+| Magento\Framework\Data\Structure | Class was added. |
+| Magento\Framework\HTTP\PhpEnvironment\Request | Class was added. |
+| Magento\Framework\HTTP\PhpEnvironment\Response | Class was added. |
+| Magento\Framework\Locale\Resolver | Class was added. |
+| Magento\Framework\ObjectManager\ObjectManager | Class was added. |
+| Magento\Framework\Session\SessionManager | Class was added. |
+| Magento\Framework\Url | Class was added. |
+| Magento\Framework\Webapi\Request | Class was added. |
+| Magento\SalesRule\Model\Validator | Class was added. |

--- a/src/pages/development/backward-incompatible-changes/reference.md
+++ b/src/pages/development/backward-incompatible-changes/reference.md
@@ -27,6 +27,26 @@ To view changes in functional tests, refer to [Backward incompatible changes in 
 
 Patch releases are primarily focused on delivering security and quality enhancements on a regular basis to help you keep your sites performing at their peak. On an exceptional basis, breaking changes or additional patches or hotfixes may be released to address security or compliance issues and high-impact quality issues. On the module level, these are mostly PATCH-level changes; sometimes MINOR-level changes. See [Release policy](https://experienceleague.adobe.com/docs/commerce-operations/release/policy.html).
 
+## 2.4.6 - 2.4.7-beta2
+
+### Adobe Commerce
+
+import Ac247b2 from '/src/_includes/backward-incompatible-changes/commerce/2.4.6-2.4.7-beta2.md'
+
+<Ac247b2 />
+
+### B2B for Adobe Commerce
+
+import B2b247b2 from '/src/_includes/backward-incompatible-changes/b2b/2.4.6-2.4.7-beta2.md'
+
+<B2b247b2 />
+
+### Magento Open Source
+
+import Os247b2 from '/src/_includes/backward-incompatible-changes/open-source/2.4.6-2.4.7-beta2.md'
+
+<Os247b2 />
+
 ## 2.4.6 - 2.4.7-beta1
 
 ### Adobe Commerce


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds backward incompatible changes reference documentation for the 2.4.6 - 2.4.7-beta2 delta.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/php/development/backward-incompatible-changes/reference/

## Additional info

### Preview

- https://commerce-docs.github.io/commerce-php/development/backward-incompatible-changes/reference/#246---247-beta2

---
whatsnew

Published the [Backward incompatible changes reference docs](https://developer.adobe.com/commerce/php/development/backward-incompatible-changes/reference/) for 2.4.6 - 2.4.7-beta2.
