### PR TITLE
Upgrade test-pull-request workflow

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -61,7 +61,6 @@ jobs:
           DEFAULT_BRANCH: main
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_GITHUB_ACTIONS: true
-          FILTER_REGEX_EXCLUDE: .git/*
 
       - name: Setup Node v16 for Yarn v3
         uses: actions/setup-node@v3

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -9,7 +9,6 @@ name: Latest Pull Request
 # Documentation:
 # - Workflow: https://help.github.com/en/articles/workflow-syntax-for-github-actions
 # - SuperLinter: https://github.com/github/super-linter
-# - Markdown linter: https://github.com/DavidAnson/markdownlint
 # - Link validation: https://github.com/remarkjs/remark-validate-links
 
 ######################################################
@@ -25,6 +24,14 @@ jobs:
     # Set the agent to run on
     runs-on: ubuntu-latest
 
+    ############################################
+    # Grant status permission for MULTI_STATUS #
+    ############################################
+    permissions:
+      contents: read
+      packages: read
+      statuses: write
+
     ##################
     # Load all steps #
     ##################
@@ -33,7 +40,7 @@ jobs:
       # Checkout the code base #
       ##########################
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Full git history is needed to get a proper list of changed files
           # within `super-linter`
@@ -48,12 +55,13 @@ jobs:
         # Use full version number to avoid cases when a next
         # released version is buggy
         # About slim image: https://github.com/github/super-linter#slim-image
-        uses: github/super-linter/slim@v4.10.1
+        uses: super-linter/super-linter/slim@v5.4.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_GITHUB_ACTIONS: true
+          FILTER_REGEX_EXCLUDE: .git/*
 
       - name: Setup Node v16 for Yarn v3
         uses: actions/setup-node@v3

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "serve": "gatsby serve",
     "clean": "gatsby clean",
     "test": "remark src/pages --quiet --frail",
-    "lint": "docker run --rm -e RUN_LOCAL=true --env-file .github/super-linter.env -v \"$PWD\":/tmp/lint github/super-linter:slim-v4.10.1"
+    "lint": "docker run --rm -e RUN_LOCAL=true --env-file .github/super-linter.env -v \"$PWD\":/tmp/lint github/super-linter:slim-v5"
   },
   "packageManager": "yarn@3.2.4"
 }


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates dependencies for the linting steps in the PR testing workflow:
* Upgrades actions/checkout to v4
* Upgrades super-linter/super-linter to 5.4.3 (latest)
* Adds multistatus permissions recommended by the [example](https://github.com/super-linter/super-linter#example-connecting-github-action-workflow) workflow

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

none
