### PR TITLE
Update BIC highlights with note about otp_window

### DIFF
--- a/src/pages/development/backward-incompatible-changes/highlights.md
+++ b/src/pages/development/backward-incompatible-changes/highlights.md
@@ -179,9 +179,9 @@ The following module is affected by this change:
 
 The `spomky-labs/otphp` library was updated which introduced a new validation requirement for supplying custom `otp_window` values. This configuration setting controls the grace period (in number of seconds) that is allowed for an expired one-time-password (OTP) to be used before it is denied. Previously, the library allowed any number of seconds to be specified. Now, the value cannot be higher than the lifetime of a single OTP (usually 30 seconds). This change means that the configuration value must be changed if it is set to 30 or higher.
 
-If your Commerce application is affected by this change, admin users might see the following message when they log in:  `There was an internal error trying to verify your code`. You can confirm the cause of the error by checking the `system.log` file in `var/log` for an entry `main.ERROR: The leeway must be lower than the TOTP period`.
+If your Commerce application is affected by this change, admin users might see the following message when they log in: `There was an internal error trying to verify your code`. You can confirm the cause of the error by checking the `system.log` file in `var/log` for an entry `main.ERROR: The leeway must be lower than the TOTP period`.
 
-To fix this issue, change the value of the configuration path `twofactorauth/google/otp_window` to be shorter than the TOTP period which is usually 30 seconds. For example, you can reset it to the default value of `1` with the command `bin/magento twofactorauth/google/otp_window 1`. You might need to flush the cache to apply the updated configuration. 
+To fix this issue, change the value of the configuration path `twofactorauth/google/otp_window` to be shorter than the TOTP period which is usually 30 seconds. For example, you can reset it to the default value of `1` with the command `bin/magento twofactorauth/google/otp_window 1`. You might need to flush the cache to apply the updated configuration.
 
 ## 2.4.6
 

--- a/src/pages/development/backward-incompatible-changes/highlights.md
+++ b/src/pages/development/backward-incompatible-changes/highlights.md
@@ -181,7 +181,7 @@ The `spomky-labs/otphp` library was updated which introduced a new validation re
 
 If your Commerce application is affected by this change, admin users might see the following message when they log in: `There was an internal error trying to verify your code`. You can confirm the cause of the error by checking the `system.log` file in `var/log` for an entry `main.ERROR: The leeway must be lower than the TOTP period`.
 
-To fix this issue, change the value of the configuration path `twofactorauth/google/otp_window` to be shorter than the TOTP period which is usually 30 seconds. For example, you can reset it to the default value of `1` with the command `bin/magento twofactorauth/google/otp_window 1`. You might need to flush the cache to apply the updated configuration.
+To fix this issue, change the value of the configuration path `twofactorauth/google/otp_window` to be shorter than the TOTP period which is usually 30 seconds. For example, you can reset it to the default value of `1` with the command `bin/magento config:set twofactorauth/google/otp_window 1`. You might need to flush the cache to apply the updated configuration.
 
 ## 2.4.6
 

--- a/src/pages/development/backward-incompatible-changes/highlights.md
+++ b/src/pages/development/backward-incompatible-changes/highlights.md
@@ -177,11 +177,11 @@ The following module is affected by this change:
 
 ### New system configuration validation for Two Factor Authentication `otp_window` value
 
-The `spomky-labs/otphp` library was updated which introduced a new validation requirement for supplying custom `otp_window` values. This configuration setting controls the grace period (in number of seconds) that is allowed for an expired one-time-password (OTP) to be used before it is denied. Previously it allowed for any number of seconds but now it must not be longer than the lifetime of a single OTP (usually 30 seconds). This means that the configuration value must now be changed if it is set longer.
+The `spomky-labs/otphp` library was updated which introduced a new validation requirement for supplying custom `otp_window` values. This configuration setting controls the grace period (in number of seconds) that is allowed for an expired one-time-password (OTP) to be used before it is denied. Previously, the library allowed any number of seconds to be specified. Now the value cannot be higher than the lifetime of a single OTP (usually 30 seconds).  This change means that the configuration value must be changed if it is set to 30 or higher.
 
-If you are affected by this change, admin users may be unable to login and see the message `There was an internal error trying to verify your code`. You can confirm this by checking the `system.log` file in `var/log` for an entry `main.ERROR: The leeway must be lower than the TOTP period`.
+If your Commerce application is affected by this change, admin users might see the following message when they log in:  `There was an internal error trying to verify your code`. You can confirm the cause of the error by checking the `system.log` file in `var/log` for an entry `main.ERROR: The leeway must be lower than the TOTP period`.
 
-To fix this issue, you must change the value of the configuration path `twofactorauth/google/otp_window` to be shorter than the TOTP period which is usually 30 seconds. For example, you can reset it to the default value of `1` with the command `bin/magento twofactorauth/google/otp_window 1`. Note that you may need to flush the cache for this setting change to be enforced.
+To fix this issue, change the value of the configuration path `twofactorauth/google/otp_window` to be shorter than the TOTP period which is usually 30 seconds. For example, you can reset it to the default value of `1` with the command `bin/magento twofactorauth/google/otp_window 1`. You might need to flush the cache to apply the updated configuration. 
 
 ## 2.4.6
 

--- a/src/pages/development/backward-incompatible-changes/highlights.md
+++ b/src/pages/development/backward-incompatible-changes/highlights.md
@@ -177,11 +177,11 @@ The following module is affected by this change:
 
 ### New system configuration validation for Two Factor Authentication `otp_window` value
 
-The `spomky-labs/otphp` library was updated which introduced a new validation requirement for supplying custom `otp_window` values. This configuration setting controls the grace period (in number of seconds) that is allowed for an expired one-time-password (OTP) to be used before it is denied. Previously, the library allowed any number of seconds to be specified. Now, the value cannot be higher than the lifetime of a single OTP (usually 30 seconds). This change means that the configuration value must be changed if it is set to 30 or higher.
+The updated`spomky-labs/otphp` library introduced a new validation requirement for supplying custom `otp_window` values. This configuration setting controls how long (in seconds) the system accepts an administrator's one-time-password (OTP) after it has expired. Previously, the library allowed any number of seconds to be specified. Now, the value cannot be higher than the lifetime of a single OTP (usually 30 seconds). You must update this value if it is currently set to 30 or higher.
 
 If your Commerce application is affected by this change, admin users might see the following message when they log in: `There was an internal error trying to verify your code`. You can confirm the cause of the error by checking the `system.log` file in `var/log` for an entry `main.ERROR: The leeway must be lower than the TOTP period`.
 
-To fix this issue, change the value of the configuration path `twofactorauth/google/otp_window` to be shorter than the TOTP period which is usually 30 seconds. For example, you can reset it to the default value of `1` with the command `bin/magento config:set twofactorauth/google/otp_window 1`. You might need to flush the cache to apply the updated configuration.
+To fix this issue, change the value of the configuration path `twofactorauth/google/otp_window` to be shorter than the TOTP period, which is usually 30 seconds. For example, you can reset it to 29 seconds using the `bin/magento config:set twofactorauth/google/otp_window 29` command. You might need to flush the cache to apply the updated configuration.
 
 ## 2.4.6
 

--- a/src/pages/development/backward-incompatible-changes/highlights.md
+++ b/src/pages/development/backward-incompatible-changes/highlights.md
@@ -177,7 +177,7 @@ The following module is affected by this change:
 
 ### New system configuration validation for Two Factor Authentication `otp_window` value
 
-The `spomky-labs/otphp` library was updated which introduced a new validation requirement for supplying custom `otp_window` values. This configuration setting controls the grace period (in number of seconds) that is allowed for an expired one-time-password (OTP) to be used before it is denied. Previously, the library allowed any number of seconds to be specified. Now the value cannot be higher than the lifetime of a single OTP (usually 30 seconds).  This change means that the configuration value must be changed if it is set to 30 or higher.
+The `spomky-labs/otphp` library was updated which introduced a new validation requirement for supplying custom `otp_window` values. This configuration setting controls the grace period (in number of seconds) that is allowed for an expired one-time-password (OTP) to be used before it is denied. Previously, the library allowed any number of seconds to be specified. Now, the value cannot be higher than the lifetime of a single OTP (usually 30 seconds). This change means that the configuration value must be changed if it is set to 30 or higher.
 
 If your Commerce application is affected by this change, admin users might see the following message when they log in:  `There was an internal error trying to verify your code`. You can confirm the cause of the error by checking the `system.log` file in `var/log` for an entry `main.ERROR: The leeway must be lower than the TOTP period`.
 

--- a/src/pages/development/backward-incompatible-changes/highlights.md
+++ b/src/pages/development/backward-incompatible-changes/highlights.md
@@ -27,6 +27,7 @@ The following major backward-incompatible changes were introduced in the 2.4.7 A
 * New system configuration for full-page caching
 * New system configuration for limiting coupon generation
 * New system configuration for payment information rate limiting
+* New system configuration validation for Two Factor Authentication `otp_window` value
 
 ### API integration: FedEx SOAP
 
@@ -173,6 +174,14 @@ No action for merchants or extension developers is necessary.
 The following module is affected by this change:
 
 * [Magento_Quote](https://developer.adobe.com/commerce/php/module-reference/module-quote/)
+
+### New system configuration validation for Two Factor Authentication `otp_window` value
+
+The `spomky-labs/otphp` library was updated which introduced a new validation requirement for supplying custom `otp_window` values. This configuration setting controls the grace period (in number of seconds) that is allowed for an expired one-time-password (OTP) to be used before it is denied. Previously it allowed for any number of seconds but now it must not be longer than the lifetime of a single OTP (usually 30 seconds). This means that the configuration value must now be changed if it is set longer.
+
+If you are affected by this change, admin users may be unable to login and see the message `There was an internal error trying to verify your code`. You can confirm this by checking the `system.log` file in `var/log` for an entry `main.ERROR: The leeway must be lower than the TOTP period`.
+
+To fix this issue, you must change the value of the configuration path `twofactorauth/google/otp_window` to be shorter than the TOTP period which is usually 30 seconds. For example, you can reset it to the default value of `1` with the command `bin/magento twofactorauth/google/otp_window 1`. Note that you may need to flush the cache for this setting change to be enforced.
 
 ## 2.4.6
 


### PR DESCRIPTION
## Purpose of this pull request

Adds a BIC highlight that explains the fix for 2FA login failure that can impact merchants with a custom configuration value for `twofactorauth/google/otp_window` that violates the constraints of one of our dependency libraries. Change caused by update to `spomky-labs/otphp`.

If the issue occurs, admin users see the message "There was an internal error trying to verify your code" and in the `system.log` logs there will be `main.ERROR: The leeway must be lower than the TOTP period .The fix is to use a value less than 30 and then flush the cache.

## Affected pages

- [Backward incompatible change highlights](https://developer.adobe.com/commerce/php/development/backward-incompatible-changes/highlights/)

## Links to Magento Open Source code

Issue report:  https://github.com/magento/magento2/issues/38597)


