### PR TITLE
Add definition of Model directories

### DIFF
--- a/src/pages/development/build/component-file-structure.md
+++ b/src/pages/development/build/component-file-structure.md
@@ -37,25 +37,31 @@ Following are some common module directories:
 The directory structure for the ORM follows the MVC pattern:
 
 ```tree
-├── Model: Each file is responsible for defining the behavior, properties, and interactions related to a specific entity.
-│   ├── ResourceModel: contains files that handle the interaction with the database or data storage backend for the corresponding models. These classes abstract the database operations and provide a convenient interface for CRUD (Create, Read, Update, Delete) operations on the associated entities.
-│     └──  ModelName/Collection: contains files that define collections of entities. Collections provide a way to work with sets of data or multiple instances of a model simultaneously. These classes offer methods for querying, filtering, and manipulating groups of records from the database.
+├── Model
+│   ├── ResourceModel
+│     └──  ModelName/Collection
 ```
+
+Model directories include:
+
+* `Model`: Each file is responsible for defining the behavior, properties, and interactions related to a specific entity.
+* `ResourceModel`: contains files that handle the interaction with the database or data storage backend for the corresponding models. These classes abstract the database operations and provide a convenient interface for CRUD (Create, Read, Update, Delete) operations on the associated entities.
+* `ModelName/Collection`: contains files that define collections of entities. Collections provide a way to work with sets of data or multiple instances of a model simultaneously. These classes offer methods for querying, filtering, and manipulating groups of records from the database.
 
 ### Additional directories
 
 Additional folders can be added for configuration and other ancillary functions for items like [plugin-ins](../components/plugins.md), localization, and layout files.
 
-*  `Api`: contains any PHP classes exposed to the API.
-*  `Console`: contains CLI commands. For more info, see [Add CLI commands](../cli-commands/custom.md).
-*  `Cron`: contains cron job definitions.
-*  `CustomerData`: contains section files.
-*  `Helper`: contains aggregated functionality.
-*  `i18n`: contains localization files.
-*  `Observer`: contains files for executing commands from the listener.
-*  `Plugin`: contains any needed [plug-ins](../components/plugins.md).
-*  `UI`: contains data generation files.
-*  `view`: contains view files, including static view files, design templates, email templates, and layout files.
+* `Api`: contains any PHP classes exposed to the API.
+* `Console`: contains CLI commands. For more info, see [Add CLI commands](../cli-commands/custom.md).
+* `Cron`: contains cron job definitions.
+* `CustomerData`: contains section files.
+* `Helper`: contains aggregated functionality.
+* `i18n`: contains localization files.
+* `Observer`: contains files for executing commands from the listener.
+* `Plugin`: contains any needed [plug-ins](../components/plugins.md).
+* `UI`: contains data generation files.
+* `view`: contains view files, including static view files, design templates, email templates, and layout files.
 
 ## Theme file structure
 
@@ -107,11 +113,11 @@ Typical theme directories are:
 *  `media`: Theme preview images (screen capture of your theme) can be put in here.
 *  `web`: Optional directory that contains static files organized into the following subdirectories:
 
-  *  `css/source`: Contains a theme's `less` configuration files that invoke mixins for global elements from the [UI library](https://developer.adobe.com/commerce/frontend-core/guide/css/ui-library/), and the `theme.less` file that overrides the default variables values.
-  *  `css/source/lib`: Contains view files that override the [UI library](https://developer.adobe.com/commerce/frontend-core/guide/css/ui-library/) files stored in `lib/web/css/source/lib`.
-  *  `fonts`: The folder to place the different fonts for your theme.
-  *  `images`: Static images folder.
-  *  `js`: The folder for your JavaScript files.
+   *  `css/source`: Contains a theme's `less` configuration files that invoke mixins for global elements from the [UI library](https://developer.adobe.com/commerce/frontend-core/guide/css/ui-library/), and the `theme.less` file that overrides the default variables values.
+   *  `css/source/lib`: Contains view files that override the [UI library](https://developer.adobe.com/commerce/frontend-core/guide/css/ui-library/) files stored in `lib/web/css/source/lib`.
+   *  `fonts`: The folder to place the different fonts for your theme.
+   *  `images`: Static images folder.
+   *  `js`: The folder for your JavaScript files.
 
 For more details on the theme folder structure, see [theme structure](https://developer.adobe.com/commerce/frontend-core/guide/themes/structure/).
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) includes the proposed changes in PR #183 but provides formatting that is easier to read and conforms to the other tree content format in the topic.

## Affected pages

https://developer.adobe.com/commerce/php/development/build/component-file-structure/

### Formatting change

In the earlier #183 , the definitions were in the code block, which caused a hard-to-read scrolling:

<img width="826" alt="Screenshot 2023-11-07 at 09 53 39" src="https://github.com/AdobeDocs/commerce-php/assets/5817319/e0a58343-89e7-4c92-842e-fb9c74b172c5">

I moved the definitions to a list, similar to other directory definitions in the topic:

<img width="843" alt="Screenshot 2023-11-07 at 09 52 17" src="https://github.com/AdobeDocs/commerce-php/assets/5817319/b74bb526-bdf3-4c01-87e1-4ccea469dc55">
