### PR TITLE
Add links to additional release resources

### DIFF
--- a/src/pages/development/backward-incompatible-changes/index.md
+++ b/src/pages/development/backward-incompatible-changes/index.md
@@ -10,3 +10,12 @@ keywords:
 Adobe Commerce and Magento Open Source releases may contain backward-incompatible changes (BICs).
 
 To review minor backward-incompatible changes by release version, see [reference](reference.md). To review major backward-incompatible changes and detailed workaround instructions, see [highlights](highlights.md). Not all releases introduce major BICs.
+
+## More release resources
+
+See additional Commerce release resources on Experience League:
+
+- [Release schedule](https://experienceleague.adobe.com/en/docs/commerce-operations/release/planning/schedule)—Learn when Adobe plans to announce the release of new features and patches for Commerce.
+- [Release notes](https://experienceleague.adobe.com/en/docs/commerce-operations/release/notes/overview)—Learn where to find detailed release information for specific Adobe Commerce products, services, and tools.
+- [Beta releases](https://experienceleague.adobe.com/en/docs/commerce-operations/release/beta)—Learn about the Adobe Commerce beta releases and how to participate. Beta releases may contain defects and are provided "AS IS" without warranty of any kind.
+- [Quality Patches Tool](https://experienceleague.adobe.com/en/docs/commerce-operations/tools/quality-patches-tool/usage)—Learn how to apply, revert, and view general information about all individual patches that are available for the installed version of Commerce.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds links to additional release resources on Experience League, including the Quality Patches Tool. We recently received feedback from the community that devsite search results don't include that tool. This PR should address that feedback.

## Affected pages

- https://developer.adobe.com/commerce/php/development/backward-incompatible-changes/