### PR TITLE
GH-213: Fixed broken link

### DIFF
--- a/src/_includes/page-cache-checklist.md
+++ b/src/_includes/page-cache-checklist.md
@@ -10,7 +10,7 @@
 
 -  Model and block level should identify themselves for invalidation support
 
--  Declare a custom [context variable](../pages/development/cache/page/public-content.md#configure-page-variations) if you plan to show different public content with the same URL
+-  Declare a custom [context variable](/src/pages/development/cache/page/public-content.md#configure-page-variations) if you plan to show different public content with the same URL
 
 ## Non-cacheable page checklist
 

--- a/src/pages/development/cache/page/private-content.md
+++ b/src/pages/development/cache/page/private-content.md
@@ -162,6 +162,6 @@ Versioning works as follows:
 
 The customer data invalidation mechanism no longer relies on the `private_content_version`.
 
-import Docs from '/src/_includes/page-cache-checklist.md'
+import PageChecklist from '/src/_includes/page-cache-checklist.md'
 
-<Docs />
+<PageChecklist />


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes #213.

It also changes the import directive for the include to something more intuitive.

## Affected pages

- https://developer.adobe.com/commerce/php/development/cache/page/private-content/#cacheable-page-checklist