### PR TITLE
Fix typos for the module name in module-admin-adobe-ims.md

### DIFF
--- a/src/pages/module-reference/module-admin-adobe-ims.md
+++ b/src/pages/module-reference/module-admin-adobe-ims.md
@@ -3,9 +3,9 @@ title: AdminAdobeIms
 description: README.md contents of the module from the source code
 ---
 
-# Magento_Admin_Adobe_Ims module
+# Magento_AdminAdobeIms module
 
-The Magento_Admin_Adobe_Ims module contains integration with Adobe IMS for backend authentication.
+The Magento_AdminAdobeIms module contains integration with Adobe IMS for backend authentication.
 
 For information about module installation in Magento 2, see [Enable or disable modules](https://devdocs.magento.com/guides/v2.4/install-gde/install/cli/install-cli-subcommands-enable.html).
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes typos for the module name in module-admin-adobe-ims.md
Incorrect value: `Magento_Admin_Adobe_Ims`
Correct value: `Magento_AdminAdobeIms`

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/php/module-reference/module-admin-adobe-ims/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- None

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-php/blob/main/.github/CONTRIBUTING.md) for more information.
-->
