### PR TITLE
Develop data and schema patches - apply() method should return $this - required by PatchInterface docblock

### DIFF
--- a/src/pages/development/components/declarative-schema/patches.md
+++ b/src/pages/development/components/declarative-schema/patches.md
@@ -82,6 +82,7 @@ class DummyPatch
         //Please note, that one patch is responsible only for one setup version
         //So one UpgradeData can consist of few data patches
         $this->moduleDataSetup->getConnection()->endSetup();
+        return $this;
     }
 
     /**


### PR DESCRIPTION
## Purpose of this pull request

[PatchInterface](https://github.com/magento/magento2/blob/2.4-develop/lib/internal/Magento/Framework/Setup/Patch/PatchInterface.php) requires apply() method to `@return $this`.

Code Sample provided on https://developer.adobe.com/commerce/php/development/components/declarative-schema/patches/ generates the following error when checked with phpstan:

Method Vendor\Module\Setup\Patch\Data\SomePatch::apply() should return $this, but return statement is missing.

## Affected pages

- https://developer.adobe.com/commerce/php/development/components/declarative-schema/patches/

## Links to Magento Open Source code

- [magento/framework/Setup/Patch/DataPatchInterface.php](https://github.com/magento/magento2/blob/2.4-develop/lib/internal/Magento/Framework/Setup/Patch/DataPatchInterface.php)
- [magento/framework/Setup/Patch/PatchInterface.php](https://github.com/magento/magento2/blob/2.4-develop/lib/internal/Magento/Framework/Setup/Patch/PatchInterface.php)