### PR TITLE
Update 2.4.6-2.4.7.md about ChangeLogBatchWalkerInterface

### DIFF
--- a/src/_includes/backward-incompatible-changes/commerce/2.4.6-2.4.7.md
+++ b/src/_includes/backward-incompatible-changes/commerce/2.4.6-2.4.7.md
@@ -110,6 +110,7 @@
 | Magento\Framework\Logger\Handler\Base::\_\_debugInfo | [public] Method has been added. |
 | Magento\Framework\Logger\Handler\Base::\_resetState | [public] Method has been added. |
 | Magento\Framework\Math\Random::getRandomBytes | [public] Method has been added. |
+| Magento\Framework\Mview\View\ChangeLogBatchWalker | Class was renamed Change**l**ogBatchWalker. |
 | Magento\Framework\Pricing\Price\Collection | Interface has been added. |
 | Magento\Framework\Pricing\Price\Collection::\_resetState | [public] Method has been added. |
 | Magento\Framework\Registry | Interface has been added. |
@@ -194,6 +195,7 @@
 | Magento\CommerceBackendUix\Api\Data\MassActionInterface | Interface was added. |
 | Magento\CommerceBackendUix\Api\MassActionRepositoryInterface | Interface was added. |
 | Magento\Framework\Indexer\StateInterface::STATUS\_SUSPENDED | Constant has been added. |
+| Magento\Framework\Mview\View\ChangeLogBatchWalkerInterface | Interface was renamed Change**l**ogBatchWalkerInterface. |
 | Magento\Framework\ObjectManager\ResetAfterRequestInterface | Interface was added. |
 | Magento\ImportJsonApi\Api\Data\SourceDataInterface | Interface was added. |
 | Magento\ImportJsonApi\Api\StartImportInterface | Interface was added. |

--- a/src/_includes/backward-incompatible-changes/open-source/2.4.6-2.4.7.md
+++ b/src/_includes/backward-incompatible-changes/open-source/2.4.6-2.4.7.md
@@ -106,6 +106,7 @@
 | Magento\Framework\Logger\Handler\Base::\_\_debugInfo | [public] Method has been added. |
 | Magento\Framework\Logger\Handler\Base::\_resetState | [public] Method has been added. |
 | Magento\Framework\Math\Random::getRandomBytes | [public] Method has been added. |
+| Magento\Framework\Mview\View\ChangeLogBatchWalker | Class was renamed Change**l**ogBatchWalker. |
 | Magento\Framework\Pricing\Price\Collection | Interface has been added. |
 | Magento\Framework\Pricing\Price\Collection::\_resetState | [public] Method has been added. |
 | Magento\Framework\Registry | Interface has been added. |
@@ -174,6 +175,7 @@
 | --- | --- |
 | Magento\Catalog\Api\ProductAttributeIsFilterableManagementInterface | Interface was added. |
 | Magento\Framework\Indexer\StateInterface::STATUS\_SUSPENDED | Constant has been added. |
+| Magento\Framework\Mview\View\ChangeLogBatchWalkerInterface | Interface was renamed Change**l**ogBatchWalkerInterface. |
 | Magento\Framework\ObjectManager\ResetAfterRequestInterface | Interface was added. |
 | Magento\InventorySalesApi\Model\GetStockItemsDataInterface | Interface was added. |
 | Magento\PageCache\Model\VclGeneratorInterface::generateVcl | [public] Added optional parameter(s). |


### PR DESCRIPTION
\Magento\Framework\Mview\View\ChangeLogBatchWalkerInterface was renamed along with \Magento\Framework\Mview\View\ChangeLogBatchWalker which will break compatibility of third-party modules implementing their own log batch walker.

## Purpose of this pull request

This pull request (PR) addresses the renaming of interface \Magento\Framework\Mview\View\ChangeLogBatchWalkerInterface into \Magento\Framework\Mview\View\ChangelogBatchWalkerInterface which will prevent third party modules or project implementing the interface to migrate properly from 2.4.6 to 2.4.7 

- phpstan will raise an error
- setup:di:compile will fail

I didn't know if it was preferable to have the old or the new name in the left column.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- [Backward-incompatible changes references](https://developer.adobe.com/commerce/php/development/backward-incompatible-changes/reference/#246---247)

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- [Magento/Framework/Mview/View/ChangelogBatchWalkerInterface.php history](https://github.com/magento/magento2/commits/2.4-develop/lib/internal/Magento/Framework/Mview/View/ChangelogBatchWalkerInterface.php)
- [Magento/Framework/Mview/View/ChangelogBatchWalker.php history](https://github.com/magento/magento2/commits/2.4-develop/lib/internal/Magento/Framework/Mview/View/ChangelogBatchWalker.php)
- [Renaming commit](https://github.com/magento/magento2/commit/57889b5696048bf8447355bd9e29f5cdf38e0aa1)
