### PR TITLE
Dropdown menu for the Module reference versions

### DIFF
--- a/src/data/navigation/header.js
+++ b/src/data/navigation/header.js
@@ -17,11 +17,16 @@ module.exports = [
     },
     {
       title: "Module Reference",
-      path: "/module-reference/",
-    },
-    {
-      title: "Module Reference (Beta)",
-      path: "/module-reference-beta/",
+      menu: [
+        {
+          title: "v2.4.6",
+          path: "/module-reference/",
+        },
+        {
+          title: "v2.4.7-beta",
+          path: "/module-reference-beta/",
+        },
+      ]
     },
     {
       title: "Coding Standards",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6230,9 +6230,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001370, caniuse-lite@npm:^1.0.30001373":
-  version: 1.0.30001464
-  resolution: "caniuse-lite@npm:1.0.30001464"
-  checksum: 67cdee102c1660d62d7b9dbd4740bb7af096236618f2509fd2e0039d50db5f02fb87c21d90b6d573fdcf50deaf3c84503d009e871502b5c221d0ba1dec18ba11
+  version: 1.0.30001562
+  resolution: "caniuse-lite@npm:1.0.30001562"
+  checksum: 414ed45ae47a432607be1c9588bd478440acb033e46ede74c97501bfdb9ba4b1615e221d3ce7c7be55e1e0834725fd1ce5bf5e037bb9dd384c8e85b5e83dc6d1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) replaces the separate menu items for the **Module reference** and **Module reference (Beta)** in the top navigation with a dropdown menu as was suggested in https://github.com/AdobeDocs/commerce-php/pull/211.

### Before

<img width="1146" alt="module reference top nav before" src="https://github.com/AdobeDocs/commerce-php/assets/12731225/8f224867-60da-440c-85c6-e8b7c42d652f">

### After

<img width="1099" alt="module reference top nav after" src="https://github.com/AdobeDocs/commerce-php/assets/12731225/9e3df87b-0cee-418b-aa19-b09776b1dec2">

Also, upgraded the caniuse-lite package as recommended by a package manager.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- Main navigation on all pages

## Preview

https://commerce-docs.github.io/commerce-php/
