### PR TITLE
Rename the test:links task

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Check internal links
         uses: borales/actions-yarn@v3
         with:
-          cmd: test:links
+          cmd: test
 
       - name: Build site
         if: ${{ success() }}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build": "gatsby build",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
-    "test:links": "remark src/pages --quiet --frail",
+    "test": "remark src/pages --quiet --frail",
     "lint": "docker run --rm -e RUN_LOCAL=true --env-file .github/super-linter.env -v \"$PWD\":/tmp/lint github/super-linter:slim-v4.10.1"
   },
   "packageManager": "yarn@3.2.4"


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) renames the `test:links` task to `test` because the functionality of the tasks was extended to more than only testing the links.

## Affected pages

none

## Related PRs

- https://github.com/AdobeDocs/commerce-admin-developer/pull/81
- https://github.com/AdobeDocs/commerce-cloud-tools/pull/71
- https://github.com/AdobeDocs/commerce-extensibility/pull/90
- https://github.com/AdobeDocs/commerce-frontend-core/pull/142
- https://github.com/AdobeDocs/commerce-marketplace/pull/108
- https://github.com/AdobeDocs/commerce-pwa-studio/pull/205
- https://github.com/AdobeDocs/commerce-services/pull/70
- https://github.com/AdobeDocs/commerce-testing/pull/68
- https://github.com/AdobeDocs/commerce-webapi/pull/216
- https://github.com/AdobeDocs/commerce-xd-kits/pull/117
- https://github.com/AdobeDocs/graphql-mesh-gateway/pull/166
- https://github.com/AdobeDocs/commerce-contributor/pull/100