### PR TITLE
ACP2E-3031: Update the documentation on OM in templates

### DIFF
--- a/src/pages/coding-standards/technical-guidelines.md
+++ b/src/pages/coding-standards/technical-guidelines.md
@@ -522,6 +522,8 @@ You need to read configuration from different sources (like database or filesyst
 
 6.2.5 Blocks MUST NOT assume that a specific, or any, controller has been invoked for current request.
 
+6.2.6 Templates MUST NOT instantiate objects. All objects MUST be passed from the block.
+
 ### 6.3. Data Access (Persistence) layer
 
 6.3.1. Entities MAY have fields scoped differently (in product, EAV --- per store, options --- per website).

--- a/src/pages/coding-standards/technical-guidelines.md
+++ b/src/pages/coding-standards/technical-guidelines.md
@@ -522,7 +522,10 @@ You need to read configuration from different sources (like database or filesyst
 
 6.2.5 Blocks MUST NOT assume that a specific, or any, controller has been invoked for current request.
 
-6.2.6 Templates MUST NOT instantiate objects. All objects MUST be passed from the block.
+6.2.6 Templates MUST NOT instantiate objects. All objects MUST be passed from the Block object.
+This way, the template remains stateless and its sole responsibility is to display the data it receives from the Block object.
+This approach promotes a clear separation of concerns, improves testability, and makes the code more modular and easier to maintain.
+It also ensures that the template does not have unexpected side effects, as it is not responsible for creating objects or managing their lifecycle.
 
 ### 6.3. Data Access (Persistence) layer
 

--- a/src/pages/coding-standards/technical-guidelines.md
+++ b/src/pages/coding-standards/technical-guidelines.md
@@ -522,7 +522,7 @@ You need to read configuration from different sources (like database or filesyst
 
 6.2.5 Blocks MUST NOT assume that a specific, or any, controller has been invoked for current request.
 
-6.2.6 Templates MUST NOT instantiate objects. All objects MUST be passed from the Block object.
+6.2.6 Templates MUST NOT instantiate objects. All objects MUST be passed from the Block objects.
 
 ### 6.3. Data Access (Persistence) layer
 

--- a/src/pages/coding-standards/technical-guidelines.md
+++ b/src/pages/coding-standards/technical-guidelines.md
@@ -523,9 +523,6 @@ You need to read configuration from different sources (like database or filesyst
 6.2.5 Blocks MUST NOT assume that a specific, or any, controller has been invoked for current request.
 
 6.2.6 Templates MUST NOT instantiate objects. All objects MUST be passed from the Block object.
-This way, the template remains stateless and its sole responsibility is to display the data it receives from the Block object.
-This approach promotes a clear separation of concerns, improves testability, and makes the code more modular and easier to maintain.
-It also ensures that the template does not have unexpected side effects, as it is not responsible for creating objects or managing their lifecycle.
 
 ### 6.3. Data Access (Persistence) layer
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is to add a note to technical guidelines about instantiation of the new objects from templates to avoid confusion.

**Please note I am keeping this as draft for collaboration between developers to edit and approve and will change the status once we will be done. Thanks.**

Related PR: https://github.com/AdobeDocs/commerce-frontend-core/pull/168

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/php/coding-standards/technical-guidelines/#62-presentation-layer

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-php/blob/main/.github/CONTRIBUTING.md) for more information.
-->
