### PR TITLE
COMDOX-849: BIC highlights for 2.4.7 GA

### DIFF
--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -27,7 +27,8 @@ const remarkConfig = {
 				skipUrlPatterns: [
 					"https://www.php.net",
 					"https://cardinalcommerce.com/",
-					"https://www.cyberciti.biz"
+					"https://www.cyberciti.biz",
+					"https://eat.magento.com/ui/phpFqn?searchKey=TWFnZW50b1xGcmFtZXdvcmtcQ29uc29sZVxDbGk6OmdldERlZmF1bHRDb21tYW5kcw=="
 
 				],
 				skipOffline: "true"

--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -28,7 +28,7 @@ const remarkConfig = {
 					"https://www.php.net",
 					"https://cardinalcommerce.com/",
 					"https://www.cyberciti.biz",
-					"https://eat.magento.com/ui/phpFqn?searchKey=TWFnZW50b1xGcmFtZXdvcmtcQ29uc29sZVxDbGk6OmdldERlZmF1bHRDb21tYW5kcw=="
+					"https://eat.magento.com/ui/phpFqn"
 
 				],
 				skipOffline: "true"

--- a/src/pages/development/backward-incompatible-changes/highlights.md
+++ b/src/pages/development/backward-incompatible-changes/highlights.md
@@ -30,7 +30,7 @@ The following major backward-incompatible changes were introduced in the 2.4.7 A
 
 ### New block class for subresource integrity verification
 
-A new block class was added (`Magento\Csp\Block\Sri\Hashes`) marked with the `@api` annotation to support [subresource integrity](../security/subresource-integrity.md) verification. This ensures that all scripts executed on the payment pages have an integrity attribute so that no unauthorized scripts can run. You must add integrity attributes to all custom and remote JavaScript resources.
+A new block class was added (`Magento\Csp\Block\Sri\Hashes`) marked with the `@api` annotation to support [subresource integrity](../security/subresource-integrity.md) verification. This ensures that all scripts executed on payment pages and the Admin have an integrity attribute so that no unauthorized scripts can run. You must add integrity attributes to all custom and remote JavaScript resources.
 
 The following module is affected by this change:
 

--- a/src/pages/development/backward-incompatible-changes/highlights.md
+++ b/src/pages/development/backward-incompatible-changes/highlights.md
@@ -7,15 +7,25 @@ keywords:
 
 # Backward-incompatible changes highlights
 
-This page highlights backward-incompatible changes between Adobe Commerce and Magento Open Source releases that have a major impact and require detailed explanation and special instructions to ensure third-party modules continue working. High-level reference information for all backward-incompatible changes in each release are documented in [Backward incompatible changes reference](reference.md).
+This page highlights backward-incompatible changes between Adobe Commerce and Magento Open Source releases that have a major impact and require detailed explanation and special instructions to ensure third-party modules continue working. High-level reference information for all backward-incompatible changes in each release are documented in [Backward-incompatible changes reference](reference.md).
 
-## 2.4.7-beta3
+## 2.4.7
 
-The following major backward-incompatible changes were introduced in the 2.4.7-beta3 Adobe Commerce and Magento Open Source releases:
+The following major backward-incompatible changes were introduced in the 2.4.7 Adobe Commerce and Magento Open Source releases:
 
 * Fixes to resolve compatibility issues with Symfony
 * New system configuration for limiting coupon generation
 * New method and an optional parameter for multicoupons
+* Commerce FedEx SOAP API integration
+* Commerce UPS SOAP API integration
+* Elasticsearch 7 deprecation
+* New method for encryption key generation
+* New SKU validation in inventory source items API
+* New full-page caching system configuration
+* New interface and method for ApplicationServer module
+* New public method in `Config/Type/System`
+* New configuration for payment information rate limiting
+* Default behavior for isEmailAvailable API
 
 ### Fixes to resolve compatibility issues with Symfony
 
@@ -46,17 +56,6 @@ All changes have been done in a way to minimize any impact to extensions and cus
 The following module is affected by this change:
 
 * [Magento_SalesRule](https://developer.adobe.com/commerce/php/module-reference/module-sales-rule/)
-
-## 2.4.7-beta2
-
-The following major backward-incompatible changes were introduced in the 2.4.7-beta2 Adobe Commerce and Magento Open Source releases:
-
-* Commerce FedEx SOAP API integration
-* Commerce UPS SOAP API integration
-* Elasticsearch 7 deprecation
-* New method for encryption key generation
-* New SKU validation in inventory source items API
-* New full-page caching system configuration
 
 ### Commerce FedEx SOAP API integration
 
@@ -122,18 +121,9 @@ The following module is affected by this change:
 
 * [Magento_PageCache](https://developer.adobe.com/commerce/php/module-reference/module-page-cache/)
 
-## 2.4.7-beta1
-
-The following major backward-incompatible changes were introduced in the 2.4.7-beta1 Adobe Commerce and Magento Open Source releases:
-
-* New interface and method for ApplicationServer module
-* New public method in `Config/Type/System`
-* New configuration for payment information rate limiting
-* Default behavior for isEmailAvailable API
-
 ### New interface and method for ApplicationServer module
 
-State management has been enabled for all GraphQL APIs (excluding B2B and service-related processes). The 2.4.7-beta1 release introduces a new PHP application server that is implemented on a Swoole PHP extension. The [ApplicationServer](https://experienceleague.adobe.com/docs/commerce-operations/performance-best-practices/performance-best-practices/application-server.html) module enables Adobe Commerce to maintain state between Commerce GraphQL API requests and eliminates the need for request bootstrapping. By sharing application state among processes, API requests become significantly more efficient, and API response times potentially decrease by 50 to 60 milliseconds.
+State management has been enabled for all GraphQL APIs (excluding B2B and service-related processes). The 2.4.7 release introduces a new PHP application server that is implemented on a Swoole PHP extension. The [ApplicationServer](https://experienceleague.adobe.com/en/docs/commerce-operations/performance-best-practices/concepts/application-server) module enables Adobe Commerce to maintain state between Commerce GraphQL API requests and eliminates the need for request bootstrapping. By sharing application state among processes, API requests become significantly more efficient, and API response times potentially decrease by 50 to 60 milliseconds.
 
 The `ResetAfterRequestInterface` interface and `_resetState()` method were added to enable the PHP application server. The `__debugInfo()` method was also added to fix issues with `var_dump` calls.
 

--- a/src/pages/development/backward-incompatible-changes/highlights.md
+++ b/src/pages/development/backward-incompatible-changes/highlights.md
@@ -13,20 +13,70 @@ This page highlights backward-incompatible changes between Adobe Commerce and Ma
 
 The following major backward-incompatible changes were introduced in the 2.4.7 Adobe Commerce and Magento Open Source releases:
 
-* New block class for subresource integrity verification
-* Fixes to resolve compatibility issues with Symfony
-* New system configuration for limiting coupon generation
-* New method and an optional parameter for multicoupons
-* Commerce FedEx SOAP API integration
-* Commerce UPS SOAP API integration
+* API integration: FedEx SOAP
+* API integration: UPS SOAP
+* Default behavior for `isEmailAvailable` API
 * Elasticsearch 7 deprecation
+* Fixes to resolve compatibility issues with Symfony
+* New block class for subresource integrity verification
+* New interface and method for ApplicationServer module
+* New method and an optional parameter for multicoupons
+* New method in `Config/Type/System`
 * New method for encryption key generation
 * New SKU validation in inventory source items API
-* New full-page caching system configuration
-* New interface and method for ApplicationServer module
-* New public method in `Config/Type/System`
-* New configuration for payment information rate limiting
-* Default behavior for isEmailAvailable API
+* New system configuration for full-page caching
+* New system configuration for limiting coupon generation
+* New system configuration for payment information rate limiting
+
+### API integration: FedEx SOAP
+
+The Commerce FedEx SOAP API integration has been migrated to the new FedEx REST API. The FedEx Web Services for Tracking API was retired on May 15, 2024. All previous FedEx SOAP APIs have been removed from the Adobe Commerce and Magento Open Source 2.4.7 code base.
+
+This change affects custom code and extensions that use the SOAP APIs. You must update your code to use the REST APIs.
+
+You must generate REST credentials (Account Number, API Key, and Secret Key) from the FedEx developer portal and add those credentials to the Admin by going to **Stores** > **Configuration** > **Sales** > **Shipping/Delivery Methods** > **FedEx**.
+
+The following module is affected by this change:
+
+* [Magento_Fedex](https://developer.adobe.com/commerce/php/module-reference/module-fedex/)
+
+### API integration: UPS SOAP
+
+The Commerce UPS SOAP API integration has been migrated to the new UPS REST API to support updates that UPS is making to their [API security model](https://developer.ups.com/oauth-developer-guide). UPS is implementing an OAuth 2.0 security model (bearer tokens) for all APIs. All previous Commerce UPS SOAP APIs have been removed from the Adobe Commerce and Magento Open Source 2.4.7 code base.
+
+You must generate REST credentials (Account Number, API Key, and Secret Key) from the UPS developer portal and update those credentials to the Admin by going to **Stores** > **Configuration** > **Sales** > **Shipping/Delivery Methods** > **UPS**.
+
+The following module is affected by this change:
+
+* [Magento_Ups](https://developer.adobe.com/commerce/php/module-reference/module-ups/)
+
+### Default behavior for `isEmailAvailable` API
+
+The default behavior of the [`isEmailAvailable`](https://developer.adobe.com/commerce/webapi/graphql/schema/customer/queries/is-email-available/) GraphQL query and ([`V1/customers/isEmailAvailable`](https://adobe-commerce.redoc.ly/2.4.6-admin/tag/customersisEmailAvailable/#operation/PostV1CustomersIsEmailAvailable)) REST endpoint has changed. By default, the API now always returns `true`.
+The new default behaviour also affects the checkout workflow for guests that do not realize they already have an account. Previously, by default, when a guest supplied an email address that matched an existing customer account, they were prompted to sign in. Now, they are no longer prompted to sign in.
+
+Merchants can restore the original default behavior of the `isEmailAvailable` API and checkout flow by setting the **Stores > Configuration > Sales > Checkout > Enable Guest Checkout Login field** to **Yes**. However, doing this can expose customer information to unauthenticated users.
+
+### Elasticsearch 7 deprecation
+
+This change removes the `Magento_Elasticsearch` module (for Elasticsearch 5) and adds support for Elasticsearch 8. The `Magento_Elasticsearch7` module is being deprecated because Elasticsearch 7 reached end-of-life in August 2023. However, it is still the default option for 2.4.7-beta2.
+
+The `Magento_Elasticsearch8` module is not currently supported because of backward-incompatible changes in ES7 and ES8. It is available as a Composer metapackage only in 2.4.7-beta2 until the `Magento_Elasticsearch7` module is removed from the codebase.
+
+You can use the `Magento_Elasticsearch7` module or install the Magento_Elasticsearch8 module in 2.4.7-beta2.
+
+The following modules are affected by this change:
+
+* [Magento_Elasticsearch](https://developer.adobe.com/commerce/php/module-reference/module-elasticsearch/)
+* [Magento_ElasticsearchCatalogPermissions](https://developer.adobe.com/commerce/php/module-reference/module-elasticsearch-catalog-permissions/)
+* [Magento_Elasticsearch7](https://developer.adobe.com/commerce/php/module-reference/module-elasticsearch-7/)
+* [Magento_OpenSearch](https://developer.adobe.com/commerce/php/module-reference/module-open-search/)
+
+### Fixes to resolve compatibility issues with Symfony
+
+The return type was changed for the [`Magento\Framework\Console\Cli::getDefaultCommands`](https://eat.magento.com/ui/phpFqn?searchKey=TWFnZW50b1xGcmFtZXdvcmtcQ29uc29sZVxDbGk6OmdldERlZmF1bHRDb21tYW5kcw==) interface to provide compatibility with the latest Symfony 6.4 LTS version.
+
+Extension developers must define strict typing for return values in classes that use the changed interface: `Magento\Framework\Console\Cli::getDefaultCommands`.
 
 ### New block class for subresource integrity verification
 
@@ -36,19 +86,20 @@ The following module is affected by this change:
 
 * [Magento_Csp](https://developer.adobe.com/commerce/php/module-reference/module-csp/)
 
-### Fixes to resolve compatibility issues with Symfony
+### New interface and method for ApplicationServer module
 
-The return type was changed for the [`Magento\Framework\Console\Cli::getDefaultCommands`](https://eat.magento.com/ui/phpFqn?searchKey=TWFnZW50b1xGcmFtZXdvcmtcQ29uc29sZVxDbGk6OmdldERlZmF1bHRDb21tYW5kcw==) interface to provide compatibility with the latest Symfony 6.4 LTS version.
+State management has been enabled for all GraphQL APIs (excluding B2B and service-related processes). The 2.4.7 release introduces a new PHP application server that is implemented on a Swoole PHP extension. The [ApplicationServer](https://experienceleague.adobe.com/en/docs/commerce-operations/performance-best-practices/concepts/application-server) module enables Adobe Commerce to maintain state between Commerce GraphQL API requests and eliminates the need for request bootstrapping. By sharing application state among processes, API requests become significantly more efficient, and API response times potentially decrease by 50 to 60 milliseconds.
 
-Extension developers must define strict typing for return values in classes that use the changed interface: `Magento\Framework\Console\Cli::getDefaultCommands`.
+The `ResetAfterRequestInterface` interface and `_resetState()` method were added to enable the PHP application server. The `__debugInfo()` method was also added to fix issues with `var_dump` calls.
 
-### New system configuration for limiting coupon generation
+No action for merchants or extension developers is necessary.
 
-Added a new setting for the number of coupons to generate. This property has a default value of `250,000`, which is also the maximum value. Merchants can disable this feature by it setting it to `0`  in the Admin by going to  **Stores** > **Settings** > **Configuration** > **Customers** > **Promotions** > **Code Quantity Limit**.
+The following modules are affected by this change:
 
-The following module is affected by this change:
-
-* [Magento_SalesRule](https://developer.adobe.com/commerce/php/module-reference/module-sales-rule/)
+* [Magento_Authorization](https://developer.adobe.com/commerce/php/module-reference/module-authorization/)
+* [Magento_Config](https://developer.adobe.com/commerce/php/module-reference/module-config/)
+* [Magento_Customer](https://developer.adobe.com/commerce/php/module-reference/module-customer/)
+* [Magento_ResourceConnections](https://developer.adobe.com/commerce/php/module-reference/module-resource-connections/)
 
 ### New method and an optional parameter for multicoupons
 
@@ -66,43 +117,6 @@ The following module is affected by this change:
 
 * [Magento_SalesRule](https://developer.adobe.com/commerce/php/module-reference/module-sales-rule/)
 
-### Commerce FedEx SOAP API integration
-
-The Commerce FedEx SOAP API integration has been migrated to the new FedEx REST API. The FedEx Web Services for Tracking API was retired on May 15, 2024. All previous FedEx SOAP APIs have been removed from the Adobe Commerce and Magento Open Source 2.4.7 code base.
-
-This change affects custom code and extensions that use the SOAP APIs. You must update your code to use the REST APIs.
-
-You must generate REST credentials (Account Number, API Key, and Secret Key) from the FedEx developer portal and add those credentials to the Admin by going to **Stores** > **Configuration** > **Sales** > **Shipping/Delivery Methods** > **FedEx**.
-
-The following module is affected by this change:
-
-* [Magento_Fedex](https://developer.adobe.com/commerce/php/module-reference/module-fedex/)
-
-### Commerce UPS SOAP API integration
-
-The Commerce UPS SOAP API integration has been migrated to the new UPS REST API to support updates that UPS is making to their [API security model](https://developer.ups.com/oauth-developer-guide). UPS is implementing an OAuth 2.0 security model (bearer tokens) for all APIs. All previous Commerce UPS SOAP APIs have been removed from the Adobe Commerce and Magento Open Source 2.4.7 code base.
-
-You must generate REST credentials (Account Number, API Key, and Secret Key) from the UPS developer portal and update those credentials to the Admin by going to **Stores** > **Configuration** > **Sales** > **Shipping/Delivery Methods** > **UPS**.
-
-The following module is affected by this change:
-
-* [Magento_Ups](https://developer.adobe.com/commerce/php/module-reference/module-ups/)
-
-### Elasticsearch 7 deprecation
-
-This change removes the `Magento_Elasticsearch` module (for Elasticsearch 5) and adds support for Elasticsearch 8. The `Magento_Elasticsearch7` module is being deprecated because Elasticsearch 7 reached end-of-life in August 2023. However, it is still the default option for 2.4.7-beta2.
-
-The `Magento_Elasticsearch8` module is not currently supported because of backward-incompatible changes in ES7 and ES8. It is available as a Composer metapackage only in 2.4.7-beta2 until the `Magento_Elasticsearch7` module is removed from the codebase.
-
-You can use the `Magento_Elasticsearch7` module or install the Magento_Elasticsearch8 module in 2.4.7-beta2.
-
-The following modules are affected by this change:
-
-* [Magento_Elasticsearch](https://developer.adobe.com/commerce/php/module-reference/module-elasticsearch/)
-* [Magento_ElasticsearchCatalogPermissions](https://developer.adobe.com/commerce/php/module-reference/module-elasticsearch-catalog-permissions/)
-* [Magento_Elasticsearch7](https://developer.adobe.com/commerce/php/module-reference/module-elasticsearch-7/)
-* [Magento_OpenSearch](https://developer.adobe.com/commerce/php/module-reference/module-open-search/)
-
 ### New method for encyption key generation
 
 This change improves the security of encrypted user data. You must [reset the encryption key](https://experienceleague.adobe.com/docs/commerce-admin/systems/security/encryption-key.html) and set the **Auto-generate** option to `Yes`. After resetting the encryption key, all credit card data and cache files are re-encrypted with the new key.
@@ -112,11 +126,23 @@ The following files are affected by this change:
 * [`lib/internal/Magento/Framework/Config/ConfigOptionsListConstants.php`](https://github.com/magento/magento2/blob/2.4-develop/lib/internal/Magento/Framework/Config/ConfigOptionsListConstants.php)—A new method was added to increase the entropy of encryption keys generated by the framework for stored credit card and cache data.
 * [`lib/internal/Magento/Framework/Math/Random.php`](https://github.com/magento/magento2/blob/2.4-develop/lib/internal/Magento/Framework/Math/Random.php)—A new constant was added to prefix base64-encoded encryption keys for use in `env.php` files.
 
+### New method in `Config/Type/System`
+
+The `bin/magento cache:clean config` CLI command, and its Admin UI equivalent, now pre-warm the config cache (when config cache is enabled) in order to reduce the lock time after cleaning the config cache. This reduces the downtime for large configurations that take significant time to generate the config cache.
+
+We've also changed the configuration save so that it no longer cleans the `config_scopes` cache (when config cache is enabled). Config saving also pre-warms the config cache now, which also reduces the lock time for large configurations. Cleaning the config cache after saving configuration changes is still recommended.
+
+No action for merchants or extension developers is necessary because the general functionality is the same. Only the order of generating the config cache, serializing, and encrypting (before lock instead of after) was changed.
+
+The following module is affected by this change:
+
+* [Magento_Config](https://developer.adobe.com/commerce/php/module-reference/module-config/)
+
 ### New SKU validation in inventory source items API
 
 Payload containing SKU will now be validated for leading and trailing spaces in the `rest/V1/inventory/source-items` API.
 
-### New full-page caching system configuration
+### New system configuration full-page caching
 
 This change improves the security and performance of how the framework resolves [Varnish Edge Side Includes (ESI)](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cache/use-varnish-esi.html) for [full-page caching](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cache/configure-varnish-commerce.html).
 
@@ -130,34 +156,15 @@ The following module is affected by this change:
 
 * [Magento_PageCache](https://developer.adobe.com/commerce/php/module-reference/module-page-cache/)
 
-### New interface and method for ApplicationServer module
+### New system configuration for limiting coupon generation
 
-State management has been enabled for all GraphQL APIs (excluding B2B and service-related processes). The 2.4.7 release introduces a new PHP application server that is implemented on a Swoole PHP extension. The [ApplicationServer](https://experienceleague.adobe.com/en/docs/commerce-operations/performance-best-practices/concepts/application-server) module enables Adobe Commerce to maintain state between Commerce GraphQL API requests and eliminates the need for request bootstrapping. By sharing application state among processes, API requests become significantly more efficient, and API response times potentially decrease by 50 to 60 milliseconds.
-
-The `ResetAfterRequestInterface` interface and `_resetState()` method were added to enable the PHP application server. The `__debugInfo()` method was also added to fix issues with `var_dump` calls.
-
-No action for merchants or extension developers is necessary.
-
-The following modules are affected by this change:
-
-* [Magento_Authorization](https://developer.adobe.com/commerce/php/module-reference/module-authorization/)
-* [Magento_Config](https://developer.adobe.com/commerce/php/module-reference/module-config/)
-* [Magento_Customer](https://developer.adobe.com/commerce/php/module-reference/module-customer/)
-* [Magento_ResourceConnections](https://developer.adobe.com/commerce/php/module-reference/module-resource-connections/)
-
-### New public method in `Config/Type/System`
-
-The `bin/magento cache:clean config` CLI command, and its Admin UI equivalent, now pre-warm the config cache (when config cache is enabled) in order to reduce the lock time after cleaning the config cache. This reduces the downtime for large configurations that take significant time to generate the config cache.
-
-We've also changed the configuration save so that it no longer cleans the `config_scopes` cache (when config cache is enabled). Config saving also pre-warms the config cache now, which also reduces the lock time for large configurations. Cleaning the config cache after saving configuration changes is still recommended.
-
-No action for merchants or extension developers is necessary because the general functionality is the same. Only the order of generating the config cache, serializing, and encrypting (before lock instead of after) was changed.
+Added a new setting for the number of coupons to generate. This property has a default value of `250,000`, which is also the maximum value. Merchants can disable this feature by it setting it to `0`  in the Admin by going to  **Stores** > **Settings** > **Configuration** > **Customers** > **Promotions** > **Code Quantity Limit**.
 
 The following module is affected by this change:
 
-* [Magento_Config](https://developer.adobe.com/commerce/php/module-reference/module-config/)
+* [Magento_SalesRule](https://developer.adobe.com/commerce/php/module-reference/module-sales-rule/)
 
-### New configuration for payment information rate limiting
+### New system configuration for payment information rate limiting
 
 New native application rate-limiting features have been added with initial out-of-the-box support for rate limiting of payment API's. Disabled by default.
 
@@ -166,13 +173,6 @@ No action for merchants or extension developers is necessary.
 The following module is affected by this change:
 
 * [Magento_Quote](https://developer.adobe.com/commerce/php/module-reference/module-quote/)
-
-### `isEmailAvailable` API
-
-The default behavior of the [`isEmailAvailable`](https://developer.adobe.com/commerce/webapi/graphql/schema/customer/queries/is-email-available/) GraphQL query and ([`V1/customers/isEmailAvailable`](https://adobe-commerce.redoc.ly/2.4.6-admin/tag/customersisEmailAvailable/#operation/PostV1CustomersIsEmailAvailable)) REST endpoint has changed. By default, the API now always returns `true`.
-The new default behaviour also affects the checkout workflow for guests that do not realize they already have an account. Previously, by default, when a guest supplied an email address that matched an existing customer account, they were prompted to sign in. Now, they are no longer prompted to sign in.
-
-Merchants can restore the original default behavior of the `isEmailAvailable` API and checkout flow by setting the **Stores > Configuration > Sales > Checkout > Enable Guest Checkout Login field** to **Yes**. However, doing this can expose customer information to unauthenticated users.
 
 ## 2.4.6
 

--- a/src/pages/development/backward-incompatible-changes/highlights.md
+++ b/src/pages/development/backward-incompatible-changes/highlights.md
@@ -13,6 +13,7 @@ This page highlights backward-incompatible changes between Adobe Commerce and Ma
 
 The following major backward-incompatible changes were introduced in the 2.4.7 Adobe Commerce and Magento Open Source releases:
 
+* New block class for subresource integrity verification
 * Fixes to resolve compatibility issues with Symfony
 * New system configuration for limiting coupon generation
 * New method and an optional parameter for multicoupons
@@ -26,6 +27,14 @@ The following major backward-incompatible changes were introduced in the 2.4.7 A
 * New public method in `Config/Type/System`
 * New configuration for payment information rate limiting
 * Default behavior for isEmailAvailable API
+
+### New block class for subresource integrity verification
+
+A new block class was added (`Magento\Csp\Block\Sri\Hashes`) marked with the `@api` annotation to support [subresource integrity](../security/subresource-integrity.md) verification. This ensures that all scripts executed on the payment pages have an integrity attribute so that no unauthorized scripts can run. You must add integrity attributes to all custom and remote JavaScript resources.
+
+The following module is affected by this change:
+
+* [Magento_Csp](https://developer.adobe.com/commerce/php/module-reference/module-csp/)
 
 ### Fixes to resolve compatibility issues with Symfony
 

--- a/src/pages/development/backward-incompatible-changes/highlights.md
+++ b/src/pages/development/backward-incompatible-changes/highlights.md
@@ -7,7 +7,7 @@ keywords:
 
 # Backward-incompatible changes highlights
 
-This page highlights backward-incompatible changes between Adobe Commerce and Magento Open Source releases that have a major impact and require detailed explanation and special instructions to ensure third-party modules continue working. High-level reference information for all backward-incompatible changes in each release are documented in [Backward-incompatible changes reference](reference.md).
+This page highlights backward-incompatible changes between Adobe Commerce and Magento Open Source releases that have a major impact and require detailed explanation and special instructions to ensure third-party modules continue working. High-level reference information for all backward-incompatible changes in each release is documented in [Backward-incompatible changes reference](reference.md).
 
 ## 2.4.7
 
@@ -53,7 +53,7 @@ The following module is affected by this change:
 ### Default behavior for `isEmailAvailable` API
 
 The default behavior of the [`isEmailAvailable`](https://developer.adobe.com/commerce/webapi/graphql/schema/customer/queries/is-email-available/) GraphQL query and ([`V1/customers/isEmailAvailable`](https://adobe-commerce.redoc.ly/2.4.6-admin/tag/customersisEmailAvailable/#operation/PostV1CustomersIsEmailAvailable)) REST endpoint has changed. By default, the API now always returns `true`.
-The new default behaviour also affects the checkout workflow for guests that do not realize they already have an account. Previously, by default, when a guest supplied an email address that matched an existing customer account, they were prompted to sign in. Now, they are no longer prompted to sign in.
+The new default behavior also affects the checkout workflow for guests that do not realize they already have an account. Previously, by default, when a guest supplied an email address that matched an existing customer account, they were prompted to sign in. Now, they are no longer prompted to sign in.
 
 Merchants can restore the original default behavior of the `isEmailAvailable` API and checkout flow by setting the **Stores > Configuration > Sales > Checkout > Enable Guest Checkout Login field** to **Yes**. However, doing this can expose customer information to unauthenticated users.
 
@@ -117,7 +117,7 @@ The following module is affected by this change:
 
 * [Magento_SalesRule](https://developer.adobe.com/commerce/php/module-reference/module-sales-rule/)
 
-### New method for encyption key generation
+### New method for encryption key generation
 
 This change improves the security of encrypted user data. You must [reset the encryption key](https://experienceleague.adobe.com/docs/commerce-admin/systems/security/encryption-key.html) and set the **Auto-generate** option to `Yes`. After resetting the encryption key, all credit card data and cache files are re-encrypted with the new key.
 
@@ -158,7 +158,7 @@ The following module is affected by this change:
 
 ### New system configuration for limiting coupon generation
 
-Added a new setting for the number of coupons to generate. This property has a default value of `250,000`, which is also the maximum value. Merchants can disable this feature by it setting it to `0`  in the Admin by going to  **Stores** > **Settings** > **Configuration** > **Customers** > **Promotions** > **Code Quantity Limit**.
+Added a new setting for the number of coupons to generate. This property has a default value of `250,000`, which is also the maximum value. Merchants can disable this feature by setting it to `0`  in the Admin by going to  **Stores** > **Settings** > **Configuration** > **Customers** > **Promotions** > **Code Quantity Limit**.
 
 The following module is affected by this change:
 
@@ -166,7 +166,7 @@ The following module is affected by this change:
 
 ### New system configuration for payment information rate limiting
 
-New native application rate-limiting features have been added with initial out-of-the-box support for rate limiting of payment API's. Disabled by default.
+New native application rate-limiting features have been added with initial out-of-the-box support for rate limiting of payment APIs. Disabled by default.
 
 No action for merchants or extension developers is necessary.
 

--- a/src/pages/development/backward-incompatible-changes/highlights.md
+++ b/src/pages/development/backward-incompatible-changes/highlights.md
@@ -59,11 +59,11 @@ Merchants can restore the original default behavior of the `isEmailAvailable` AP
 
 ### Elasticsearch 7 deprecation
 
-This change removes the `Magento_Elasticsearch` module (for Elasticsearch 5) and adds support for Elasticsearch 8. The `Magento_Elasticsearch7` module is being deprecated because Elasticsearch 7 reached end-of-life in August 2023. However, it is still the default option for 2.4.7-beta2.
+This change removes the `Magento_Elasticsearch` module (for Elasticsearch 5) and adds support for Elasticsearch 8. The `Magento_Elasticsearch7` module is being deprecated because Elasticsearch 7 reached end-of-life in August 2023. However, it is still the default option for 2.4.7.
 
-The `Magento_Elasticsearch8` module is not currently supported because of backward-incompatible changes in ES7 and ES8. It is available as a Composer metapackage only in 2.4.7-beta2 until the `Magento_Elasticsearch7` module is removed from the codebase.
+The `Magento_Elasticsearch8` module is not currently supported because of backward-incompatible changes in ES7 and ES8. It is available as a Composer metapackage only in 2.4.7 until the `Magento_Elasticsearch7` module is removed from the codebase.
 
-You can use the `Magento_Elasticsearch7` module or install the Magento_Elasticsearch8 module in 2.4.7-beta2.
+You can use the `Magento_Elasticsearch7` module or install the Magento_Elasticsearch8 module in 2.4.7.
 
 The following modules are affected by this change:
 

--- a/src/pages/development/components/app-server.md
+++ b/src/pages/development/components/app-server.md
@@ -8,13 +8,13 @@ edition: ee
 
 <InlineAlert variant="info" slots="text" />
 
-Available in [2.4.7](https://experienceleague.adobe.com/docs/commerce-operations/release/notes/adobe-commerce/2-4-7.html) only.
+Available in [2.4.7](https://experienceleague.adobe.com/en/docs/commerce-operations/release/notes/adobe-commerce/2-4-7) only.
 
 # Application Server for GraphQL APIs
 
-The [Application Server for GraphQL APIs](https://experienceleague.adobe.com/docs/commerce-operations/performance-best-practices/performance-best-practices/application-server.html) enables Adobe Commerce to maintain state among GraphQL API requests. The Application Server, which is built on the Open Swoole extension, operates as a process with worker threads that handle request processing. By preserving a bootstrapped application state among GraphQL API requests, the Application Server enhances request handling and overall product performance. As a result, GraphQL request response time can be reduced by up to 30%.
+The [Application Server for GraphQL APIs](https://experienceleague.adobe.com/en/docs/commerce-operations/performance-best-practices/concepts/application-server) enables Adobe Commerce to maintain state among GraphQL API requests. The Application Server, which is built on the Open Swoole extension, operates as a process with worker threads that handle request processing. By preserving a bootstrapped application state among GraphQL API requests, the Application Server enhances request handling and overall product performance. As a result, GraphQL request response time can be reduced by up to 30%.
 
-The Application Server is supported on [Cloud Starter](https://experienceleague.adobe.com/docs/commerce-cloud-service/user-guide/architecture/starter-architecture.html) deployments only. It is not available for Cloud Pro projects during Beta. It is not available for deployments of the Magento Open Source code base.
+The Application Server is supported on [Cloud Starter](https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/architecture/starter-architecture) deployments only. It is not available for Cloud Pro projects during Beta. It is not available for deployments of the Magento Open Source code base.
 
 ## Challenges to consider
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR):

- Adds a single BIC highlight for 2.4.7 GA (_New block class for subresource integrity verification_)
- Combines all previous 2.4.7-beta sections into a single section at the request of PM
- Alphabetizes the list of 2.4.7 BIC highlights

### TODO

- [x] Verify whether the `Magento_Elasticsearch7` module been removed for GA and update the related [highlight](https://developer.adobe.com/commerce/php/development/backward-incompatible-changes/highlights/#elasticsearch-7-deprecation) accordingly (e.g., remove references to 2.4.7-beta2)

## Review build

- https://adobedocs.github.io/commerce-php/development/backward-incompatible-changes/highlights/