### PR TITLE
Update Backward incompatible changes reference reports

### DIFF
--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -31,7 +31,6 @@ const remarkConfig = {
 					"https://eat.magento.com",
 					"https://developer.ups.com/oauth-developer-guide",
 					"https://business.adobe.com/products/magento/business-intelligence.html",
-					"https://business.adobe.com/products/magento/business-intelligence.html",
 					"https://www.adobe.com/trust/security/product-security.html"
 				],
 				skipOffline: "true"

--- a/src/_includes/backward-incompatible-changes/commerce/2.4.7-2.4.7-p1.md
+++ b/src/_includes/backward-incompatible-changes/commerce/2.4.7-2.4.7-p1.md
@@ -1,0 +1,868 @@
+#### Class changes {#commerce-BICs-247-247-p1-class}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\CompanyCredit\Block\Adminhtml\Company\Edit\CreditBalance | Class was removed. |
+| Magento\CompanyCredit\Block\Adminhtml\Order\CancelButton | Class was removed. |
+| Magento\CompanyCredit\Block\Adminhtml\Order\Message | Class was removed. |
+| Magento\CompanyCredit\Block\Company\CreditBalance | Class was removed. |
+| Magento\CompanyCredit\Block\Customer\Link | Class was removed. |
+| Magento\CompanyCredit\Block\Link\Delimiter | Class was removed. |
+| Magento\CompanyPayment\Block\Company\Profile\PaymentMethod | Class was removed. |
+| Magento\CompanyShipping\Block\Company\Profile\ShippingMethod | Class was removed. |
+| Magento\Company\Block\Adminhtml\Customer\Edit\Tab\View\PersonalInfo | Class was removed. |
+| Magento\Company\Block\Adminhtml\Sales\Order\View\Info\Creditmemo\OrderCompanyInfo | Class was removed. |
+| Magento\Company\Block\Adminhtml\Sales\Order\View\Info\Invoice\OrderCompanyInfo | Class was removed. |
+| Magento\Company\Block\Adminhtml\Sales\Order\View\Info\OrderCompanyInfo | Class was removed. |
+| Magento\Company\Block\Adminhtml\Sales\Order\View\Info\Shipment\OrderCompanyInfo | Class was removed. |
+| Magento\Company\Block\Company\Account\Create | Class was removed. |
+| Magento\Company\Block\Company\Account\Dashboard\RoleInfo | Class was removed. |
+| Magento\Company\Block\Company\CompanyInfo | Class was removed. |
+| Magento\Company\Block\Company\CompanyProfile | Class was removed. |
+| Magento\Company\Block\Company\Login\Info | Class was removed. |
+| Magento\Company\Block\Company\Management | Class was removed. |
+| Magento\Company\Block\Company\Management\Add | Class was removed. |
+| Magento\Company\Block\Company\Management\Info | Class was removed. |
+| Magento\Company\Block\Company\Register\Link | Class was removed. |
+| Magento\Company\Block\Company\Register\Profile | Class was removed. |
+| Magento\Company\Block\Company\Role\Edit | Class was removed. |
+| Magento\Company\Block\Link\Company | Class was removed. |
+| Magento\Company\Block\Link\CompanyLink | Class was removed. |
+| Magento\Company\Block\Link\Current | Class was removed. |
+| Magento\Company\Block\Link\Delimiter | Class was removed. |
+| Magento\Company\Block\Link\DelimiterContainer | Class was removed. |
+| Magento\Company\Block\Link\OrdersLink | Class was removed. |
+| Magento\Company\Model\CompanyContext | Class was removed. |
+| Magento\Company\Ui\DataProvider\Roles\DataProvider | Class was removed. |
+| Magento\Company\Ui\DataProvider\Users\DataProvider | Class was removed. |
+| Magento\NegotiableQuoteSharedCatalog\Block\Adminhtml\Quote\View\Info | Class was removed. |
+| Magento\NegotiableQuote\Block\Adminhtml\AdvancedCheckout\Sales\Order\Create\Sku\Add | Class was removed. |
+| Magento\NegotiableQuote\Block\Adminhtml\CustomerEdit\Tab\Grid | Class was removed. |
+| Magento\NegotiableQuote\Block\Adminhtml\Order\Info\Quote | Class was removed. |
+| Magento\NegotiableQuote\Block\Adminhtml\Order\Totals | Class was removed. |
+| Magento\NegotiableQuote\Block\Adminhtml\Quote\Comments | Class was removed. |
+| Magento\NegotiableQuote\Block\Adminhtml\Quote\Create\Form | Class was removed. |
+| Magento\NegotiableQuote\Block\Adminhtml\Quote\Create\Store\Select | Class was removed. |
+| Magento\NegotiableQuote\Block\Adminhtml\Quote\History | Class was removed. |
+| Magento\NegotiableQuote\Block\Adminhtml\Quote\PrintQuote\Negotiation | Class was removed. |
+| Magento\NegotiableQuote\Block\Adminhtml\Quote\PrintQuote\StoreInformation | Class was removed. |
+| Magento\NegotiableQuote\Block\Adminhtml\Quote\PrintQuote\Subtotals | Class was removed. |
+| Magento\NegotiableQuote\Block\Adminhtml\Quote\View | Class was removed. |
+| Magento\NegotiableQuote\Block\Adminhtml\Quote\View\CustomerGroup | Class was removed. |
+| Magento\NegotiableQuote\Block\Adminhtml\Quote\View\Errors\Grid | Class was removed. |
+| Magento\NegotiableQuote\Block\Adminhtml\Quote\View\Errors\GridContainer | Class was removed. |
+| Magento\NegotiableQuote\Block\Adminhtml\Quote\View\Info | Class was removed. |
+| Magento\NegotiableQuote\Block\Adminhtml\Quote\View\Items | Class was removed. |
+| Magento\NegotiableQuote\Block\Adminhtml\Quote\View\Items\Grid | Class was removed. |
+| Magento\NegotiableQuote\Block\Adminhtml\Quote\View\Shipping\Method | Class was removed. |
+| Magento\NegotiableQuote\Block\Adminhtml\Quote\View\Sku | Class was removed. |
+| Magento\NegotiableQuote\Block\Adminhtml\Quote\View\Totals | Class was removed. |
+| Magento\NegotiableQuote\Block\Adminhtml\Quote\View\Totals\Negotiation | Class was removed. |
+| Magento\NegotiableQuote\Block\Adminhtml\Quote\View\Totals\Shipping | Class was removed. |
+| Magento\NegotiableQuote\Block\Adminhtml\Sales\Order\Create\Sku\Errors | Class was removed. |
+| Magento\NegotiableQuote\Block\Checkout\Link | Class was removed. |
+| Magento\NegotiableQuote\Block\Customer\Account\Link\Quote | Class was removed. |
+| Magento\NegotiableQuote\Block\Link\Order | Class was removed. |
+| Magento\NegotiableQuote\Block\Link\Quote | Class was removed. |
+| Magento\NegotiableQuote\Block\Order\CreatedBy | Class was removed. |
+| Magento\NegotiableQuote\Block\Order\Info\CreationInfo | Class was removed. |
+| Magento\NegotiableQuote\Block\Order\Info\Quote | Class was removed. |
+| Magento\NegotiableQuote\Block\Order\OwnerFilter | Class was removed. |
+| Magento\NegotiableQuote\Block\Order\Reorder | Class was removed. |
+| Magento\NegotiableQuote\Block\Quote\Comments | Class was removed. |
+| Magento\NegotiableQuote\Block\Quote\History | Class was removed. |
+| Magento\NegotiableQuote\Block\Quote\Info | Class was removed. |
+| Magento\NegotiableQuote\Block\Quote\Info\Links | Class was removed. |
+| Magento\NegotiableQuote\Block\Quote\Info\Order | Class was removed. |
+| Magento\NegotiableQuote\Block\Quote\Item\Actions\Note | Class was removed. |
+| Magento\NegotiableQuote\Block\Quote\Item\Actions\Remove | Class was removed. |
+| Magento\NegotiableQuote\Block\Quote\Items | Class was removed. |
+| Magento\NegotiableQuote\Block\Quote\Message | Class was removed. |
+| Magento\NegotiableQuote\Block\Quote\PrintQuote\StoreInformation | Class was removed. |
+| Magento\NegotiableQuote\Block\Quote\Success | Class was removed. |
+| Magento\NegotiableQuote\Block\Quote\Totals | Class was removed. |
+| Magento\NegotiableQuote\Block\Quote\Totals\Original | Class was removed. |
+| Magento\NegotiableQuote\Block\Quote\View | Class was removed. |
+| Magento\NegotiableQuote\Model\Quote\ItemRemove | Class was removed. |
+| Magento\NegotiableQuote\Model\Validator\ValidatorResult | Class was removed. |
+| Magento\OrderHistorySearch\Block\Filters | Class was removed. |
+| Magento\OrderHistorySearch\Block\Order\CreatedBy | Class was removed. |
+| Magento\PurchaseOrderRule\Block\Form | Class was removed. |
+| Magento\PurchaseOrderRule\Block\Grid\CreateRuleButton | Class was removed. |
+| Magento\PurchaseOrderRule\Block\PurchaseOrder\ApprovalFlow | Class was removed. |
+| Magento\PurchaseOrderRule\Block\PurchaseOrder\Approval\Counter | Class was removed. |
+| Magento\PurchaseOrderRule\Block\PurchaseOrder\Info\Validate | Class was removed. |
+| Magento\PurchaseOrderRule\Block\RuleFieldset\Condition | Class was removed. |
+| Magento\PurchaseOrderRule\Block\RuleFieldset\ViewCondition | Class was removed. |
+| Magento\PurchaseOrder\Block\Customer\Account\Link | Class was removed. |
+| Magento\PurchaseOrder\Block\Link\PurchaseOrder | Class was removed. |
+| Magento\PurchaseOrder\Block\Order\Info\PurchaseOrder | Class was removed. |
+| Magento\PurchaseOrder\Block\PurchaseOrder\Comments | Class was removed. |
+| Magento\PurchaseOrder\Block\PurchaseOrder\EmailTotals | Class was removed. |
+| Magento\PurchaseOrder\Block\PurchaseOrder\Grid | Class was removed. |
+| Magento\PurchaseOrder\Block\PurchaseOrder\History | Class was removed. |
+| Magento\PurchaseOrder\Block\PurchaseOrder\Info\Banner | Class was removed. |
+| Magento\PurchaseOrder\Block\PurchaseOrder\Info\Buttons | Class was removed. |
+| Magento\PurchaseOrder\Block\PurchaseOrder\Info\Links | Class was removed. |
+| Magento\PurchaseOrder\Block\PurchaseOrder\Info\NegotiableQuote | Class was removed. |
+| Magento\PurchaseOrder\Block\PurchaseOrder\Info\Order | Class was removed. |
+| Magento\PurchaseOrder\Block\PurchaseOrder\Info\Shipping | Class was removed. |
+| Magento\PurchaseOrder\Block\PurchaseOrder\Info\Status | Class was removed. |
+| Magento\PurchaseOrder\Block\PurchaseOrder\Info\Title | Class was removed. |
+| Magento\PurchaseOrder\Block\PurchaseOrder\Items | Class was removed. |
+| Magento\PurchaseOrder\Block\PurchaseOrder\Items\Messages | Class was removed. |
+| Magento\PurchaseOrder\Block\PurchaseOrder\Success | Class was removed. |
+| Magento\PurchaseOrder\Block\PurchaseOrder\Totals | Class was removed. |
+| Magento\PurchaseOrder\Block\PurchaseOrder\Totals\Giftcards | Class was removed. |
+| Magento\PurchaseOrder\Block\PurchaseOrder\Totals\Original | Class was removed. |
+| Magento\PurchaseOrder\Block\PurchaseOrder\View | Class was removed. |
+| Magento\PurchaseOrder\Block\Quote\Info\PurchaseOrder | Class was removed. |
+| Magento\QuickOrder\Block\Link | Class was removed. |
+| Magento\QuickOrder\Block\Sample | Class was removed. |
+| Magento\RequisitionList\Block\Cart\Item\Renderer\Actions\AddToRequisition | Class was removed. |
+| Magento\RequisitionList\Block\Catalog\Product\ProductList\Item\AddTo\Requisition | Class was removed. |
+| Magento\RequisitionList\Block\Catalog\Product\View\Addto\Requisition | Class was removed. |
+| Magento\RequisitionList\Block\Checkout\Cart\Addto\Requisition | Class was removed. |
+| Magento\RequisitionList\Block\Link\Lists | Class was removed. |
+| Magento\RequisitionList\Block\Link\RequisitionListLink | Class was removed. |
+| Magento\RequisitionList\Block\Requisition\Item\Options | Class was removed. |
+| Magento\RequisitionList\Block\Requisition\PrintRequisition\StoreInformation | Class was removed. |
+| Magento\RequisitionList\Block\Requisition\View\Details | Class was removed. |
+| Magento\RequisitionList\Block\Requisition\View\Item | Class was removed. |
+| Magento\RequisitionList\Block\Requisition\View\Items\Grid | Class was removed. |
+| Magento\RequisitionList\Model\RequisitionListItem\Validation | Class was removed. |
+| Magento\RequisitionList\Ui\Component\Listing\Column\Actions | Class was removed. |
+| Magento\RequisitionList\Ui\DataProvider\DataProvider | Class was removed. |
+| Magento\SharedCatalog\Block\Adminhtml\Company\Edit | Class was removed. |
+| Magento\SharedCatalog\Block\Adminhtml\SharedCatalog\Configure\Edit | Class was removed. |
+| Magento\SharedCatalog\Block\Adminhtml\SharedCatalog\Messages\Notification | Class was removed. |
+| Magento\SharedCatalog\Block\Adminhtml\SharedCatalog\Wizard\Container | Class was removed. |
+| Magento\SharedCatalog\Block\Adminhtml\SharedCatalog\Wizard\State | Class was removed. |
+| Magento\SharedCatalog\Block\Adminhtml\SharedCatalog\Wizard\State\Category\Tree | Class was removed. |
+| Magento\SharedCatalog\Block\Adminhtml\SharedCatalog\Wizard\Step\Pricing | Class was removed. |
+| Magento\SharedCatalog\Block\Adminhtml\SharedCatalog\Wizard\Step\Pricing\Category\Tree | Class was removed. |
+| Magento\SharedCatalog\Block\Adminhtml\SharedCatalog\Wizard\Step\Structure | Class was removed. |
+| Magento\SharedCatalog\Block\Adminhtml\SharedCatalog\Wizard\Step\Structure\Category\Tree | Class was removed. |
+| Magento\SharedCatalog\Block\Adminhtml\SharedCatalog\Wizard\StepsWizard | Class was removed. |
+| Magento\SharedCatalog\Block\Adminhtml\SharedCatalog\Wizard\Store\Switcher | Class was removed. |
+
+#### Interface changes {#commerce-BICs-247-247-p1-interface}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\CompanyCredit\Api\CreditBalanceManagementInterface | Interface was removed. |
+| Magento\CompanyCredit\Api\CreditDataProviderInterface | Interface was removed. |
+| Magento\CompanyCredit\Api\CreditHistoryManagementInterface | Interface was removed. |
+| Magento\CompanyCredit\Api\CreditLimitManagementInterface | Interface was removed. |
+| Magento\CompanyCredit\Api\CreditLimitRepositoryInterface | Interface was removed. |
+| Magento\CompanyCredit\Api\Data\CreditBalanceOptionsInterface | Interface was removed. |
+| Magento\CompanyCredit\Api\Data\CreditDataInterface | Interface was removed. |
+| Magento\CompanyCredit\Api\Data\CreditLimitInterface | Interface was removed. |
+| Magento\CompanyCredit\Api\Data\CreditLimitSearchResultsInterface | Interface was removed. |
+| Magento\CompanyCredit\Api\Data\HistoryDataInterface | Interface was removed. |
+| Magento\CompanyCredit\Api\Data\HistorySearchResultsInterface | Interface was removed. |
+| Magento\CompanyCredit\Model\HistoryInterface | Interface was removed. |
+| Magento\CompanyCredit\Model\HistoryRepositoryInterface | Interface was removed. |
+| Magento\Company\Api\AclInterface | Interface was removed. |
+| Magento\Company\Api\AuthorizationInterface | Interface was removed. |
+| Magento\Company\Api\CompanyHierarchyInterface | Interface was removed. |
+| Magento\Company\Api\CompanyManagementInterface | Interface was removed. |
+| Magento\Company\Api\CompanyRepositoryInterface | Interface was removed. |
+| Magento\Company\Api\CompanyUserManagerInterface | Interface was removed. |
+| Magento\Company\Api\Data\CompanyCustomerInterface | Interface was removed. |
+| Magento\Company\Api\Data\CompanyInterface | Interface was removed. |
+| Magento\Company\Api\Data\CompanyOrderInterface | Interface was removed. |
+| Magento\Company\Api\Data\CompanySearchResultsInterface | Interface was removed. |
+| Magento\Company\Api\Data\HierarchyInterface | Interface was removed. |
+| Magento\Company\Api\Data\PermissionInterface | Interface was removed. |
+| Magento\Company\Api\Data\RoleInterface | Interface was removed. |
+| Magento\Company\Api\Data\RoleSearchResultsInterface | Interface was removed. |
+| Magento\Company\Api\Data\StructureInterface | Interface was removed. |
+| Magento\Company\Api\Data\StructureSearchResultsInterface | Interface was removed. |
+| Magento\Company\Api\Data\TeamInterface | Interface was removed. |
+| Magento\Company\Api\Data\TeamSearchResultsInterface | Interface was removed. |
+| Magento\Company\Api\RoleManagementInterface | Interface was removed. |
+| Magento\Company\Api\RoleRepositoryInterface | Interface was removed. |
+| Magento\Company\Api\StatusServiceInterface | Interface was removed. |
+| Magento\Company\Api\TeamRepositoryInterface | Interface was removed. |
+| Magento\Company\Model\Customer\PermissionInterface | Interface was removed. |
+| Magento\Company\Model\PermissionManagementInterface | Interface was removed. |
+| Magento\Company\Model\SaveHandlerInterface | Interface was removed. |
+| Magento\Company\Model\SaveValidatorInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\AttachmentContentManagementInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\BillingAddressManagementInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\CartTotalRepositoryInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\CommentLocatorInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\CompanyQuoteConfigManagementInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\CompanyQuoteConfigRepositoryInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\CouponManagementInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\Data\AttachmentContentInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\Data\CommentAttachmentInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\Data\CommentInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\Data\CompanyQuoteConfigInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\Data\HistoryInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\Data\ItemNoteInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\Data\ItemNoteSearchResultsInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\Data\NegotiableQuoteInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\Data\NegotiableQuoteItemInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\Data\NegotiableQuoteItemTotalsInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\Data\NegotiableQuoteTotalsInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\GiftCardAccountManagementInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\ItemNoteRepositoryInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\NegotiableCartRepositoryInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\NegotiableQuoteDraftManagementInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\NegotiableQuoteItemManagementInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\NegotiableQuoteItemRepositoryInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\NegotiableQuoteManagementInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\NegotiableQuotePriceManagementInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\NegotiableQuoteRepositoryInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\NegotiableQuoteShippingManagementInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\PaymentInformationManagementInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\ShipmentEstimationInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\ShippingInformationManagementInterface | Interface was removed. |
+| Magento\NegotiableQuote\Api\ShippingMethodManagementInterface | Interface was removed. |
+| Magento\NegotiableQuote\Model\Attachment\DownloadPermission\AllowInterface | Interface was removed. |
+| Magento\NegotiableQuote\Model\CommentManagementInterface | Interface was removed. |
+| Magento\NegotiableQuote\Model\CommentRepositoryInterface | Interface was removed. |
+| Magento\NegotiableQuote\Model\EmailSenderInterface | Interface was removed. |
+| Magento\NegotiableQuote\Model\HistoryManagementInterface | Interface was removed. |
+| Magento\NegotiableQuote\Model\HistoryRepositoryInterface | Interface was removed. |
+| Magento\NegotiableQuote\Model\ProductOptionsProviderInterface | Interface was removed. |
+| Magento\NegotiableQuote\Model\Quote\ViewAccessInterface | Interface was removed. |
+| Magento\NegotiableQuote\Model\ResourceModel\QuoteGridInterface | Interface was removed. |
+| Magento\NegotiableQuote\Model\Restriction\RestrictionInterface | Interface was removed. |
+| Magento\NegotiableQuote\Model\Status\LabelProviderInterface | Interface was removed. |
+| Magento\NegotiableQuote\Model\Validator\ValidatorInterface | Interface was removed. |
+| Magento\OrderHistorySearch\Model\Filter\FilterInterface | Interface was removed. |
+| Magento\PurchaseOrderRule\Api\AppliedRuleApproverRepositoryInterface | Interface was removed. |
+| Magento\PurchaseOrderRule\Api\AppliedRuleRepositoryInterface | Interface was removed. |
+| Magento\PurchaseOrderRule\Api\Data\AppliedRuleApproverInterface | Interface was removed. |
+| Magento\PurchaseOrderRule\Api\Data\AppliedRuleApproverSearchResultsInterface | Interface was removed. |
+| Magento\PurchaseOrderRule\Api\Data\AppliedRuleInterface | Interface was removed. |
+| Magento\PurchaseOrderRule\Api\Data\AppliedRuleSearchResultsInterface | Interface was removed. |
+| Magento\PurchaseOrderRule\Api\Data\RuleInterface | Interface was removed. |
+| Magento\PurchaseOrderRule\Api\Data\RuleSearchResultsInterface | Interface was removed. |
+| Magento\PurchaseOrderRule\Api\RuleRepositoryInterface | Interface was removed. |
+| Magento\PurchaseOrderRule\Model\Rule\ConditionInterface | Interface was removed. |
+| Magento\PurchaseOrderRule\Model\Rule\ValidateInterface | Interface was removed. |
+| Magento\PurchaseOrder\Api\Data\CommentInterface | Interface was removed. |
+| Magento\PurchaseOrder\Api\Data\PurchaseOrderInterface | Interface was removed. |
+| Magento\PurchaseOrder\Api\Data\PurchaseOrderLogInterface | Interface was removed. |
+| Magento\PurchaseOrder\Api\Data\PurchaseOrderSearchResultsInterface | Interface was removed. |
+| Magento\PurchaseOrder\Api\PurchaseOrderManagementInterface | Interface was removed. |
+| Magento\PurchaseOrder\Api\PurchaseOrderPaymentInformationManagementInterface | Interface was removed. |
+| Magento\PurchaseOrder\Api\PurchaseOrderRepositoryInterface | Interface was removed. |
+| Magento\PurchaseOrder\Model\CommentRepositoryInterface | Interface was removed. |
+| Magento\PurchaseOrder\Model\Company\ConfigInterface | Interface was removed. |
+| Magento\PurchaseOrder\Model\Company\Config\RepositoryInterface | Interface was removed. |
+| Magento\PurchaseOrder\Model\Customer\Authorization\ActionInterface | Interface was removed. |
+| Magento\PurchaseOrder\Model\Notification\ActionNotificationInterface | Interface was removed. |
+| Magento\PurchaseOrder\Model\Notification\Action\Recipient\ResolverInterface | Interface was removed. |
+| Magento\PurchaseOrder\Model\Notification\Config\ProviderInterface | Interface was removed. |
+| Magento\PurchaseOrder\Model\Notification\ContentSourceInterface | Interface was removed. |
+| Magento\PurchaseOrder\Model\Notification\NotifierInterface | Interface was removed. |
+| Magento\PurchaseOrder\Model\Notification\SenderInterface | Interface was removed. |
+| Magento\PurchaseOrder\Model\Payment\DeferredPaymentStrategyInterface | Interface was removed. |
+| Magento\PurchaseOrder\Model\ProcessorInterface | Interface was removed. |
+| Magento\PurchaseOrder\Model\Processor\ApprovalProcessorInterface | Interface was removed. |
+| Magento\PurchaseOrder\Model\PurchaseOrderLogRepositoryInterface | Interface was removed. |
+| Magento\PurchaseOrder\Model\PurchaseOrder\LogManagementInterface | Interface was removed. |
+| Magento\PurchaseOrder\Model\Validator\ActionReady\ValidatorInterface | Interface was removed. |
+| Magento\PurchaseOrder\Model\Validator\ValidatorInterface | Interface was removed. |
+| Magento\RequisitionList\Api\Data\RequisitionListInterface | Interface was removed. |
+| Magento\RequisitionList\Api\Data\RequisitionListItemInterface | Interface was removed. |
+| Magento\RequisitionList\Api\RequisitionListManagementInterface | Interface was removed. |
+| Magento\RequisitionList\Api\RequisitionListRepositoryInterface | Interface was removed. |
+| Magento\RequisitionList\Model\AddToCartProcessorInterface | Interface was removed. |
+| Magento\RequisitionList\Model\Checker\ProductQtyChangeAvailabilityInterface | Interface was removed. |
+| Magento\RequisitionList\Model\RequisitionListItem\ValidatorInterface | Interface was removed. |
+| Magento\SharedCatalog\Api\AssignTierPriceInterface | Interface was removed. |
+| Magento\SharedCatalog\Api\CategoryManagementInterface | Interface was removed. |
+| Magento\SharedCatalog\Api\CompanyManagementInterface | Interface was removed. |
+| Magento\SharedCatalog\Api\Data\PermissionInterface | Interface was removed. |
+| Magento\SharedCatalog\Api\Data\ProductItemInterface | Interface was removed. |
+| Magento\SharedCatalog\Api\Data\ProductItemSearchResultsInterface | Interface was removed. |
+| Magento\SharedCatalog\Api\Data\SearchResultsInterface | Interface was removed. |
+| Magento\SharedCatalog\Api\Data\SharedCatalogInterface | Interface was removed. |
+| Magento\SharedCatalog\Api\Data\ValidationResultsInterface | Interface was removed. |
+| Magento\SharedCatalog\Api\PriceManagementInterface | Interface was removed. |
+| Magento\SharedCatalog\Api\ProductItemManagementInterface | Interface was removed. |
+| Magento\SharedCatalog\Api\ProductItemRepositoryInterface | Interface was removed. |
+| Magento\SharedCatalog\Api\ProductManagementInterface | Interface was removed. |
+| Magento\SharedCatalog\Api\ResetTierPriceInterface | Interface was removed. |
+| Magento\SharedCatalog\Api\SharedCatalogDuplicationInterface | Interface was removed. |
+| Magento\SharedCatalog\Api\SharedCatalogManagementInterface | Interface was removed. |
+| Magento\SharedCatalog\Api\SharedCatalogRepositoryInterface | Interface was removed. |
+| Magento\SharedCatalog\Api\StatusInfoInterface | Interface was removed. |
+| Magento\SharedCatalog\Model\Configure\Category\Tree\RendererInterface | Interface was removed. |
+
+#### Database changes {#commerce-BICs-247-247-p1-database}
+
+| What changed | How it changed |
+| --- | --- |
+| company | Module db schema whitelist reduced (company). |
+| company | Table was dropped |
+| company\_advanced\_customer\_entity | Module db schema whitelist reduced (company\_advanced\_customer\_entity). |
+| company\_advanced\_customer\_entity | Table was dropped |
+| company\_credit | Module db schema whitelist reduced (company\_credit). |
+| company\_credit | Table was dropped |
+| company\_credit\_history | Module db schema whitelist reduced (company\_credit\_history). |
+| company\_credit\_history | Table was dropped |
+| company\_order\_entity | Module db schema whitelist reduced (company\_order\_entity). |
+| company\_order\_entity | Table was dropped |
+| company\_payment | Module db schema whitelist reduced (company\_payment). |
+| company\_payment | Table was dropped |
+| company\_permissions | Module db schema whitelist reduced (company\_permissions). |
+| company\_permissions | Table was dropped |
+| company\_roles | Module db schema whitelist reduced (company\_roles). |
+| company\_roles | Table was dropped |
+| company\_shipping | Module db schema whitelist reduced (company\_shipping). |
+| company\_shipping | Table was dropped |
+| company\_structure | Module db schema whitelist reduced (company\_structure). |
+| company\_structure | Table was dropped |
+| company\_team | Module db schema whitelist reduced (company\_team). |
+| company\_team | Table was dropped |
+| company\_user\_roles | Module db schema whitelist reduced (company\_user\_roles). |
+| company\_user\_roles | Table was dropped |
+| negotiable\_quote | Module db schema whitelist reduced (negotiable\_quote). |
+| negotiable\_quote | Table was dropped |
+| negotiable\_quote\_comment | Module db schema whitelist reduced (negotiable\_quote\_comment). |
+| negotiable\_quote\_comment | Table was dropped |
+| negotiable\_quote\_comment\_attachment | Module db schema whitelist reduced (negotiable\_quote\_comment\_attachment). |
+| negotiable\_quote\_comment\_attachment | Table was dropped |
+| negotiable\_quote\_company\_config | Module db schema whitelist reduced (negotiable\_quote\_company\_config). |
+| negotiable\_quote\_company\_config | Table was dropped |
+| negotiable\_quote\_grid | Module db schema whitelist reduced (negotiable\_quote\_grid). |
+| negotiable\_quote\_grid | Table was dropped |
+| negotiable\_quote\_history | Module db schema whitelist reduced (negotiable\_quote\_history). |
+| negotiable\_quote\_history | Table was dropped |
+| negotiable\_quote\_item | Module db schema whitelist reduced (negotiable\_quote\_item). |
+| negotiable\_quote\_item | Table was dropped |
+| negotiable\_quote\_item\_note | Module db schema whitelist reduced (negotiable\_quote\_item\_note). |
+| negotiable\_quote\_item\_note | Table was dropped |
+| negotiable\_quote\_purged\_content | Module db schema whitelist reduced (negotiable\_quote\_purged\_content). |
+| negotiable\_quote\_purged\_content | Table was dropped |
+| purchase\_order | Module db schema whitelist reduced (purchase\_order). |
+| purchase\_order | Table was dropped |
+| purchase\_order\_applied\_rule | Module db schema whitelist reduced (purchase\_order\_applied\_rule). |
+| purchase\_order\_applied\_rule | Table was dropped |
+| purchase\_order\_applied\_rule\_approver | Module db schema whitelist reduced (purchase\_order\_applied\_rule\_approver). |
+| purchase\_order\_applied\_rule\_approver | Table was dropped |
+| purchase\_order\_approved\_by | Module db schema whitelist reduced (purchase\_order\_approved\_by). |
+| purchase\_order\_approved\_by | Table was dropped |
+| purchase\_order\_comment | Module db schema whitelist reduced (purchase\_order\_comment). |
+| purchase\_order\_comment | Table was dropped |
+| purchase\_order\_company\_config | Module db schema whitelist reduced (purchase\_order\_company\_config). |
+| purchase\_order\_company\_config | Table was dropped |
+| purchase\_order\_log | Module db schema whitelist reduced (purchase\_order\_log). |
+| purchase\_order\_log | Table was dropped |
+| purchase\_order\_rule | Module db schema whitelist reduced (purchase\_order\_rule). |
+| purchase\_order\_rule | Table was dropped |
+| purchase\_order\_rule\_applies\_to | Module db schema whitelist reduced (purchase\_order\_rule\_applies\_to). |
+| purchase\_order\_rule\_applies\_to | Table was dropped |
+| purchase\_order\_rule\_approver | Module db schema whitelist reduced (purchase\_order\_rule\_approver). |
+| purchase\_order\_rule\_approver | Table was dropped |
+| requisition\_list | Module db schema whitelist reduced (requisition\_list). |
+| requisition\_list | Table was dropped |
+| requisition\_list\_item | Module db schema whitelist reduced (requisition\_list\_item). |
+| requisition\_list\_item | Table was dropped |
+| shared\_catalog | Module db schema whitelist reduced (shared\_catalog). |
+| shared\_catalog | Table was dropped |
+| shared\_catalog\_product\_item | Module db schema whitelist reduced (shared\_catalog\_product\_item). |
+| shared\_catalog\_product\_item | Table was dropped |
+| sharedcatalog\_category\_permissions | Module db schema whitelist reduced (sharedcatalog\_category\_permissions). |
+| sharedcatalog\_category\_permissions | Table was dropped |
+
+#### Di changes {#commerce-BICs-247-247-p1-di}
+
+| What changed | How it changed |
+| --- | --- |
+| CompanyCreditCommandPool | Virtual Type was removed |
+| CompanyCreditConfig | Virtual Type was removed |
+| CompanyCreditCountryValidator | Virtual Type was removed |
+| CompanyCreditDefaultValueHandler | Virtual Type was removed |
+| CompanyCreditFacade | Virtual Type was removed |
+| CompanyCreditValidatorPool | Virtual Type was removed |
+| CompanyCreditValueHandlerPool | Virtual Type was removed |
+| CompanyGirdFilterPool | Virtual Type was removed |
+| CompanyProvider | Virtual Type was removed |
+| Magento\Catalog\Model\Api\SearchCriteria\CollectionProcessor\ProductFilterProcessor | Virtual Type was removed |
+| Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Pool | Virtual Type was removed |
+| Magento\Catalog\Ui\DataProvider\Product\Listing\Modifier\Pool | Virtual Type was removed |
+| Magento\Company\Acl\AclResource\Config\Reader\Filesystem | Virtual Type was removed |
+| Magento\Company\Acl\AclResource\Provider | Virtual Type was removed |
+| Magento\Company\Acl\Cache | Virtual Type was removed |
+| Magento\Company\Acl\RootResource | Virtual Type was removed |
+| Magento\Company\Authorization\Acl\Builder | Virtual Type was removed |
+| Magento\Company\Authorization\Loader\ResourceLoader | Virtual Type was removed |
+| Magento\Company\Model\Create\Session\Storage | Virtual Type was removed |
+| Magento\NegotiableQuoteGraphQl\Helper\Error\PlaceNegotiableQuoteOrderMessageFormatter | Virtual Type was removed |
+| Magento\NegotiableQuote\Model\ResourceModel\Grid\Collection | Virtual Type was removed |
+| Magento\NegotiableQuote\Model\ResourceModel\Items\Grid\Collection | Virtual Type was removed |
+| Magento\NegotiableQuote\Model\Validator\Message\CustomerIsNotAssignedToWebsite | Virtual Type was removed |
+| Magento\NegotiableQuote\Model\Validator\Message\CustomerIsNotAssociatedWithCompany | Virtual Type was removed |
+| Magento\NegotiableQuote\Model\Validator\Message\DisabledStore | Virtual Type was removed |
+| Magento\NegotiableQuote\Model\Validator\Message\InactiveB2BQuoting | Virtual Type was removed |
+| Magento\NegotiableQuote\Model\Validator\Message\InactiveCustomer | Virtual Type was removed |
+| Magento\NegotiableQuote\Model\Validator\Message\UnacceptableCompanyStatus | Virtual Type was removed |
+| Magento\PurchaseOrderRule\Block\RuleFieldset\ShippingAmount | Virtual Type was removed |
+| Magento\PurchaseOrderRule\Block\RuleFieldset\TotalUnique | Virtual Type was removed |
+| Magento\PurchaseOrderRule\Block\RuleFieldset\ViewShippingAmount | Virtual Type was removed |
+| Magento\PurchaseOrderRule\Block\RuleFieldset\ViewTotalUnique | Virtual Type was removed |
+| Magento\PurchaseOrderRule\Model\Api\SearchCriteria\CollectionProcessor\RuleFilterProcessor | Virtual Type was removed |
+| Magento\PurchaseOrderRule\Model\Api\SearchCriteria\RuleCollectionProcessor | Virtual Type was removed |
+| Magento\SharedCatalog\Ui\DataProvider\Modifier\GridPool | Virtual Type was removed |
+| Magento\SharedCatalog\Ui\DataProvider\Modifier\Pool | Virtual Type was removed |
+| Magento\SharedCatalog\Ui\DataProvider\Modifier\SharedCatalogPool | Virtual Type was removed |
+| SharedCatalogDataProvider | Virtual Type was removed |
+| SharedCatalogGirdFilterPool | Virtual Type was removed |
+| approvalProcessorComposite | Virtual Type was removed |
+| myPurchaseOrderCollection | Virtual Type was removed |
+| placePoValidatorComposite | Virtual Type was removed |
+| sharedCatalogCompaniesSession | Virtual Type was removed |
+| sharedCatalogWizardSession | Virtual Type was removed |
+
+#### Layout changes {#commerce-BICs-247-247-p1-layout}
+
+| What changed | How it changed |
+| --- | --- |
+| CATALOG\_PRODUCT\_COMPOSITE\_CONFIGURE | An Update was removed |
+| additional\_area | Block was removed |
+| additional\_area.add | Block was removed |
+| adminhtml.customer.edit.tab.quotes | Block was removed |
+| adminhtml.customer.grid.columnSet.company\_name | Block was removed |
+| adminhtml.customer.grid.columnSet.customer\_type | Block was removed |
+| after.body.start.create.quote | Block was removed |
+| after.body.start.product\_composite\_configure | Block was removed |
+| approval.count | Block was removed |
+| b2blinks | Block was removed |
+| bundle.back.button | Block was removed |
+| bundle.options.container | Container was removed |
+| bundle.product.view.options.notice | Block was removed |
+| bundle.summary | Block was removed |
+| captcha | Block was removed |
+| captcha\_page\_head\_components | Block was removed |
+| catalog-steps-wizard | Block was removed |
+| catalog.configure.state | Block was removed |
+| catalog.configure.state.category.tree | Block was removed |
+| catalog.configure.state.store | Block was removed |
+| catalog\_product\_view | An Update was removed |
+| catalog\_product\_view\_type\_bundle | An Update was removed |
+| catalog\_product\_view\_type\_configurable | An Update was removed |
+| catalog\_product\_view\_type\_giftcard | An Update was removed |
+| catalogsearch.product.addto.requisition | Block was removed |
+| category.product.addto.requisition | Block was removed |
+| category.tree | Block was removed |
+| checkout.cart.item.renderers | Block was removed |
+| checkout.cart.item.renderers.bundle | Block was removed |
+| checkout.cart.item.renderers.bundle.actions | Block was removed |
+| checkout.cart.item.renderers.bundle.actions.add\_to\_requisition\_list | Block was removed |
+| checkout.cart.item.renderers.bundle.actions.note | Block was removed |
+| checkout.cart.item.renderers.bundle.actions.remove | Block was removed |
+| checkout.cart.item.renderers.bundle.item\_notes | Block was removed |
+| checkout.cart.item.renderers.configurable | Block was removed |
+| checkout.cart.item.renderers.configurable.actions | Block was removed |
+| checkout.cart.item.renderers.configurable.actions.add\_to\_requisition\_list | Block was removed |
+| checkout.cart.item.renderers.configurable.actions.note | Block was removed |
+| checkout.cart.item.renderers.configurable.actions.remove | Block was removed |
+| checkout.cart.item.renderers.configurable.item\_notes | Block was removed |
+| checkout.cart.item.renderers.default | Block was removed |
+| checkout.cart.item.renderers.default.actions | Block was removed |
+| checkout.cart.item.renderers.default.actions.add\_to\_requisition\_list | Block was removed |
+| checkout.cart.item.renderers.default.actions.note | Block was removed |
+| checkout.cart.item.renderers.default.actions.remove | Block was removed |
+| checkout.cart.item.renderers.default.item\_notes | Block was removed |
+| checkout.cart.item.renderers.downloadable | Block was removed |
+| checkout.cart.item.renderers.downloadable.actions | Block was removed |
+| checkout.cart.item.renderers.downloadable.actions.add\_to\_requisition\_list | Block was removed |
+| checkout.cart.item.renderers.downloadable.actions.note | Block was removed |
+| checkout.cart.item.renderers.downloadable.actions.remove | Block was removed |
+| checkout.cart.item.renderers.downloadable.item\_notes | Block was removed |
+| checkout.cart.item.renderers.gift-card.actions.add\_to\_requisition\_list | Block was removed |
+| checkout.cart.item.renderers.giftcard | Block was removed |
+| checkout.cart.item.renderers.giftcard.actions | Block was removed |
+| checkout.cart.item.renderers.giftcard.actions.note | Block was removed |
+| checkout.cart.item.renderers.giftcard.actions.remove | Block was removed |
+| checkout.cart.item.renderers.giftcard.item\_notes | Block was removed |
+| checkout.cart.item.renderers.grouped | Block was removed |
+| checkout.cart.item.renderers.grouped.actions | Block was removed |
+| checkout.cart.item.renderers.grouped.actions.add\_to\_requisition\_list | Block was removed |
+| checkout.cart.item.renderers.grouped.actions.note | Block was removed |
+| checkout.cart.item.renderers.grouped.actions.remove | Block was removed |
+| checkout.cart.item.renderers.grouped.item\_notes | Block was removed |
+| checkout.cart.item.renderers.messages | Block was removed |
+| checkout.cart.item.renderers.simple | Block was removed |
+| checkout.cart.item.renderers.simple.actions | Block was removed |
+| checkout.cart.item.renderers.simple.actions.add\_to\_requisition\_list | Block was removed |
+| checkout.cart.item.renderers.simple.actions.note | Block was removed |
+| checkout.cart.item.renderers.simple.actions.remove | Block was removed |
+| checkout.cart.item.renderers.simple.item\_notes | Block was removed |
+| checkout.cart.item.renderers.virtual.actions.add\_to\_requisition\_list | Block was removed |
+| checkout.cart.items.add.to.requisition.desktop | Block was removed |
+| checkout.cart.items.add.to.requisition.mobile | Block was removed |
+| checkout.cart.methods.request.quote | Block was removed |
+| checkout.cart.order.actions | Block was removed |
+| checkout.customer.sku | Block was removed |
+| checkout.customer.sku.quick\_order\_advancedcheckout\_file | Block was removed |
+| checkout.customer.sku.quick\_order\_multipleskus | Block was removed |
+| checkout\_item\_price\_renderers | An Update was removed |
+| comment.form | Block was removed |
+| company-credit-customer-account-navigation-delimiter-b2b | Block was removed |
+| company-credit-history-balance | Block was removed |
+| company-customer-account-navigation-orders-link | Block was removed |
+| company.account.create.wrapper | Block was removed |
+| company.container | Container was removed |
+| company.container.actions\_popup | Container was removed |
+| company.link | Block was removed |
+| company.management.dialog.alert.alert | Block was removed |
+| company.management.dialog.customer.add | Block was removed |
+| company.management.dialog.customer.users\_actions\_popup | Block was removed |
+| company.management.dialog.delete.del | Block was removed |
+| company.management.dialog.team.add | Block was removed |
+| company.management.info | Block was removed |
+| company.new | Block was removed |
+| company.new.wrapper | Block was removed |
+| company\_account\_create | Block was removed |
+| company\_credit\_message | Block was removed |
+| company\_index\_edit | An Update was removed |
+| company\_management | Block was removed |
+| company\_notice\_blocked | Block was removed |
+| company\_payment\_method | Block was removed |
+| company\_profile | Block was removed |
+| company\_profile\_edit\_link | Block was removed |
+| company\_shipping\_method | Block was removed |
+| companycredit\_cancel\_confirmation | Block was removed |
+| copyright | Block was removed |
+| crosssell.product.addto.requisition | Block was removed |
+| customer-account-navigation-company-credit-history-link | Block was removed |
+| customer-account-navigation-company-link | Block was removed |
+| customer-account-navigation-company-profile-link | Block was removed |
+| customer-account-navigation-company-roles-link | Block was removed |
+| customer-account-navigation-company-users-link | Block was removed |
+| customer-account-navigation-delimiter-b2b | Block was removed |
+| customer-account-navigation-delimiter-container-b2b | Block was removed |
+| customer-account-navigation-purchase-order-rule-link | Block was removed |
+| customer-account-navigation-purchaseorder-link | Block was removed |
+| customer-account-navigation-quotes-link | Block was removed |
+| customer-account-navigation-requisition-list-link | Block was removed |
+| customer.form.edit.fields.before.in.form | Container was removed |
+| customer.grid.container | Block was removed |
+| customer.group.extra.data | Block was removed |
+| customer\_account | An Update was removed |
+| customer\_account\_dashboard\_info\_role | Block was removed |
+| customer\_account\_reorder | Block was removed |
+| customer\_form\_template\_handle | An Update was removed |
+| customer\_form\_user\_attributes | Block was removed |
+| customer\_form\_user\_attributes\_create | Block was removed |
+| customer\_form\_user\_attributes\_edit | Block was removed |
+| customize.button | Block was removed |
+| diff.values | Block was removed |
+| errors | Block was removed |
+| extended\_customer\_edit | Block was removed |
+| extended\_personal\_info | Block was removed |
+| form | Block was removed |
+| form.additional.info | Container was removed |
+| grid.buttons | Block was removed |
+| head.components.requisition | Block was removed |
+| html\_calendar | Block was removed |
+| massaction.copy | Block was removed |
+| massaction.move | Block was removed |
+| massaction.remove | Block was removed |
+| negotiable.quote.addbysku | Block was removed |
+| negotiable.quote.comments | Block was removed |
+| negotiable.quote.edit | Block was removed |
+| negotiable.quote.errors.grid | Block was removed |
+| negotiable.quote.history | Block was removed |
+| negotiable.quote.info | Block was removed |
+| negotiable.quote.info.buttons | Block was removed |
+| negotiable.quote.info.extra.container | Block was removed |
+| negotiable.quote.info.links | Block was removed |
+| negotiable.quote.info.order | Block was removed |
+| negotiable.quote.info.purchase.order | Block was removed |
+| negotiable.quote.items | Block was removed |
+| negotiable.quote.items.grid | Block was removed |
+| negotiable.quote.items.grid-actions | Block was removed |
+| negotiable.quote.items.grid.print | Block was removed |
+| negotiable.quote.message | Block was removed |
+| negotiable.quote.shipping | Block was removed |
+| negotiable.quote.shipping.form | Block was removed |
+| negotiable.quote.subtotals | Block was removed |
+| negotiable.quote.success | Block was removed |
+| negotiable.quote.totals | Block was removed |
+| negotiable.quote.totals.negotiation | Block was removed |
+| negotiable.quote.totals.original | Block was removed |
+| negotiable.quote.totals.shipping | Block was removed |
+| negotiable.quote.totals.subtotals | Block was removed |
+| negotiable\_quote\_create\_customer\_block | An Update was removed |
+| order.info.quote | Block was removed |
+| order.list.link | Block was removed |
+| order.references.container | Container was removed |
+| order.total.catalog.price | Block was removed |
+| order\_company\_info | Block was removed |
+| po.checkout.success | Block was removed |
+| print | An Update was removed |
+| product.composite.fieldset | Block was removed |
+| product.composite.fieldset.bundle | Block was removed |
+| product.composite.fieldset.configurable | Block was removed |
+| product.composite.fieldset.giftcard | Block was removed |
+| product.composite.fieldset.options | Block was removed |
+| product.composite.fieldset.options.date | Block was removed |
+| product.composite.fieldset.options.default | Block was removed |
+| product.composite.fieldset.options.file | Block was removed |
+| product.composite.fieldset.options.select | Block was removed |
+| product.composite.fieldset.options.text | Block was removed |
+| product.composite.fieldset.qty | Block was removed |
+| product.composite.giftcard.qty | Block was removed |
+| product.info.addto.bundle | Block was removed |
+| product.info.addtocart.bundle | Block was removed |
+| product.info.bundle | Block was removed |
+| product.info.bundle.extra | Container was removed |
+| product.info.bundle.options | Block was removed |
+| product.info.bundle.options.checkbox | Block was removed |
+| product.info.bundle.options.multi | Block was removed |
+| product.info.bundle.options.radio | Block was removed |
+| product.info.bundle.options.select | Block was removed |
+| product.info.bundle.options.top | Container was removed |
+| product.info.configurable | Block was removed |
+| product.info.configurable.extra | Container was removed |
+| product.info.options.configurable | Block was removed |
+| product.info.qtyincrements | Block was removed |
+| product.price.render.bundle.customization | Block was removed |
+| product.price.render.default | Block was removed |
+| purchase.order.action.additem | Block was removed |
+| purchase.order.actions.container | Container was removed |
+| purchase.order.comments.form | Block was removed |
+| purchase.order.email.details | Block was removed |
+| purchase.order.email.items | Block was removed |
+| purchase.order.email.shipping | Block was removed |
+| purchase.order.email.title | Block was removed |
+| purchase.order.email.totals | Block was removed |
+| purchase.order.index.approval | Block was removed |
+| purchase.order.index.company | Block was removed |
+| purchase.order.index.my | Block was removed |
+| purchase.order.index.view | Block was removed |
+| purchase.order.info | Block was removed |
+| purchase.order.info.buttons | Block was removed |
+| purchase.order.info.buttons.additional | Block was removed |
+| purchase.order.info.links | Block was removed |
+| purchase.order.info.negotiable.quote | Block was removed |
+| purchase.order.info.order | Block was removed |
+| purchase.order.info.validate | Block was removed |
+| purchase.order.payment.banner | Block was removed |
+| purchase.order.references.container | Container was removed |
+| purchase.order.rules.view.approval.flow | Block was removed |
+| purchase.order.status | Block was removed |
+| purchase.order.title | Block was removed |
+| purchase.order.totals | Block was removed |
+| purchase.order.totals.giftcards | Block was removed |
+| purchase.order.totals.original | Block was removed |
+| purchase.order.view | Block was removed |
+| purchase.order.view.comments | Block was removed |
+| purchase.order.view.history.log | Block was removed |
+| purchase.order.view.items | Block was removed |
+| purchaseorder.list.link | Block was removed |
+| purchaseorderrule\_create\_rule\_button | Block was removed |
+| purchaseorderrule\_create\_rule\_form | Block was removed |
+| purchaseorderrule\_form | An Update was removed |
+| purchaseorderrule\_info | An Update was removed |
+| purchaseorderrule\_rule\_item\_qty | Block was removed |
+| purchaseorderrule\_rule\_order\_total | Block was removed |
+| purchaseorderrule\_rule\_shipping\_cost | Block was removed |
+| purchaseorderrule\_rule\_view | Block was removed |
+| quick\_order\_download\_template\_link | Block was removed |
+| quick\_order\_link | Block was removed |
+| quote.actions.container | Container was removed |
+| quote.address | Block was removed |
+| quote.create.form | Block was removed |
+| quote.create.form.store | Block was removed |
+| quote.date | Block was removed |
+| quote.list.link | Block was removed |
+| quote.message | Block was removed |
+| quote.negotiation | Block was removed |
+| quote.references.container | Container was removed |
+| quote.status | Block was removed |
+| quote.view | Block was removed |
+| quote\_comments | Block was removed |
+| quote\_history | Block was removed |
+| quote\_info | Block was removed |
+| quote\_items | Block was removed |
+| quote\_items.item\_popup | Block was removed |
+| quote\_subtotals | Block was removed |
+| quote\_totals | Block was removed |
+| recaptcha | Block was removed |
+| register.company.link | Block was removed |
+| register.customer.link | Block was removed |
+| register.link.container | Block was removed |
+| related.product.addto.requisition | Block was removed |
+| requisition.create | Block was removed |
+| requisition.items.buttons | Block was removed |
+| requisition.items.grid | Block was removed |
+| requisition.list.export | Block was removed |
+| requisition.list.item.options | Block was removed |
+| requisition.list.item.view | Block was removed |
+| requisition.list.link | Block was removed |
+| requisition.list.print | Block was removed |
+| requisition.list.title | Block was removed |
+| requisition.list.toolbar | Block was removed |
+| requisition.list.toolbar.massactions | Container was removed |
+| requisition.management | Block was removed |
+| requisition\_list | An Update was removed |
+| role.form | Block was removed |
+| root | Container was removed |
+| sales.order.history.filters | Block was removed |
+| sales.order.info.button.requisition.add | Block was removed |
+| sales.order.info.purchase.order | Block was removed |
+| sales.order.quote.container | Container was removed |
+| sales.order.view.creation\_info | Block was removed |
+| sales.order.view.quote | Block was removed |
+| sales\_order\_create\_customer\_block | An Update was removed |
+| sales\_order\_createdby\_data | Block was removed |
+| sales\_order\_createdby\_header | Block was removed |
+| sales\_order\_history\_reorder | Block was removed |
+| sales\_order\_view\_reorder | Block was removed |
+| shared.configure | Block was removed |
+| sharedCatalog.messages.notification | Block was removed |
+| sharedCatalog.messages.notification.wizard | Block was removed |
+| shared\_catalog\_sharedcatalog\_edit | An Update was removed |
+| show.all.orders.link | Block was removed |
+| sku\_error\_grid | Block was removed |
+| sku\_error\_grid.columnSet | Block was removed |
+| sku\_error\_grid.columnSet.description | Block was removed |
+| sku\_error\_grid.columnSet.price | Block was removed |
+| sku\_error\_grid.columnSet.qty | Block was removed |
+| sku\_error\_grid.columnSet.remove | Block was removed |
+| step.pricing.category.tree | Block was removed |
+| step.pricing.sidebar.left | Container was removed |
+| step.pricing.sidebar.listing | Container was removed |
+| step.pricing.store.switcher | Block was removed |
+| step.structure.sidebar.left | Container was removed |
+| step.structure.sidebar.listing | Container was removed |
+| step.structure.store.switcher | Block was removed |
+| step\_pricing | Block was removed |
+| step\_structure | Block was removed |
+| store.name | Block was removed |
+| store.phone | Block was removed |
+| styles | An Update was removed |
+| upsell.product.addto.requisition | Block was removed |
+| view.addto.compare.bundle | Block was removed |
+| view.addto.requisition | Block was removed |
+| view.addto.requisition.bundle | Block was removed |
+| view.addto.wishlist.bundle | Block was removed |
+| wizard-container | Block was removed |
+
+#### System changes {#commerce-BICs-247-247-p1-system}
+
+| What changed | How it changed |
+| --- | --- |
+| btob | a section-node was removed |
+| btob/order\_approval | A group-node was removed |
+| btob/order\_approval/purchaseorder\_active | A field-node was removed |
+| btob/website\_configuration | A group-node was removed |
+| btob/website\_configuration/company\_active | A field-node was removed |
+| btob/website\_configuration/default\_b2b\_payment\_methods | A group-node was removed |
+| btob/website\_configuration/default\_b2b\_payment\_methods/applicable\_payment\_methods | A field-node was removed |
+| btob/website\_configuration/default\_b2b\_payment\_methods/available\_payment\_methods | A field-node was removed |
+| btob/website\_configuration/default\_b2b\_shipping\_methods | A group-node was removed |
+| btob/website\_configuration/default\_b2b\_shipping\_methods/applicable\_shipping\_methods | A field-node was removed |
+| btob/website\_configuration/default\_b2b\_shipping\_methods/available\_shipping\_methods | A field-node was removed |
+| btob/website\_configuration/direct\_products\_price\_assigning | A field-node was removed |
+| btob/website\_configuration/negotiablequote\_active | A field-node was removed |
+| btob/website\_configuration/quickorder\_active | A field-node was removed |
+| btob/website\_configuration/requisition\_list\_active | A field-node was removed |
+| btob/website\_configuration/sharedcatalog\_active | A field-node was removed |
+| catalog | a section-node was removed |
+| catalog/magento\_catalogpermissions | A group-node was removed |
+| catalog/magento\_catalogpermissions/enabled | A field-node was removed |
+| catalog/magento\_catalogpermissions/grant\_catalog\_category\_view\_groups | A field-node was removed |
+| company | a section-node was removed |
+| company/email | A group-node was removed |
+| company/email/company\_copy\_method | A field-node was removed |
+| company/email/company\_credit\_change | A field-node was removed |
+| company/email/company\_credit\_change\_copy | A field-node was removed |
+| company/email/company\_credit\_copy\_method | A field-node was removed |
+| company/email/company\_notify\_admin\_template | A field-node was removed |
+| company/email/company\_registration | A field-node was removed |
+| company/email/company\_registration\_copy | A field-node was removed |
+| company/email/company\_status\_blocked\_template | A field-node was removed |
+| company/email/company\_status\_change\_copy | A field-node was removed |
+| company/email/company\_status\_copy\_method | A field-node was removed |
+| company/email/company\_status\_pending\_approval\_template | A field-node was removed |
+| company/email/company\_status\_pending\_approval\_to\_active\_template | A field-node was removed |
+| company/email/company\_status\_rejected\_blocked\_to\_active\_template | A field-node was removed |
+| company/email/company\_status\_rejected\_template | A field-node was removed |
+| company/email/credit\_allocated\_email\_template | A field-node was removed |
+| company/email/credit\_refunded\_email\_template | A field-node was removed |
+| company/email/credit\_reimbursed\_email\_template | A field-node was removed |
+| company/email/credit\_reverted\_email\_template | A field-node was removed |
+| company/email/credit\_updated\_email\_template | A field-node was removed |
+| company/email/customer\_account\_activated\_template | A field-node was removed |
+| company/email/customer\_account\_locked\_template | A field-node was removed |
+| company/email/customer\_assign\_super\_user\_template | A field-node was removed |
+| company/email/customer\_company\_customer\_assign\_template | A field-node was removed |
+| company/email/customer\_inactivate\_super\_user\_template | A field-node was removed |
+| company/email/customer\_remove\_super\_user\_template | A field-node was removed |
+| company/email/customer\_sales\_representative\_template | A field-node was removed |
+| company/email/heading\_company\_credit | A field-node was removed |
+| company/email/heading\_company\_status | A field-node was removed |
+| company/email/heading\_customer | A field-node was removed |
+| company/general | A group-node was removed |
+| company/general/allow\_company\_registration | A field-node was removed |
+| general | a section-node was removed |
+| general/restriction | A group-node was removed |
+| general/restriction/is\_active | A field-node was removed |
+| payment | a section-node was removed |
+| payment/companycredit | A group-node was removed |
+| payment/companycredit/active | A field-node was removed |
+| payment/companycredit/allowspecific | A field-node was removed |
+| payment/companycredit/max\_order\_total | A field-node was removed |
+| payment/companycredit/min\_order\_total | A field-node was removed |
+| payment/companycredit/model | A field-node was removed |
+| payment/companycredit/order\_status | A field-node was removed |
+| payment/companycredit/sort\_order | A field-node was removed |
+| payment/companycredit/specificcountry | A field-node was removed |
+| payment/companycredit/title | A field-node was removed |
+| quote | a section-node was removed |
+| quote/attached\_files | A group-node was removed |
+| quote/attached\_files/file\_formats | A field-node was removed |
+| quote/attached\_files/maximum\_file\_size | A field-node was removed |
+| quote/general | A group-node was removed |
+| quote/general/default\_expiration\_period | A field-node was removed |
+| quote/general/minimum\_amount | A field-node was removed |
+| quote/general/minimum\_amount\_message | A field-node was removed |
+| recaptcha\_frontend | a section-node was removed |
+| recaptcha\_frontend/type\_for | A group-node was removed |
+| recaptcha\_frontend/type\_for/company\_create | A field-node was removed |
+| requisitionlist | a section-node was removed |
+| requisitionlist/general | A group-node was removed |
+| requisitionlist/general/number\_requisition\_lists | A field-node was removed |
+| sales\_email | a section-node was removed |
+| sales\_email/purchase\_order\_notification | A group-node was removed |
+| sales\_email/purchase\_order\_notification/enabled | A field-node was removed |
+| sales\_email/purchase\_order\_notification/purchase\_order\_approval\_request | A field-node was removed |
+| sales\_email/purchase\_order\_notification/purchase\_order\_approval\_required | A field-node was removed |
+| sales\_email/purchase\_order\_notification/purchase\_order\_approval\_required\_payment\_details | A field-node was removed |
+| sales\_email/purchase\_order\_notification/purchase\_order\_approved | A field-node was removed |
+| sales\_email/purchase\_order\_notification/purchase\_order\_approved\_payment\_details | A field-node was removed |
+| sales\_email/purchase\_order\_notification/purchase\_order\_auto\_approved | A field-node was removed |
+| sales\_email/purchase\_order\_notification/purchase\_order\_auto\_approved\_payment\_details | A field-node was removed |
+| sales\_email/purchase\_order\_notification/purchase\_order\_comment\_added | A field-node was removed |
+| sales\_email/purchase\_order\_notification/purchase\_order\_order\_place\_failed | A field-node was removed |
+| sales\_email/purchase\_order\_notification/purchase\_order\_rejected | A field-node was removed |
+| sales\_email/quote | A group-node was removed |
+| sales\_email/quote/copy\_method | A field-node was removed |
+| sales\_email/quote/copy\_to | A field-node was removed |
+| sales\_email/quote/declined\_buyer\_template | A field-node was removed |
+| sales\_email/quote/enabled | A field-node was removed |
+| sales\_email/quote/expire\_occur\_template | A field-node was removed |
+| sales\_email/quote/expire\_one\_day\_template | A field-node was removed |
+| sales\_email/quote/expire\_reset\_template | A field-node was removed |
+| sales\_email/quote/expire\_two\_days\_template | A field-node was removed |
+| sales\_email/quote/new\_quote\_by\_seller\_template | A field-node was removed |
+| sales\_email/quote/new\_seller\_template | A field-node was removed |
+| sales\_email/quote/updated\_buyer\_template | A field-node was removed |
+| sales\_email/quote/updated\_seller\_template | A field-node was removed |
+| shipping | a section-node was removed |
+| shipping/origin | A group-node was removed |
+| shipping/origin/country\_id | A field-node was removed |
+| shipping/origin/postcode | A field-node was removed |
+| shipping/origin/region\_id | A field-node was removed |

--- a/src/_includes/backward-incompatible-changes/open-source/2.4.7-2.4.7-p1.md
+++ b/src/_includes/backward-incompatible-changes/open-source/2.4.7-2.4.7-p1.md
@@ -1,8 +1,3 @@
-#### Class changes {#open-source-BICs-247-247-p1-class}
-
-| What changed | How it changed |
-| --- | --- |
-
 #### System changes {#open-source-BICs-247-247-p1-system}
 
 | What changed | How it changed |

--- a/src/_includes/backward-incompatible-changes/open-source/2.4.7-2.4.7-p1.md
+++ b/src/_includes/backward-incompatible-changes/open-source/2.4.7-2.4.7-p1.md
@@ -1,0 +1,10 @@
+#### Class changes {#open-source-BICs-247-247-p1-class}
+
+| What changed | How it changed |
+| --- | --- |
+
+#### System changes {#open-source-BICs-247-247-p1-system}
+
+| What changed | How it changed |
+| --- | --- |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/paypal\_l2\_l3\_send\_data | A field-node was added |

--- a/src/pages/development/backward-incompatible-changes/reference.md
+++ b/src/pages/development/backward-incompatible-changes/reference.md
@@ -27,6 +27,22 @@ To view changes in functional tests, refer to [Backward incompatible changes in 
 
 Patch releases are primarily focused on delivering security and quality enhancements on a regular basis to help you keep your sites performing at their peak. On an exceptional basis, breaking changes or additional patches or hotfixes may be released to address security or compliance issues and high-impact quality issues. On the module level, these are mostly PATCH-level changes; sometimes MINOR-level changes. See [Release policy](https://experienceleague.adobe.com/docs/commerce-operations/release/policy.html).
 
+## 2.4.7 - 2.4.7-p1
+
+### Adobe Commerce
+
+Adobe Commerce v2.4.7-p1 includes the B2B extension v1.4.2.
+
+import Ac247p1 from '/src/_includes/backward-incompatible-changes/commerce/2.4.7-2.4.7-p1.md'
+
+<Ac247p1 />
+
+### Magento Open Source
+
+import Os247p1 from '/src/_includes/backward-incompatible-changes/open-source/2.4.7-2.4.7-p1.md'
+
+<Os247p1 />
+
 ## 2.4.6 - 2.4.7
 
 ### Adobe Commerce


### PR DESCRIPTION
2.4.7-2.4.7-p1 [Backward incompatible changes reference](https://developer.adobe.com/commerce/php/development/backward-incompatible-changes/reference/) docs.

Preview: https://commerce-docs.github.io/commerce-php/development/backward-incompatible-changes/reference/