### PR TITLE
fix-commerce-php-issue-241

### DIFF
--- a/src/pages/tutorials/frontend/custom-checkout/add-shipping-carrier.md
+++ b/src/pages/tutorials/frontend/custom-checkout/add-shipping-carrier.md
@@ -200,9 +200,9 @@ use Psr\Log\LoggerInterface;
 
 class Customshipping extends AbstractCarrier implements CarrierInterface
 {
-    protected string $_code = 'customshipping';
+    protected $_code = 'customshipping';
 
-    protected bool $_isFixed = true;
+    protected $_isFixed = true;
 
     private ResultFactory $rateResultFactory;
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is fix for https://github.com/AdobeDocs/commerce-php/issues/241

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- [https://developer.adobe.com/commerce/php/tutorials/frontend/custom-checkout/add-shipping-carrier/](https://developer.adobe.com/commerce/php/tutorials/frontend/custom-checkout/add-shipping-carrier/)

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- src/pages/tutorials/frontend/custom-checkout/add-shipping-carrier.md

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-php/blob/main/.github/CONTRIBUTING.md) for more information.
-->
