### PR TITLE
Add top-nav dropdown for Module Reference Guide

### DIFF
--- a/src/data/navigation/header.js
+++ b/src/data/navigation/header.js
@@ -17,11 +17,18 @@ module.exports = [
     },
     {
       title: "Module Reference",
-      path: "/module-reference/",
-    },
-    {
-      title: "Module Reference (Beta)",
-      path: "/module-reference-beta/",
+      menu: [
+        {
+          title: "2.4.6",
+          description: "Lorem ipsum",
+          path: "/module-reference/",
+        },
+        {
+          title: "2.4.7-beta",
+          description: "Lorem ipsum",
+          path: "/module-reference-beta/",
+        },
+      ]
     },
     {
       title: "Coding Standards",


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is an experiment that demonstrates the possibility of using dropdown menus in the top navigation bar in devsite repos. Merging is optional. The primary purpose of this PR is to raise awareness among @AdobeDocs/commerce-writers.

**Staging build**: https://developer-stage.adobe.com/commerce/php/

![Screenshot 2023-11-10 at 9 49 49 AM](https://github.com/AdobeDocs/commerce-php/assets/13662379/0b3c2320-ad72-4673-90d0-7e9934c1c478)

## Notes

The Document Cloud/Services team uses this extensively in their [repo](https://github.com/AdobeDocs/document-services/blob/main/gatsby-config.js#L34). See their [production docs](https://developer.adobe.com/document-services/) for an example.

~This isn't documented in the devsite theme [README](https://github.com/adobe/aio-theme/), but maintainers often point to it as an example for teams that require top-nav dropdowns.~ See the devsite theme [README](https://github.com/adobe/aio-theme/#menus) for details.

This could help improve the organization of content in some of our Commerce repos.