### PR TITLE
Fix and update workflows with a build step

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -6,12 +6,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - name: Yarn Install
-        uses: bahmutov/npm-install@v1
-      - name: Build
-        run: |
-          yarn build
+        uses: actions/checkout@v4
+
+      - name: Setup Node v16
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+          cache-dependency-path: 'yarn.lock'
+
+      - name: Enable Corepack for Yarn
+        run: corepack enable
+
+      - name: Install Dependencies
+        run: yarn install
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
+
+      - name: Build site
+        run: yarn build
         env:
           NODE_OPTIONS: "--max-old-space-size=8192"
           PREFIX_PATHS: true # works like --prefix-paths flag for 'gatsby build'

--- a/.github/workflows/index.yml
+++ b/.github/workflows/index.yml
@@ -18,32 +18,27 @@ jobs:
   build-and-index:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Setup Node v16 for Yarn v3
+      - name: Setup Node v16
         uses: actions/setup-node@v3
         with:
-          node-version: '16.15.0' # Current LTS version
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+          cache-dependency-path: 'yarn.lock'
 
-      - name: Enable Corepack for Yarn v3
+      - name: Enable Corepack for Yarn
         run: corepack enable
 
-      - name: Install Yarn v3
-        uses: borales/actions-yarn@v3
-        with:
-          cmd: set version stable
-
-      - name: Install dependencies
-        uses: borales/actions-yarn@v3
-        with:
-          cmd: install
+      - name: Install Dependencies
+        run: yarn install
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
       - name: Build site
-        uses: borales/actions-yarn@v3
-        with:
-          cmd: build
+        run: yarn build
+
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
           PREFIX_PATHS: true # equivalent to --prefix-paths flag for 'gatsby build'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       branch_short_ref: ${{ steps.get_branch.outputs.branch }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get pathPrefix
         uses: actions/github-script@v6
@@ -56,30 +56,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Setup Node v16 for Yarn v3
+      - name: Setup Node v16
         uses: actions/setup-node@v3
         with:
-          node-version: '16.15.0' # Current LTS version
-
-      - name: Enable Corepack for Yarn v3
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+          cache-dependency-path: 'yarn.lock'
+  
+      - name: Enable Corepack for Yarn
         run: corepack enable
-
-      - name: Install Yarn v3
-        uses: borales/actions-yarn@v3
-        with:
-          cmd: set version stable
-
+  
       - name: Install Dependencies
-        uses: borales/actions-yarn@v3
+        run: yarn install
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
-        with:
-          cmd: install
-
+  
       - name: Gatsby Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3.3.2
         with:
           path: |
             public
@@ -89,9 +84,7 @@ jobs:
             ${{ needs.set-state.outputs.branch_short_ref }}-gatsby-cache-
 
       - name: Build site
-        uses: borales/actions-yarn@v3
-        with:
-          cmd: build
+        run: yarn build
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
           PREFIX_PATHS: true # equivalent to --prefix-paths flag for 'gatsby build'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,6 @@
 ---
 name: Production deployment
 on:
-  workflow_dispatch:
-
   push:
     branches:
       - main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 ---
 name: Production deployment
 on:
+  workflow_dispatch:
+
   push:
     branches:
       - main

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -1,149 +1,148 @@
 ---
-name: Staging deployment
-on:
-  workflow_dispatch:
-    inputs:
-      clean:
-        description: 'Clean cache (yes|no)'
-        required: true
-        default: 'no'
-      excludeSubfolder:
-        description: 'Exclude a subfolder from deletion'
-        required: false
-        default: ''
-jobs:
-  set-state:
-    runs-on: ubuntu-latest
-    outputs:
-      clean_cache: ${{ contains(github.event.inputs.clean, 'yes') }}
-      path_prefix: ${{ steps.get_path_prefix.outputs.path_prefix }}
-      branch_short_ref: ${{ steps.get_branch.outputs.branch }}
-      exclude_subfolder: ${{ github.event.inputs.excludeSubfolder }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Get pathPrefix
-        uses: actions/github-script@v6
-        id: get_path_prefix
-        with:
-          script: |
-            const script = require('./.github/scripts/get-path-prefix.js');
-            script({ core });
-          result-encoding: string
-      - name: Get branch name
-        shell: bash
-        run: echo "branch=${GITHUB_REF#refs/heads/}" >> "$GITHUB_OUTPUT"
-        id: get_branch
-
-  echo-state:
-    needs: [set-state]
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Clean cache - ${{ needs.set-state.outputs.clean_cache }}"
-      - run: echo "Repository org - ${{ github.event.repository.owner.login }}"
-      - run: echo "Repository name - ${{ github.event.repository.name }}"
-      - run: echo "Repository branch - ${{ needs.set-state.outputs.branch_short_ref }}"
-      - run: echo "Path prefix - ${{ needs.set-state.outputs.path_prefix }}"
-      - run: echo "Exclude subfolder - ${{ needs.set-state.outputs.exclude_subfolder }}"
-
-  pre-build:
-    needs: [set-state]
-    runs-on: ubuntu-latest
-    steps:
-      - name: check dev azure connection string
-        if: env.AIO_AZURE_DEV_CONNECTION_STRING == null
-        run: |
-          echo "::error::Please set the Azure Blob Storage connection string as AIO_AZURE_DEV_CONNECTION_STRING in Github Secrets"
-          exit 1
-        env:
-          AIO_AZURE_DEV_CONNECTION_STRING: ${{ secrets.AIO_AZURE_DEV_CONNECTION_STRING }}
-
-  build:
-    defaults:
-      run:
-        shell: bash
-    needs: [set-state, pre-build]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup Node v16 for Yarn v3
-        uses: actions/setup-node@v3
-        with:
-          node-version: '16.15.0' # Current LTS version
-
-      - name: Enable Corepack for Yarn v3
-        run: corepack enable
-
-      - name: Install Yarn v3
-        uses: borales/actions-yarn@v3
-        with:
-          cmd: set version stable
-
-      - name: Install Dependencies
-        uses: borales/actions-yarn@v3
-        env:
-          YARN_ENABLE_IMMUTABLE_INSTALLS: false
-        with:
-          cmd: install
-
-      - name: Gatsby Cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            public
-            .cache
-          key: ${{ needs.set-state.outputs.branch_short_ref }}-gatsby-cache-${{ github.run_id }}
-          restore-keys: |
-            ${{ needs.set-state.outputs.branch_short_ref }}-gatsby-cache-
-
-      - name: Clean Cache
-        if: needs.set-state.outputs.clean_cache == 'true'
-        uses: borales/actions-yarn@v3
-        with:
-          cmd: clean
-
-      - name: Build site
-        uses: borales/actions-yarn@v3
-        with:
-          cmd: build
-        env:
-          NODE_OPTIONS: "--max_old_space_size=8192"
-          PREFIX_PATHS: true # equivalent to --prefix-paths flag for 'gatsby build'
-          PATH_PREFIX: ${{ needs.set-state.outputs.path_prefix }}
-          GATSBY_ADOBE_LAUNCH_SRC: ${{ secrets.AIO_ADOBE_LAUNCH_DEV_SRC }}
-          GATSBY_ADDITIONAL_ADOBE_ANALYTICS_ACCOUNTS: ${{ secrets.AIO_REPORT_SUITE_DEV}}
-          GATSBY_ADOBE_ANALYTICS_ENV: 'dev'
-          REPO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO_OWNER: ${{ github.event.repository.owner.login }}
-          REPO_NAME: ${{ github.event.repository.name }}
-          REPO_BRANCH: ${{ needs.set-state.outputs.branch_short_ref }}
-          GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
-          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
-          GOOGLE_DOCS_TOKEN: ${{ secrets.GOOGLE_DOCS_TOKEN }}
-          GOOGLE_DOCS_FOLDER_ID: ${{ secrets.GOOGLE_DOCS_FOLDER_ID }}
-          GATSBY_IMS_SRC: ${{ secrets.AIO_IMS_DEV_SRC }}
-          GATSBY_IMS_CONFIG: ${{ secrets.AIO_IMS_DEV_CONFIG }}
-          GATSBY_ALGOLIA_APPLICATION_ID: ${{ secrets.AIO_ALGOLIA_APPLICATION_ID }}
-          GATSBY_ALGOLIA_SEARCH_API_KEY: ${{ secrets.AIO_ALGOLIA_SEARCH_API_KEY }}
-          ALGOLIA_INDEXATION_MODE: skip
-          GATSBY_ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME || github.event.repository.name }}
-          GATSBY_FEDS_PRIVACY_ID: ${{ secrets.AIO_FEDS_PRIVACY_ID }}
-          GATSBY_SITE_DOMAIN_URL: https://developer-stage.adobe.com
-
-      - name: Deploy
-        uses: AdobeDocs/static-website-deploy@master
-        with:
-          enabled-static-website: 'true'
-          source: 'public'
-          target: ${{ needs.set-state.outputs.path_prefix }}
-          connection-string: ${{ secrets.AIO_AZURE_DEV_CONNECTION_STRING }}
-          remove-existing-files: 'true'
-          exclude-subfolder: ${{ needs.set-state.outputs.exclude_subfolder }}
-      - name: Purge Fastly Cache
-        uses: AdobeDocs/gatsby-fastly-purge-action@master
-        with:
-          fastly-token: ${{ secrets.AIO_FASTLY_TOKEN }}
-          fastly-url: '${{ secrets.AIO_FASTLY_DEV_URL}}${{ needs.set-state.outputs.path_prefix }}'
+  name: Staging deployment
+  on:
+    workflow_dispatch:
+      inputs:
+        clean:
+          description: 'Clean cache (yes|no)'
+          required: true
+          default: 'yes'
+        excludeSubfolder:
+          description: 'Exclude a subfolder from deletion'
+          required: false
+          default: ''
+  jobs:
+    set-state:
+      runs-on: ubuntu-latest
+      outputs:
+        clean_cache: ${{ contains(github.event.inputs.clean, 'yes') }}
+        path_prefix: ${{ steps.get_path_prefix.outputs.path_prefix }}
+        branch_short_ref: ${{ steps.get_branch.outputs.branch }}
+        exclude_subfolder: ${{ github.event.inputs.excludeSubfolder }}
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+  
+        - name: Get pathPrefix
+          uses: actions/github-script@v6
+          id: get_path_prefix
+          with:
+            script: |
+              const script = require('./.github/scripts/get-path-prefix.js');
+              script({ core });
+            result-encoding: string
+        - name: Get branch name
+          shell: bash
+          run: echo "branch=${GITHUB_REF#refs/heads/}" >> "$GITHUB_OUTPUT"
+          id: get_branch
+  
+    echo-state:
+      needs: [set-state]
+      runs-on: ubuntu-latest
+      steps:
+        - run: echo "Clean cache - ${{ needs.set-state.outputs.clean_cache }}"
+        - run: echo "Repository org - ${{ github.event.repository.owner.login }}"
+        - run: echo "Repository name - ${{ github.event.repository.name }}"
+        - run: echo "Repository branch - ${{ needs.set-state.outputs.branch_short_ref }}"
+        - run: echo "Path prefix - ${{ needs.set-state.outputs.path_prefix }}"
+        - run: echo "Exclude subfolder - ${{ needs.set-state.outputs.exclude_subfolder }}"
+  
+    pre-build:
+      needs: [set-state]
+      runs-on: ubuntu-latest
+      steps:
+        - name: check dev azure connection string
+          if: env.AIO_AZURE_DEV_CONNECTION_STRING == null
+          run: |
+            echo "::error::Please set the Azure Blob Storage connection string as AIO_AZURE_DEV_CONNECTION_STRING in Github Secrets"
+            exit 1
+          env:
+            AIO_AZURE_DEV_CONNECTION_STRING: ${{ secrets.AIO_AZURE_DEV_CONNECTION_STRING }}
+  
+    build:
+      defaults:
+        run:
+          shell: bash
+      needs: [set-state, pre-build]
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        
+        - name: free disk space
+          run: |
+            sudo swapoff -a
+            sudo rm -f /swapfile
+            sudo apt clean
+            docker rmi "$(docker image ls -aq)"
+            df -h
+  
+        - name: Setup Node v16
+          uses: actions/setup-node@v3
+          with:
+            node-version-file: '.nvmrc'
+            cache: 'yarn'
+            cache-dependency-path: 'yarn.lock'
+  
+        - name: Enable Corepack for Yarn
+          run: corepack enable
+  
+        - name: Install Dependencies
+          run: yarn install
+          env:
+            YARN_ENABLE_IMMUTABLE_INSTALLS: false
+  
+        - name: Gatsby Cache
+          uses: actions/cache@v3.3.2
+          with:
+            path: |
+              public
+              .cache
+            key: ${{ needs.set-state.outputs.branch_short_ref }}-gatsby-cache-${{ github.run_id }}
+            restore-keys: |
+              ${{ needs.set-state.outputs.branch_short_ref }}-gatsby-cache-
+  
+        - name: Clean Cache
+          if: needs.set-state.outputs.clean_cache == 'true'
+          run: yarn clean
+  
+        - name: Build site
+          run: yarn build
+          env:
+            PREFIX_PATHS: true # equivalent to --prefix-paths flag for 'gatsby build'
+            PATH_PREFIX: ${{ needs.set-state.outputs.path_prefix }}
+            GATSBY_ADOBE_LAUNCH_SRC: ${{ secrets.AIO_ADOBE_LAUNCH_DEV_SRC }}
+            GATSBY_ADDITIONAL_ADOBE_ANALYTICS_ACCOUNTS: ${{ secrets.AIO_REPORT_SUITE_DEV}}
+            GATSBY_ADOBE_ANALYTICS_ENV: 'dev'
+            REPO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            REPO_OWNER: ${{ github.event.repository.owner.login }}
+            REPO_NAME: ${{ github.event.repository.name }}
+            REPO_BRANCH: ${{ needs.set-state.outputs.branch_short_ref }}
+            GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
+            GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+            GOOGLE_DOCS_TOKEN: ${{ secrets.GOOGLE_DOCS_TOKEN }}
+            GOOGLE_DOCS_FOLDER_ID: ${{ secrets.GOOGLE_DOCS_FOLDER_ID }}
+            GATSBY_IMS_SRC: ${{ secrets.AIO_IMS_DEV_SRC }}
+            GATSBY_IMS_CONFIG: ${{ secrets.AIO_IMS_DEV_CONFIG }}
+            GATSBY_ALGOLIA_APPLICATION_ID: ${{ secrets.AIO_ALGOLIA_APPLICATION_ID }}
+            GATSBY_ALGOLIA_SEARCH_API_KEY: ${{ secrets.AIO_ALGOLIA_SEARCH_API_KEY }}
+            ALGOLIA_INDEXATION_MODE: skip
+            GATSBY_ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME || github.event.repository.name }}
+            GATSBY_FEDS_PRIVACY_ID: ${{ secrets.AIO_FEDS_PRIVACY_ID }}
+            GATSBY_SITE_DOMAIN_URL: https://developer-stage.adobe.com
+  
+        - name: Deploy
+          uses: AdobeDocs/static-website-deploy@master
+          with:
+            enabled-static-website: 'true'
+            source: 'public'
+            target: ${{ needs.set-state.outputs.path_prefix }}
+            connection-string: ${{ secrets.AIO_AZURE_DEV_CONNECTION_STRING }}
+            remove-existing-files: 'true'
+            exclude-subfolder: ${{ needs.set-state.outputs.exclude_subfolder }}
+        - name: Purge Fastly Cache
+          uses: AdobeDocs/gatsby-fastly-purge-action@master
+          with:
+            fastly-token: ${{ secrets.AIO_FASTLY_TOKEN }}
+            fastly-url: '${{ secrets.AIO_FASTLY_DEV_URL}}${{ needs.set-state.outputs.path_prefix }}'
+  

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -137,4 +137,3 @@
           with:
             fastly-token: ${{ secrets.AIO_FASTLY_TOKEN }}
             fastly-url: '${{ secrets.AIO_FASTLY_DEV_URL}}${{ needs.set-state.outputs.path_prefix }}'
-  

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -69,13 +69,13 @@
         - name: Checkout
           uses: actions/checkout@v4
         
-        - name: free disk space
-          run: |
-            sudo swapoff -a
-            sudo rm -f /swapfile
-            sudo apt clean
-            docker rmi "$(docker image ls -aq)"
-            df -h
+        # - name: free disk space
+        #   run: |
+        #     sudo swapoff -a
+        #     sudo rm -f /swapfile
+        #     sudo apt clean
+        #     docker rmi "$(docker image ls -aq)"
+        #     df -h
   
         - name: Setup Node v16
           uses: actions/setup-node@v3

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -68,14 +68,6 @@
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        
-        # - name: free disk space
-        #   run: |
-        #     sudo swapoff -a
-        #     sudo rm -f /swapfile
-        #     sudo apt clean
-        #     docker rmi "$(docker image ls -aq)"
-        #     df -h
   
         - name: Setup Node v16
           uses: actions/setup-node@v3


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes and updates the `stage`, `publish`, `github-pages`, and `index` workflows.

- Use actions/setup-node instead of borales/actions-yarn
- Upgrade actions/cache to 3.3.2
- Move the node version to `.nvrmc` to be able to use it locally too.
- Upgrade node to the latest minor version of v16 (16.20)
- Move NODE_OPTIONS to the scripts to be able to use it locally too

Internal ref: COMDOX-866

## Testing

Staging: https://github.com/AdobeDocs/commerce-php/actions/runs/7187915265
Pages: https://github.com/AdobeDocs/commerce-php/actions/runs/7188297699/job/19577690236
Indexing: https://github.com/AdobeDocs/commerce-php/actions/runs/7188538958