### PR TITLE
COMDOX-908: Update Module reference

### DIFF
--- a/src/pages/module-reference/module-scalable-checkout.md
+++ b/src/pages/module-reference/module-scalable-checkout.md
@@ -3,6 +3,8 @@ title: ScalableCheckout
 description: N/A
 ---
 
+_Deprecated since 2.4.2 and will be removed._
+
 Magento\ScalableCheckout module provides ability for system extension (Checkout can be configured to work with separate DataBase).
 Extraction of Checkout tables to separate database will guarantee better scalability for Magento,
-and will allow main server to be optimised for read operations which will reduce latency.
+and will allow main server to be optimized for read operations which will reduce latency.

--- a/src/pages/module-reference/module-scalable-inventory.md
+++ b/src/pages/module-reference/module-scalable-inventory.md
@@ -3,6 +3,8 @@ title: ScalableInventory
 description: N/A
 ---
 
+_Deprecated since 2.4.2 and will be removed._
+
 Magento\ScalableInventory module provides ability for system extension (CatalogInventory can be configured to work with separate quantity storage).
 Extraction of quantity updates to separate storage will guarantee better scalability for Magento,
-and will allow main server to be optimised for read operations which will reduce latency.
+and will allow main server to be optimized for read operations which will reduce latency.

--- a/src/pages/module-reference/module-scalable-oms.md
+++ b/src/pages/module-reference/module-scalable-oms.md
@@ -3,7 +3,9 @@ title: ScalableOms
 description: N/A
 ---
 
+_Deprecated since 2.4.2 and will be removed._
+
 Magento\ScalableOms (Order Management System) module provides ability for system extension
 (Sales can be configured to work with separate database).
 Extraction of Sales tables to separate database will guarantee better scalability for Magento,
-and will allow main server to be optimised for read operations which will reduce latency.
+and will allow main server to be optimized for read operations which will reduce latency.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds deprecation notice to Scalable checkout/inventory/oms modules in the Module reference.

Internal ref: [COMDOX-908](https://jira.corp.adobe.com/browse/COMDOX-908) 

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/php/module-reference/module-scalable-checkout/
- https://developer.adobe.com/commerce/php/module-reference/module-scalable-inventory/
- https://developer.adobe.com/commerce/php/module-reference/module-scalable-oms/

## Preview

- https://commerce-docs.github.io/commerce-php/module-reference/module-scalable-checkout/
- https://commerce-docs.github.io/commerce-php/module-reference/module-scalable-inventory/
- https://commerce-docs.github.io/commerce-php/module-reference/module-scalable-oms/