### PR TITLE
Sync deployment workflows with the template repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -116,7 +116,7 @@ jobs:
           GATSBY_FEDS_PRIVACY_ID: ${{ secrets.AIO_FEDS_PRIVACY_ID }}
           GATSBY_SITE_DOMAIN_URL: https://developer.adobe.com
       - name: Deploy
-        uses: icaraps/static-website-deploy@master
+        uses: AdobeDocs/static-website-deploy@master
         with:
           enabled-static-website: 'true'
           source: 'public'
@@ -127,7 +127,7 @@ jobs:
         run: sleep 60s
         shell: bash
       - name: Purge Fastly Cache
-        uses: icaraps/gatsby-fastly-purge-action@master
+        uses: AdobeDocs/gatsby-fastly-purge-action@master
         with:
           fastly-token: ${{ secrets.AIO_FASTLY_TOKEN }}
           fastly-url: '${{ secrets.AIO_FASTLY_PROD_URL }}${{ needs.set-state.outputs.path_prefix }}'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -123,9 +123,6 @@ jobs:
           target: ${{ needs.set-state.outputs.path_prefix }}
           connection-string: ${{ secrets.AIO_AZURE_PROD_CONNECTION_STRING }}
           remove-existing-files: 'true'
-      - name: Delay purge
-        run: sleep 60s
-        shell: bash
       - name: Purge Fastly Cache
         uses: AdobeDocs/gatsby-fastly-purge-action@master
         with:

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -134,7 +134,7 @@ jobs:
           GATSBY_SITE_DOMAIN_URL: https://developer-stage.adobe.com
 
       - name: Deploy
-        uses: icaraps/static-website-deploy@master
+        uses: AdobeDocs/static-website-deploy@master
         with:
           enabled-static-website: 'true'
           source: 'public'
@@ -146,7 +146,7 @@ jobs:
         run: sleep 60s
         shell: bash
       - name: Purge Fastly Cache
-        uses: icaraps/gatsby-fastly-purge-action@master
+        uses: AdobeDocs/gatsby-fastly-purge-action@master
         with:
           fastly-token: ${{ secrets.AIO_FASTLY_TOKEN }}
           fastly-url: '${{ secrets.AIO_FASTLY_DEV_URL}}${{ needs.set-state.outputs.path_prefix }}'

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -142,9 +142,6 @@ jobs:
           connection-string: ${{ secrets.AIO_AZURE_DEV_CONNECTION_STRING }}
           remove-existing-files: 'true'
           exclude-subfolder: ${{ needs.set-state.outputs.exclude_subfolder }}
-      - name: Delay purge
-        run: sleep 60s
-        shell: bash
       - name: Purge Fastly Cache
         uses: AdobeDocs/gatsby-fastly-purge-action@master
         with:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the stage and publish workflows to sync them with updates at the [template repo](https://github.com/AdobeDocs/dev-site-documentation-template/blob/main/.github/workflows/deploy.yml).

## Test run on staging

https://github.com/AdobeDocs/commerce-php/actions/runs/6749672181