### PR TITLE
Add Backward incompatible changes reference reports

### DIFF
--- a/src/_includes/backward-incompatible-changes/commerce/2.4.6-2.4.7.md
+++ b/src/_includes/backward-incompatible-changes/commerce/2.4.6-2.4.7.md
@@ -1,8 +1,9 @@
-#### Class changes {#b2b-246-247-class}
+#### Class changes {#commerce-BICs-246-247-class}
 
 | What changed | How it changed |
 | --- | --- |
-| Magento\AdobeCommerceWebhooksAdminUi\Block\Adminhtml\ValidationConfig | Class was added. |
+| Magento\AdobeCommerceEventsClient\Event\Event::EVENT\_HIPAA\_AUDIT\_REQUIRED | Constant has been added. |
+| Magento\AdobeCommerceEventsClient\Event\Event::isHipaaAuditRequired | [public] Method has been added. |
 | Magento\Authorization\Model\CompositeUserContext | Interface has been added. |
 | Magento\Authorization\Model\CompositeUserContext::\_resetState | [public] Method has been added. |
 | Magento\Bundle\Block\Catalog\Product\View\Type\Bundle | Interface has been added. |
@@ -181,11 +182,15 @@
 | Magento\Weee\Helper\Data | Interface has been added. |
 | Magento\Weee\Helper\Data::\_resetState | [public] Method has been added. |
 
-#### Interface changes {#b2b-246-247-interface}
+#### Interface changes {#commerce-BICs-246-247-interface}
 
 | What changed | How it changed |
 | --- | --- |
-| Magento\AdobeCommerceWebhooksAdminUi\Api\HookRepositoryInterface | Interface was added. |
+| Magento\AdobeCommerceEventsClient\Api\Data\EventDataInterface::isHipaaAuditRequired | [public] Method has been added. |
+| Magento\AdobeCommerceEventsClient\Api\Data\EventDataInterface::setHipaaAuditRequired | [public] Method has been added. |
+| Magento\AdobeCommerceEventsClient\Api\Data\EventInterface::FIELD\_HIPAA\_AUDIT\_REQUIRED | Constant has been added. |
+| Magento\AdobeCommerceEventsClient\Api\Data\EventInterface::isHipaaAuditRequired | [public] Method has been added. |
+| Magento\AdobeCommerceEventsClient\Api\Data\EventInterface::setHipaaAuditRequired | [public] Method has been added. |
 | Magento\AdobeCommerceWebhooks\Model\Filter\Converter\FieldConverterInterface | Interface was added. |
 | Magento\AdobeCommerceWebhooks\Model\HeaderResolverInterface | Interface was added. |
 | Magento\AdvancedRule\Model\Condition\FilterInterface::isCoupon | [public] Method has been added. |
@@ -218,16 +223,17 @@
 | Magento\Vault\Api\Data\PaymentTokenInterface::getWebsiteId | [public] Method has been added. |
 | Magento\Vault\Api\Data\PaymentTokenInterface::setWebsiteId | [public] Method has been added. |
 
-#### Database changes {#b2b-246-247-database}
+#### Database changes {#commerce-BICs-246-247-database}
 
 | What changed | How it changed |
 | --- | --- |
 | admin\_ui\_sdk\_mass\_actions | Table was added |
 | data\_exporter\_uuid | Table was added |
+| event\_data/hipaa\_audit\_required | Column was added |
 | magento\_salesrule\_filter/is\_coupon | Column was added |
 | payment\_services\_order\_data\_production\_submitted\_hash | Table was added |
 | payment\_services\_order\_data\_sandbox\_submitted\_hash | Table was added |
-| payment\_services\_order\_status\_data\_production\_submitted\_hash | Table was added |
+| payment\_services\_order\_status\_data\_prod\_submitted\_hash | Table was added |
 | payment\_services\_order\_status\_data\_sandbox\_submitted\_hash | Table was added |
 | payment\_services\_store\_data\_production\_submitted\_hash | Table was added |
 | payment\_services\_store\_data\_sandbox\_submitted\_hash | Table was added |
@@ -237,9 +243,8 @@
 | sales\_order\_coupons | Table was added |
 | stores\_data\_exporter | Table was added |
 | vault\_payment\_token/website\_id | Column was added |
-| webhooks\_configuration | Table was added |
 
-#### Di changes {#b2b-246-247-di}
+#### Di changes {#commerce-BICs-246-247-di}
 
 | What changed | How it changed |
 | --- | --- |
@@ -277,7 +282,7 @@
 | elasticsearch5FieldTypeFloatResolver | Virtual Type was removed |
 | elasticsearch5StaticFieldProvider | Virtual Type was removed |
 
-#### Layout changes {#b2b-246-247-layout}
+#### Layout changes {#commerce-BICs-246-247-layout}
 
 | What changed | How it changed |
 | --- | --- |
@@ -285,7 +290,7 @@
 | quickCheckoutTracking | Block was removed |
 | quickcheckoutadminpanel.index | Block was removed |
 
-#### System changes {#b2b-246-247-system}
+#### System changes {#commerce-BICs-246-247-system}
 
 | What changed | How it changed |
 | --- | --- |
@@ -337,6 +342,11 @@
 | checkout/quick\_checkout/settings/next\_stage\_after\_login | A field-node was removed |
 | checkout/quick\_checkout/settings/payment\_action | A field-node was removed |
 | checkout/quick\_checkout/settings/title | A field-node was removed |
+| commerce\_webhooks | A section-node was added |
+| commerce\_webhooks/digital\_signature | A group-node was added |
+| commerce\_webhooks/digital\_signature/enabled | A field-node was added |
+| commerce\_webhooks/digital\_signature/private\_key\_generate\_button | A field-node was added |
+| commerce\_webhooks/digital\_signature/public\_key | A field-node was added |
 | csp | A section-node was added |
 | csp/mode | A group-node was added |
 | csp/mode/admin | A group-node was added |
@@ -370,6 +380,7 @@
 | payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/active | A field-node was added |
 | payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/async\_status\_updates | A field-node was added |
 | payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/method | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/paypal\_l2\_l3\_send\_data | A field-node was added |
 | payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/production\_merchant\_id | A field-node was added |
 | payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/sandbox\_merchant\_id | A field-node was added |
 | payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/soft\_descriptor | A field-node was added |
@@ -431,15 +442,17 @@
 | system/full\_page\_cache/varnish/export\_button\_version4 | A field-node was removed |
 | system/full\_page\_cache/varnish/export\_button\_version5 | A field-node was removed |
 
-#### Xsd changes {#b2b-246-247-xsd}
+#### Xsd changes {#commerce-BICs-246-247-xsd}
 
 | What changed | How it changed |
 | --- | --- |
-| /app/code/module-adobe-commerce-webhooks/etc/webhooks.xsd | A schema declaration was added |
-| /app/code/module-data-exporter/etc/et\_schema.xsd | A schema declaration was added |
-| /app/code/module-query-xml/etc/query.xsd | A schema declaration was added |
+| module-adobe-commerce-events-client/etc/io\_events.xsd | A schema declaration was added |
+| module-adobe-commerce-events-client/etc/io\_events.xsd | A schema declaration was removed |
+| module-adobe-commerce-webhooks/etc/webhooks.xsd | A schema declaration was added |
+| module-data-exporter/etc/et\_schema.xsd | A schema declaration was added |
+| module-query-xml/etc/query.xsd | A schema declaration was added |
 
-#### EtSchema changes {#b2b-246-247-etSchema}
+#### EtSchema changes {#commerce-BICs-246-247-etSchema}
 
 | What changed | How it changed |
 | --- | --- |
@@ -451,7 +464,7 @@
 | OrderStatus | Added a new declaration for record OrderStatus. |
 | Transaction | Added a new declaration for record Transaction. |
 
-#### Class API membership changes {#b2b-246-247-class-api-membership}
+#### Class API membership changes {#commerce-BICs-246-247-class-api-membership}
 
 | What changed | How it changed |
 | --- | --- |

--- a/src/_includes/backward-incompatible-changes/open-source/2.4.6-2.4.7.md
+++ b/src/_includes/backward-incompatible-changes/open-source/2.4.6-2.4.7.md
@@ -1,4 +1,4 @@
-#### Class changes {#ce-246-247-class}
+#### Class changes {#open-source-BICs-246-247-class}
 
 | What changed | How it changed |
 | --- | --- |
@@ -168,7 +168,7 @@
 | Magento\Weee\Helper\Data | Interface has been added. |
 | Magento\Weee\Helper\Data::\_resetState | [public] Method has been added. |
 
-#### Interface changes {#ce-246-247-interface}
+#### Interface changes {#open-source-BICs-246-247-interface}
 
 | What changed | How it changed |
 | --- | --- |
@@ -191,14 +191,14 @@
 | Magento\Vault\Api\Data\PaymentTokenInterface::getWebsiteId | [public] Method has been added. |
 | Magento\Vault\Api\Data\PaymentTokenInterface::setWebsiteId | [public] Method has been added. |
 
-#### Database changes {#ce-246-247-database}
+#### Database changes {#open-source-BICs-246-247-database}
 
 | What changed | How it changed |
 | --- | --- |
 | data\_exporter\_uuid | Table was added |
 | payment\_services\_order\_data\_production\_submitted\_hash | Table was added |
 | payment\_services\_order\_data\_sandbox\_submitted\_hash | Table was added |
-| payment\_services\_order\_status\_data\_production\_submitted\_hash | Table was added |
+| payment\_services\_order\_status\_data\_prod\_submitted\_hash | Table was added |
 | payment\_services\_order\_status\_data\_sandbox\_submitted\_hash | Table was added |
 | payment\_services\_store\_data\_production\_submitted\_hash | Table was added |
 | payment\_services\_store\_data\_sandbox\_submitted\_hash | Table was added |
@@ -207,7 +207,7 @@
 | stores\_data\_exporter | Table was added |
 | vault\_payment\_token/website\_id | Column was added |
 
-#### Di changes {#ce-246-247-di}
+#### Di changes {#open-source-BICs-246-247-di}
 
 | What changed | How it changed |
 | --- | --- |
@@ -220,7 +220,7 @@
 | elasticsearch5FieldTypeFloatResolver | Virtual Type was removed |
 | elasticsearch5StaticFieldProvider | Virtual Type was removed |
 
-#### System changes {#ce-246-247-system}
+#### System changes {#open-source-BICs-246-247-system}
 
 | What changed | How it changed |
 | --- | --- |
@@ -337,14 +337,14 @@
 | system/full\_page\_cache/varnish/export\_button\_version4 | A field-node was removed |
 | system/full\_page\_cache/varnish/export\_button\_version5 | A field-node was removed |
 
-#### Xsd changes {#ce-246-247-xsd}
+#### Xsd changes {#open-source-BICs-246-247-xsd}
 
 | What changed | How it changed |
 | --- | --- |
-| /app/code/module-data-exporter/etc/et\_schema.xsd | A schema declaration was added |
-| /app/code/module-query-xml/etc/query.xsd | A schema declaration was added |
+| module-data-exporter/etc/et\_schema.xsd | A schema declaration was added |
+| module-query-xml/etc/query.xsd | A schema declaration was added |
 
-#### EtSchema changes {#ce-246-247-etSchema}
+#### EtSchema changes {#open-source-BICs-246-247-etSchema}
 
 | What changed | How it changed |
 | --- | --- |
@@ -356,7 +356,7 @@
 | OrderStatus | Added a new declaration for record OrderStatus. |
 | Transaction | Added a new declaration for record Transaction. |
 
-#### Class API membership changes {#ce-246-247-class-api-membership}
+#### Class API membership changes {#open-source-BICs-246-247-class-api-membership}
 
 | What changed | How it changed |
 | --- | --- |


### PR DESCRIPTION
Added backward incompatible changes reference reports for 2.4.6-2.4.7 versions delta. To update the [actual topic](https://developer.adobe.com/commerce/php/development/backward-incompatible-changes/reference/), make sure that the reports are included in the topic.