### PR TITLE
[TEST] Add Backward incompatible changes reference reports

### DIFF
--- a/src/_includes/backward-incompatible-changes/b2b/2.4.6-2.4.7.md
+++ b/src/_includes/backward-incompatible-changes/b2b/2.4.6-2.4.7.md
@@ -1,4 +1,4 @@
-#### Class changes {#b2b-246-247-class}
+#### Class changes {#commerce-b2b-BICs-246-247-class}
 
 | What changed | How it changed |
 | --- | --- |
@@ -181,7 +181,7 @@
 | Magento\Weee\Helper\Data | Interface has been added. |
 | Magento\Weee\Helper\Data::\_resetState | [public] Method has been added. |
 
-#### Interface changes {#b2b-246-247-interface}
+#### Interface changes {#commerce-b2b-BICs-246-247-interface}
 
 | What changed | How it changed |
 | --- | --- |
@@ -218,7 +218,7 @@
 | Magento\Vault\Api\Data\PaymentTokenInterface::getWebsiteId | [public] Method has been added. |
 | Magento\Vault\Api\Data\PaymentTokenInterface::setWebsiteId | [public] Method has been added. |
 
-#### Database changes {#b2b-246-247-database}
+#### Database changes {#commerce-b2b-BICs-246-247-database}
 
 | What changed | How it changed |
 | --- | --- |
@@ -227,7 +227,7 @@
 | magento\_salesrule\_filter/is\_coupon | Column was added |
 | payment\_services\_order\_data\_production\_submitted\_hash | Table was added |
 | payment\_services\_order\_data\_sandbox\_submitted\_hash | Table was added |
-| payment\_services\_order\_status\_data\_production\_submitted\_hash | Table was added |
+| payment\_services\_order\_status\_data\_prod\_submitted\_hash | Table was added |
 | payment\_services\_order\_status\_data\_sandbox\_submitted\_hash | Table was added |
 | payment\_services\_store\_data\_production\_submitted\_hash | Table was added |
 | payment\_services\_store\_data\_sandbox\_submitted\_hash | Table was added |
@@ -239,7 +239,7 @@
 | vault\_payment\_token/website\_id | Column was added |
 | webhooks\_configuration | Table was added |
 
-#### Di changes {#b2b-246-247-di}
+#### Di changes {#commerce-b2b-BICs-246-247-di}
 
 | What changed | How it changed |
 | --- | --- |
@@ -277,7 +277,7 @@
 | elasticsearch5FieldTypeFloatResolver | Virtual Type was removed |
 | elasticsearch5StaticFieldProvider | Virtual Type was removed |
 
-#### Layout changes {#b2b-246-247-layout}
+#### Layout changes {#commerce-b2b-BICs-246-247-layout}
 
 | What changed | How it changed |
 | --- | --- |
@@ -285,7 +285,7 @@
 | quickCheckoutTracking | Block was removed |
 | quickcheckoutadminpanel.index | Block was removed |
 
-#### System changes {#b2b-246-247-system}
+#### System changes {#commerce-b2b-BICs-246-247-system}
 
 | What changed | How it changed |
 | --- | --- |
@@ -431,15 +431,15 @@
 | system/full\_page\_cache/varnish/export\_button\_version4 | A field-node was removed |
 | system/full\_page\_cache/varnish/export\_button\_version5 | A field-node was removed |
 
-#### Xsd changes {#b2b-246-247-xsd}
+#### Xsd changes {#commerce-b2b-BICs-246-247-xsd}
 
 | What changed | How it changed |
 | --- | --- |
-| /app/code/module-adobe-commerce-webhooks/etc/webhooks.xsd | A schema declaration was added |
-| /app/code/module-data-exporter/etc/et\_schema.xsd | A schema declaration was added |
-| /app/code/module-query-xml/etc/query.xsd | A schema declaration was added |
+| var/jenkins/workspace/gendocs-BIC-reference/commerce/commerce-b2b-after/app/code/module-adobe-commerce-webhooks/etc/webhooks.xsd | A schema declaration was added |
+| var/jenkins/workspace/gendocs-BIC-reference/commerce/commerce-b2b-after/app/code/module-data-exporter/etc/et\_schema.xsd | A schema declaration was added |
+| var/jenkins/workspace/gendocs-BIC-reference/commerce/commerce-b2b-after/app/code/module-query-xml/etc/query.xsd | A schema declaration was added |
 
-#### EtSchema changes {#b2b-246-247-etSchema}
+#### EtSchema changes {#commerce-b2b-BICs-246-247-etSchema}
 
 | What changed | How it changed |
 | --- | --- |
@@ -451,7 +451,7 @@
 | OrderStatus | Added a new declaration for record OrderStatus. |
 | Transaction | Added a new declaration for record Transaction. |
 
-#### Class API membership changes {#b2b-246-247-class-api-membership}
+#### Class API membership changes {#commerce-b2b-BICs-246-247-class-api-membership}
 
 | What changed | How it changed |
 | --- | --- |

--- a/src/_includes/backward-incompatible-changes/commerce/2.4.6-2.4.7.md
+++ b/src/_includes/backward-incompatible-changes/commerce/2.4.6-2.4.7.md
@@ -1,4 +1,4 @@
-#### Class changes {#ee-246-247-class}
+#### Class changes {#commerce-BICs-246-247-class}
 
 | What changed | How it changed |
 | --- | --- |
@@ -181,7 +181,7 @@
 | Magento\Weee\Helper\Data | Interface has been added. |
 | Magento\Weee\Helper\Data::\_resetState | [public] Method has been added. |
 
-#### Interface changes {#ee-246-247-interface}
+#### Interface changes {#commerce-BICs-246-247-interface}
 
 | What changed | How it changed |
 | --- | --- |
@@ -218,7 +218,7 @@
 | Magento\Vault\Api\Data\PaymentTokenInterface::getWebsiteId | [public] Method has been added. |
 | Magento\Vault\Api\Data\PaymentTokenInterface::setWebsiteId | [public] Method has been added. |
 
-#### Database changes {#ee-246-247-database}
+#### Database changes {#commerce-BICs-246-247-database}
 
 | What changed | How it changed |
 | --- | --- |
@@ -227,7 +227,7 @@
 | magento\_salesrule\_filter/is\_coupon | Column was added |
 | payment\_services\_order\_data\_production\_submitted\_hash | Table was added |
 | payment\_services\_order\_data\_sandbox\_submitted\_hash | Table was added |
-| payment\_services\_order\_status\_data\_production\_submitted\_hash | Table was added |
+| payment\_services\_order\_status\_data\_prod\_submitted\_hash | Table was added |
 | payment\_services\_order\_status\_data\_sandbox\_submitted\_hash | Table was added |
 | payment\_services\_store\_data\_production\_submitted\_hash | Table was added |
 | payment\_services\_store\_data\_sandbox\_submitted\_hash | Table was added |
@@ -239,7 +239,7 @@
 | vault\_payment\_token/website\_id | Column was added |
 | webhooks\_configuration | Table was added |
 
-#### Di changes {#ee-246-247-di}
+#### Di changes {#commerce-BICs-246-247-di}
 
 | What changed | How it changed |
 | --- | --- |
@@ -277,7 +277,7 @@
 | elasticsearch5FieldTypeFloatResolver | Virtual Type was removed |
 | elasticsearch5StaticFieldProvider | Virtual Type was removed |
 
-#### Layout changes {#ee-246-247-layout}
+#### Layout changes {#commerce-BICs-246-247-layout}
 
 | What changed | How it changed |
 | --- | --- |
@@ -285,7 +285,7 @@
 | quickCheckoutTracking | Block was removed |
 | quickcheckoutadminpanel.index | Block was removed |
 
-#### System changes {#ee-246-247-system}
+#### System changes {#commerce-BICs-246-247-system}
 
 | What changed | How it changed |
 | --- | --- |
@@ -431,15 +431,15 @@
 | system/full\_page\_cache/varnish/export\_button\_version4 | A field-node was removed |
 | system/full\_page\_cache/varnish/export\_button\_version5 | A field-node was removed |
 
-#### Xsd changes {#ee-246-247-xsd}
+#### Xsd changes {#commerce-BICs-246-247-xsd}
 
 | What changed | How it changed |
 | --- | --- |
-| /app/code/module-adobe-commerce-webhooks/etc/webhooks.xsd | A schema declaration was added |
-| /app/code/module-data-exporter/etc/et\_schema.xsd | A schema declaration was added |
-| /app/code/module-query-xml/etc/query.xsd | A schema declaration was added |
+| var/jenkins/workspace/gendocs-BIC-reference/commerce/commerce-after/app/code/module-adobe-commerce-webhooks/etc/webhooks.xsd | A schema declaration was added |
+| var/jenkins/workspace/gendocs-BIC-reference/commerce/commerce-after/app/code/module-data-exporter/etc/et\_schema.xsd | A schema declaration was added |
+| var/jenkins/workspace/gendocs-BIC-reference/commerce/commerce-after/app/code/module-query-xml/etc/query.xsd | A schema declaration was added |
 
-#### EtSchema changes {#ee-246-247-etSchema}
+#### EtSchema changes {#commerce-BICs-246-247-etSchema}
 
 | What changed | How it changed |
 | --- | --- |
@@ -451,7 +451,7 @@
 | OrderStatus | Added a new declaration for record OrderStatus. |
 | Transaction | Added a new declaration for record Transaction. |
 
-#### Class API membership changes {#ee-246-247-class-api-membership}
+#### Class API membership changes {#commerce-BICs-246-247-class-api-membership}
 
 | What changed | How it changed |
 | --- | --- |

--- a/src/_includes/backward-incompatible-changes/open-source/2.4.6-2.4.7.md
+++ b/src/_includes/backward-incompatible-changes/open-source/2.4.6-2.4.7.md
@@ -1,4 +1,4 @@
-#### Class changes {#ce-246-247-class}
+#### Class changes {#open-source-BICs-246-247-class}
 
 | What changed | How it changed |
 | --- | --- |
@@ -168,7 +168,7 @@
 | Magento\Weee\Helper\Data | Interface has been added. |
 | Magento\Weee\Helper\Data::\_resetState | [public] Method has been added. |
 
-#### Interface changes {#ce-246-247-interface}
+#### Interface changes {#open-source-BICs-246-247-interface}
 
 | What changed | How it changed |
 | --- | --- |
@@ -191,14 +191,14 @@
 | Magento\Vault\Api\Data\PaymentTokenInterface::getWebsiteId | [public] Method has been added. |
 | Magento\Vault\Api\Data\PaymentTokenInterface::setWebsiteId | [public] Method has been added. |
 
-#### Database changes {#ce-246-247-database}
+#### Database changes {#open-source-BICs-246-247-database}
 
 | What changed | How it changed |
 | --- | --- |
 | data\_exporter\_uuid | Table was added |
 | payment\_services\_order\_data\_production\_submitted\_hash | Table was added |
 | payment\_services\_order\_data\_sandbox\_submitted\_hash | Table was added |
-| payment\_services\_order\_status\_data\_production\_submitted\_hash | Table was added |
+| payment\_services\_order\_status\_data\_prod\_submitted\_hash | Table was added |
 | payment\_services\_order\_status\_data\_sandbox\_submitted\_hash | Table was added |
 | payment\_services\_store\_data\_production\_submitted\_hash | Table was added |
 | payment\_services\_store\_data\_sandbox\_submitted\_hash | Table was added |
@@ -207,7 +207,7 @@
 | stores\_data\_exporter | Table was added |
 | vault\_payment\_token/website\_id | Column was added |
 
-#### Di changes {#ce-246-247-di}
+#### Di changes {#open-source-BICs-246-247-di}
 
 | What changed | How it changed |
 | --- | --- |
@@ -220,7 +220,7 @@
 | elasticsearch5FieldTypeFloatResolver | Virtual Type was removed |
 | elasticsearch5StaticFieldProvider | Virtual Type was removed |
 
-#### System changes {#ce-246-247-system}
+#### System changes {#open-source-BICs-246-247-system}
 
 | What changed | How it changed |
 | --- | --- |
@@ -337,14 +337,14 @@
 | system/full\_page\_cache/varnish/export\_button\_version4 | A field-node was removed |
 | system/full\_page\_cache/varnish/export\_button\_version5 | A field-node was removed |
 
-#### Xsd changes {#ce-246-247-xsd}
+#### Xsd changes {#open-source-BICs-246-247-xsd}
 
 | What changed | How it changed |
 | --- | --- |
-| /app/code/module-data-exporter/etc/et\_schema.xsd | A schema declaration was added |
-| /app/code/module-query-xml/etc/query.xsd | A schema declaration was added |
+| var/jenkins/workspace/gendocs-BIC-reference/commerce/open-source-after/app/code/module-data-exporter/etc/et\_schema.xsd | A schema declaration was added |
+| var/jenkins/workspace/gendocs-BIC-reference/commerce/open-source-after/app/code/module-query-xml/etc/query.xsd | A schema declaration was added |
 
-#### EtSchema changes {#ce-246-247-etSchema}
+#### EtSchema changes {#open-source-BICs-246-247-etSchema}
 
 | What changed | How it changed |
 | --- | --- |
@@ -356,7 +356,7 @@
 | OrderStatus | Added a new declaration for record OrderStatus. |
 | Transaction | Added a new declaration for record Transaction. |
 
-#### Class API membership changes {#ce-246-247-class-api-membership}
+#### Class API membership changes {#open-source-BICs-246-247-class-api-membership}
 
 | What changed | How it changed |
 | --- | --- |


### PR DESCRIPTION
Added backward incompatible changes reference reports for 2.4.6-2.4.7 versions delta. To update the [actual topic](https://developer.adobe.com/commerce/php/development/backward-incompatible-changes/reference/), make sure that the reports are included in the topic.