### PR TITLE
Upgrade theme to v4.11.14

### DIFF
--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -31,7 +31,8 @@ const remarkConfig = {
 					"https://eat.magento.com",
 					"https://developer.ups.com/oauth-developer-guide",
 					"https://business.adobe.com/products/magento/business-intelligence.html",
-					"https://business.adobe.com/products/magento/business-intelligence.html"
+					"https://business.adobe.com/products/magento/business-intelligence.html",
+					"https://www.adobe.com/trust/security/product-security.html"
 				],
 				skipOffline: "true"
 			}

--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -29,7 +29,9 @@ const remarkConfig = {
 					"https://cardinalcommerce.com/",
 					"https://www.cyberciti.biz",
 					"https://eat.magento.com",
-					"https://developer.ups.com/oauth-developer-guide"
+					"https://developer.ups.com/oauth-developer-guide",
+					"https://business.adobe.com/products/magento/business-intelligence.html",
+					"https://business.adobe.com/products/magento/business-intelligence.html"
 				],
 				skipOffline: "true"
 			}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/AdobeDocs/commerce-php"
   },
   "dependencies": {
-    "@adobe/gatsby-theme-aio": "4.11.9",
+    "@adobe/gatsby-theme-aio": "4.11.14",
     "gatsby": "4.22.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/src/pages/architecture/basics/security.md
+++ b/src/pages/architecture/basics/security.md
@@ -8,9 +8,9 @@ keywords:
 
 # Security
 
-The security of your data and digital experiences is our priority. To better protect Adobe Commerce and Magento Open Source installations from the physical layer up, we have implemented hundreds of processes and controls to help us comply with [industry-accepted standards](https://docs.magento.com/m2/ee/user_guide/stores/compliance-industry.html), regulations, and certifications. To help protect installations from the software layer down, we build in security measures that are based on the [Adobe Secure Product Lifecyle](https://www.adobe.com/security/engineering.html).
+The security of your data and digital experiences is our priority. To better protect Adobe Commerce and Magento Open Source installations from the physical layer up, we have implemented hundreds of processes and controls to help us comply with [industry-accepted standards](https://docs.magento.com/m2/ee/user_guide/stores/compliance-industry.html), regulations, and certifications. To help protect installations from the software layer down, we build in security measures that are based on the [Adobe Secure Product Lifecyle](https://www.adobe.com/trust/security/product-security.html).
 
-Although there is no single way to eliminate all security risks, there are many steps you can take to harden your installations and make them a less attractive target for bad actors. The [Security Best Practices Guide](https://www.adobe.com/content/dam/acom/en/security/pdfs/Adobe-Magento-Commerce-Best-Practices-Guide.pdf) offers insight and practical guidelines to help protect all installations from security incidents.
+Although there is no single way to eliminate all security risks, there are many steps you can take to harden your installations and make them a less attractive target for bad actors. The [Security Best Practices Guide](https://experienceleague.adobe.com/en/docs/commerce-operations/implementation-playbook/best-practices/launch/security-best-practices) offers insight and practical guidelines to help protect all installations from security incidents.
 
 ## Examples of built-in security measures
 

--- a/src/pages/development/validate/test-component.md
+++ b/src/pages/development/validate/test-component.md
@@ -50,7 +50,6 @@ Before you publish your component, test installing it.
 See these resources for testing in PHP and validating components:
 
 *  The [Coding Standard] provides a set of rules and sniffs for the [PHP_CodeSniffer] tool
-*  [Technical Deep Dive: How to Pass the Commerce Marketplace Extension Quality Program] (video) from Magento Imagine 2017
 *  [Extension Quality Program](https://developer.adobe.com/commerce/marketplace/guides/sellers/extension-quality-program/) in the Commerce Marketplace guide
 
 [Testing Overview]: https://developer.adobe.com/commerce/testing/guide/
@@ -61,5 +60,4 @@ See these resources for testing in PHP and validating components:
 [Install using Composer]: https://devdocs.magento.com/guides/v2.4/install-gde/install/sample-data-after-composer.html
 [Coding Standard]: https://github.com/magento/magento-coding-standard
 [PHP_CodeSniffer]: https://github.com/squizlabs/PHP_CodeSniffer
-[Technical Deep Dive: How to Pass the Commerce Marketplace Extension Quality Program]: https://magento.com/resources/technical-deep-dive-how-pass-magento-marketplace-extension-quality-program
 [01 The Module Skeleton Kata]: https://www.youtube.com/watch?v=JvBWJ6Lm9MU)

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,9 +33,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@adobe/gatsby-theme-aio@npm:4.11.9":
-  version: 4.11.9
-  resolution: "@adobe/gatsby-theme-aio@npm:4.11.9"
+"@adobe/gatsby-theme-aio@npm:4.11.14":
+  version: 4.11.14
+  resolution: "@adobe/gatsby-theme-aio@npm:4.11.14"
   dependencies:
     "@adobe/focus-ring-polyfill": ^0.1.5
     "@adobe/gatsby-source-github-file-contributors": ^0.3.1
@@ -131,7 +131,7 @@ __metadata:
     gatsby: ^4.22.0
     react: ^17.0.2
     react-dom: ^17.0.2
-  checksum: 57693d220f785d6ffa8c81c09fce1b15240de6ce483df835b5b5b373124e1b1349c99f170b2694c25b2271aff84b16eef8e5975c1f7b33f24a297a3b03e8e871
+  checksum: b93a25de446629f42f702cbe45e756fcc009857e5f96899a2b55e7465aed5246a85bd1cb2a57bdb3e572ed15d1ffd5df76e7bc992c5ce823df468634ecac54a6
   languageName: node
   linkType: hard
 
@@ -6974,7 +6974,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "commerce-php@workspace:."
   dependencies:
-    "@adobe/gatsby-theme-aio": 4.11.9
+    "@adobe/gatsby-theme-aio": 4.11.14
     gatsby: 4.22.0
     react: ^17.0.2
     react-dom: ^17.0.2


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) upgrades theme to [v4.11.14](https://github.com/adobe/aio-theme/compare/%40adobe/gatsby-theme-aio%404.11.9...adobe/gatsby-theme-aio%404.11.14).

## Preview

https://developer-stage.adobe.com/commerce/php/
