### PR TITLE
Add missing backward-incompatible changes

### DIFF
--- a/src/_includes/backward-incompatible-changes/commerce/2.4.6-2.4.7.md
+++ b/src/_includes/backward-incompatible-changes/commerce/2.4.6-2.4.7.md
@@ -7,7 +7,6 @@
 | Magento\Authorization\Model\CompositeUserContext::\_resetState | [public] Method has been added. |
 | Magento\Bundle\Block\Catalog\Product\View\Type\Bundle | Interface has been added. |
 | Magento\Bundle\Block\Catalog\Product\View\Type\Bundle::\_resetState | [public] Method has been added. |
-| Magento\CatalogImportExport\Model\Export\Product::$\_storeIdToCode | [protected] Property has been removed. |
 | Magento\Catalog\Helper\Product\Flat\Indexer | Interface has been added. |
 | Magento\Catalog\Helper\Product\Flat\Indexer::\_resetState | [public] Method has been added. |
 | Magento\Catalog\Model\Config::$\_storeManager | [protected] Property has been removed. |
@@ -28,6 +27,7 @@
 | Magento\Catalog\Model\Product\Type\Price | Interface has been added. |
 | Magento\Catalog\Model\Product\Type\Price::\_resetState | [public] Method has been added. |
 | Magento\Catalog\Model\ResourceModel\Product | Interface has been added. |
+| Magento\CatalogImportExport\Model\Export\Product::$\_storeIdToCode | [protected] Property has been removed. |
 | Magento\CommerceBackendUix\Block\Adminhtml\Order\View\CustomButton | Class was added. |
 | Magento\Config\App\Config\Type\System::\_\_debugInfo | [public] Method has been added. |
 | Magento\Config\App\Config\Type\System::cleanAndWarmDefaultScopeData | [public] Method has been added. |
@@ -38,8 +38,6 @@
 | Magento\ConfigurableProduct\Model\Product\VariationHandler | Interface has been added. |
 | Magento\ConfigurableProduct\Model\Product\VariationHandler::\_resetState | [public] Method has been added. |
 | Magento\Csp\Block\Sri\Hashes | Class was added. |
-| Magento\CustomerSegment\Model\Customer | Interface has been added. |
-| Magento\CustomerSegment\Model\Customer::\_resetState | [public] Method has been added. |
 | Magento\Customer\Helper\Address | Interface has been added. |
 | Magento\Customer\Helper\Address::\_resetState | [public] Method has been added. |
 | Magento\Customer\Model\Address\AbstractAddress | Interface has been added. |
@@ -48,6 +46,8 @@
 | Magento\Customer\Model\Customer::\_resetState | [public] Method has been added. |
 | Magento\Customer\Model\CustomerRegistry | Interface has been added. |
 | Magento\Customer\Model\CustomerRegistry::\_resetState | [public] Method has been added. |
+| Magento\CustomerSegment\Model\Customer | Interface has been added. |
+| Magento\CustomerSegment\Model\Customer::\_resetState | [public] Method has been added. |
 | Magento\DataExporter\Model\Indexer\FeedIndexer | Class was added. |
 | Magento\Directory\Helper\Data | Interface has been added. |
 | Magento\Directory\Helper\Data::\_resetState | [public] Method has been added. |
@@ -58,8 +58,8 @@
 | Magento\Directory\Model\ResourceModel\Currency | Interface has been added. |
 | Magento\Directory\Model\ResourceModel\Currency::\_resetState | [public] Method has been added. |
 | Magento\Eav\Model\Config | Interface has been added. |
-| Magento\Eav\Model\Config::$\_storeManager | [protected] Property has been added. |
 | Magento\Eav\Model\Config::\_resetState | [public] Method has been added. |
+| Magento\Eav\Model\Config::$\_storeManager | [protected] Property has been added. |
 | Magento\Eav\Model\Config::getWebsiteId | Method visibility has been changed to higher lever from [private] to [public] |
 | Magento\Eav\Model\Config::getWebsiteId | [public] Removed last method parameter(s). |
 | Magento\Eav\Model\Entity\AbstractEntity | Interface has been added. |
@@ -90,14 +90,14 @@
 | Magento\Framework\Config\Data\Scoped::$\_cacheId | [protected] Property has been removed. |
 | Magento\Framework\Config\Data\Scoped::$\_reader | [protected] Property has been removed. |
 | Magento\Framework\Console\Cli::getDefaultCommands | [protected] Method return typing changed. |
+| Magento\Framework\Data\Collection | Interface has been added. |
+| Magento\Framework\Data\Collection::\_resetState | [public] Method has been added. |
+| Magento\Framework\DataObject::\_\_debugInfo | [public] Method has been added. |
 | Magento\Framework\DB\Adapter\Pdo\Mysql | Interface has been added. |
 | Magento\Framework\DB\Adapter\Pdo\Mysql::\_\_debugInfo | [public] Method has been added. |
 | Magento\Framework\DB\Adapter\Pdo\Mysql::\_resetState | [public] Method has been added. |
-| Magento\Framework\DataObject::\_\_debugInfo | [public] Method has been added. |
-| Magento\Framework\Data\Collection | Interface has been added. |
-| Magento\Framework\Data\Collection::\_resetState | [public] Method has been added. |
-| Magento\Framework\Filesystem\DirectoryList::\_\_debugInfo | [public] Method has been added. |
 | Magento\Framework\Filesystem\Directory\Read::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\Filesystem\DirectoryList::\_\_debugInfo | [public] Method has been added. |
 | Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException | Interface has been added. |
 | Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException::getExtensions | [public] Method has been added. |
 | Magento\Framework\GraphQl\Query\Resolver\BatchResponse | Interface has been added. |
@@ -110,6 +110,7 @@
 | Magento\Framework\Logger\Handler\Base::\_\_debugInfo | [public] Method has been added. |
 | Magento\Framework\Logger\Handler\Base::\_resetState | [public] Method has been added. |
 | Magento\Framework\Math\Random::getRandomBytes | [public] Method has been added. |
+| Magento\Framework\Mview\View\ChangeLogBatchWalker | Class has been renamed to Magento\Framework\Mview\View\ChangelogBatchWalker. |
 | Magento\Framework\Pricing\Price\Collection | Interface has been added. |
 | Magento\Framework\Pricing\Price\Collection::\_resetState | [public] Method has been added. |
 | Magento\Framework\Registry | Interface has been added. |
@@ -142,34 +143,34 @@
 | Magento\PaymentServicesPaypal\Block\Info | Class was added. |
 | Magento\PaymentServicesPaypal\Block\Message | Class was added. |
 | Magento\PaymentServicesPaypal\Block\SmartButtons | Class was added. |
-| Magento\PaymentServicesPaypal\Block\SmartButtonsCart | Class was added. |
-| Magento\PaymentServicesPaypal\Block\SmartButtonsProduct | Class was added. |
 | Magento\PaymentServicesPaypal\Block\SmartButtons\Review | Class was added. |
 | Magento\PaymentServicesPaypal\Block\SmartButtons\Review\Details | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtonsCart | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtonsProduct | Class was added. |
 | Magento\PaymentServicesPaypal\Model\Api\Data\PaymentOrder | Class was added. |
 | Magento\PaymentServicesPaypal\Model\Api\PaymentOrderRequest | Class was added. |
 | Magento\PaymentServicesPaypal\Model\Api\PaymentSdkRequest | Class was added. |
-| Magento\QuickCheckoutAdminPanel\Block\Adminhtml\Index | Class was removed. |
 | Magento\QuickCheckout\Block\Adminhtml\Payment\Form | Class was removed. |
 | Magento\QuickCheckout\Block\Adminhtml\System\Config\ConfigureCallbackUrl | Class was removed. |
 | Magento\QuickCheckout\Block\Adminhtml\System\Config\Fieldset\Custom | Class was removed. |
 | Magento\QuickCheckout\Block\Adminhtml\System\Config\Fieldset\Head | Class was removed. |
 | Magento\QuickCheckout\Block\Adminhtml\System\Config\ValidateCredentials | Class was removed. |
 | Magento\QuickCheckout\Block\Sdk | Class was removed. |
+| Magento\QuickCheckoutAdminPanel\Block\Adminhtml\Index | Class was removed. |
 | Magento\Quote\Model\Quote\Address::setBaseDiscountAmount | [public] Method has been added. |
 | Magento\Quote\Model\Quote\Address\Total\AbstractTotal | Interface has been added. |
 | Magento\Quote\Model\Quote\Address\Total\AbstractTotal::\_resetState | [public] Method has been added. |
 | Magento\SaaSCommon\Model\ResyncManager | Class was added. |
-| Magento\SalesRule\Model\ResourceModel\Rule\Collection::setValidationFilter | [public] Added optional parameter(s). |
-| Magento\SalesRule\Model\Rule::getSimpleAction | [public] Method has been added. |
-| Magento\SalesSequence\Model\Builder | Interface has been added. |
-| Magento\SalesSequence\Model\Builder::\_resetState | [public] Method has been added. |
 | Magento\Sales\Model\Order\Config | Interface has been added. |
 | Magento\Sales\Model\Order\Config::\_resetState | [public] Method has been added. |
 | Magento\Sales\Model\Order\Email\Container\Container | Interface has been added. |
 | Magento\Sales\Model\Order\Email\Container\Container::\_resetState | [public] Method has been added. |
 | Magento\Sales\Model\ResourceModel\EntityAbstract | Interface has been added. |
 | Magento\Sales\Model\ResourceModel\EntityAbstract::\_resetState | [public] Method has been added. |
+| Magento\SalesRule\Model\ResourceModel\Rule\Collection::setValidationFilter | [public] Added optional parameter(s). |
+| Magento\SalesRule\Model\Rule::getSimpleAction | [public] Method has been added. |
+| Magento\SalesSequence\Model\Builder | Interface has been added. |
+| Magento\SalesSequence\Model\Builder::\_resetState | [public] Method has been added. |
 | Magento\ServicesIdLayout\Block\Adminhtml\Index | Class was added. |
 | Magento\Shipping\Model\Carrier\AbstractCarrier::$\_result | [protected] Property has been added. |
 | Magento\Store\Model\App\Emulation | Interface has been added. |
@@ -185,15 +186,16 @@
 
 | What changed | How it changed |
 | --- | --- |
-| Magento\AdobeCommerceWebhooksAdminUi\Api\HookRepositoryInterface | Interface was added. |
 | Magento\AdobeCommerceWebhooks\Model\Filter\Converter\FieldConverterInterface | Interface was added. |
 | Magento\AdobeCommerceWebhooks\Model\HeaderResolverInterface | Interface was added. |
+| Magento\AdobeCommerceWebhooksAdminUi\Api\HookRepositoryInterface | Interface was added. |
 | Magento\AdvancedRule\Model\Condition\FilterInterface::isCoupon | [public] Method has been added. |
 | Magento\AdvancedRule\Model\Condition\FilterInterface::setIsCoupon | [public] Method has been added. |
 | Magento\Catalog\Api\ProductAttributeIsFilterableManagementInterface | Interface was added. |
 | Magento\CommerceBackendUix\Api\Data\MassActionInterface | Interface was added. |
 | Magento\CommerceBackendUix\Api\MassActionRepositoryInterface | Interface was added. |
 | Magento\Framework\Indexer\StateInterface::STATUS\_SUSPENDED | Constant has been added. |
+| Magento\Framework\Mview\View\ChangeLogBatchWalkerInterface | Interface has been renamed to Magento\Framework\Mview\View\ChangelogBatchWalkerInterface. |
 | Magento\Framework\ObjectManager\ResetAfterRequestInterface | Interface was added. |
 | Magento\ImportJsonApi\Api\Data\SourceDataInterface | Interface was added. |
 | Magento\ImportJsonApi\Api\StartImportInterface | Interface was added. |
@@ -214,9 +216,9 @@
 | Magento\SaaSCommon\Model\Http\ConverterInterface | Interface was added. |
 | Magento\ServicesId\Model\ServicesClientInterface | Interface was added. |
 | Magento\ServicesId\Model\ServicesConfigInterface | Interface was added. |
-| Magento\Vault\Api\Data\PaymentTokenInterface::WEBSITE\_ID | Constant has been added. |
 | Magento\Vault\Api\Data\PaymentTokenInterface::getWebsiteId | [public] Method has been added. |
 | Magento\Vault\Api\Data\PaymentTokenInterface::setWebsiteId | [public] Method has been added. |
+| Magento\Vault\Api\Data\PaymentTokenInterface::WEBSITE\_ID | Constant has been added. |
 
 #### Database changes {#b2b-246-247-database}
 

--- a/src/_includes/backward-incompatible-changes/open-source/2.4.6-2.4.7.md
+++ b/src/_includes/backward-incompatible-changes/open-source/2.4.6-2.4.7.md
@@ -6,7 +6,6 @@
 | Magento\Authorization\Model\CompositeUserContext::\_resetState | [public] Method has been added. |
 | Magento\Bundle\Block\Catalog\Product\View\Type\Bundle | Interface has been added. |
 | Magento\Bundle\Block\Catalog\Product\View\Type\Bundle::\_resetState | [public] Method has been added. |
-| Magento\CatalogImportExport\Model\Export\Product::$\_storeIdToCode | [protected] Property has been removed. |
 | Magento\Catalog\Helper\Product\Flat\Indexer | Interface has been added. |
 | Magento\Catalog\Helper\Product\Flat\Indexer::\_resetState | [public] Method has been added. |
 | Magento\Catalog\Model\Config::$\_storeManager | [protected] Property has been removed. |
@@ -27,6 +26,7 @@
 | Magento\Catalog\Model\Product\Type\Price | Interface has been added. |
 | Magento\Catalog\Model\Product\Type\Price::\_resetState | [public] Method has been added. |
 | Magento\Catalog\Model\ResourceModel\Product | Interface has been added. |
+| Magento\CatalogImportExport\Model\Export\Product::$\_storeIdToCode | [protected] Property has been removed. |
 | Magento\Config\App\Config\Type\System::\_\_debugInfo | [public] Method has been added. |
 | Magento\Config\App\Config\Type\System::cleanAndWarmDefaultScopeData | [public] Method has been added. |
 | Magento\Config\App\Config\Type\System::loadDefaultScopeData | [private] Removed last method parameter(s). |
@@ -54,10 +54,10 @@
 | Magento\Directory\Model\ResourceModel\Currency | Interface has been added. |
 | Magento\Directory\Model\ResourceModel\Currency::\_resetState | [public] Method has been added. |
 | Magento\Eav\Model\Config | Interface has been added. |
-| Magento\Eav\Model\Config::$\_storeManager | [protected] Property has been added. |
 | Magento\Eav\Model\Config::\_resetState | [public] Method has been added. |
-| Magento\Eav\Model\Config::getWebsiteId | Method visibility has been changed to higher lever from [private] to [public] |
+| Magento\Eav\Model\Config::$\_storeManager | [protected] Property has been added. |
 | Magento\Eav\Model\Config::getWebsiteId | [public] Removed last method parameter(s). |
+| Magento\Eav\Model\Config::getWebsiteId | Method visibility has been changed to higher lever from [private] to [public] |
 | Magento\Eav\Model\Entity\AbstractEntity | Interface has been added. |
 | Magento\Eav\Model\Entity\AbstractEntity::\_resetState | [public] Method has been added. |
 | Magento\Eav\Model\Entity\Attribute\AbstractAttribute | Interface has been added. |
@@ -86,14 +86,14 @@
 | Magento\Framework\Config\Data\Scoped::$\_cacheId | [protected] Property has been removed. |
 | Magento\Framework\Config\Data\Scoped::$\_reader | [protected] Property has been removed. |
 | Magento\Framework\Console\Cli::getDefaultCommands | [protected] Method return typing changed. |
+| Magento\Framework\Data\Collection | Interface has been added. |
+| Magento\Framework\Data\Collection::\_resetState | [public] Method has been added. |
+| Magento\Framework\DataObject::\_\_debugInfo | [public] Method has been added. |
 | Magento\Framework\DB\Adapter\Pdo\Mysql | Interface has been added. |
 | Magento\Framework\DB\Adapter\Pdo\Mysql::\_\_debugInfo | [public] Method has been added. |
 | Magento\Framework\DB\Adapter\Pdo\Mysql::\_resetState | [public] Method has been added. |
-| Magento\Framework\DataObject::\_\_debugInfo | [public] Method has been added. |
-| Magento\Framework\Data\Collection | Interface has been added. |
-| Magento\Framework\Data\Collection::\_resetState | [public] Method has been added. |
-| Magento\Framework\Filesystem\DirectoryList::\_\_debugInfo | [public] Method has been added. |
 | Magento\Framework\Filesystem\Directory\Read::\_\_debugInfo | [public] Method has been added. |
+| Magento\Framework\Filesystem\DirectoryList::\_\_debugInfo | [public] Method has been added. |
 | Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException | Interface has been added. |
 | Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException::getExtensions | [public] Method has been added. |
 | Magento\Framework\GraphQl\Query\Resolver\BatchResponse | Interface has been added. |
@@ -106,6 +106,7 @@
 | Magento\Framework\Logger\Handler\Base::\_\_debugInfo | [public] Method has been added. |
 | Magento\Framework\Logger\Handler\Base::\_resetState | [public] Method has been added. |
 | Magento\Framework\Math\Random::getRandomBytes | [public] Method has been added. |
+| Magento\Framework\Mview\View\ChangeLogBatchWalker | Class has been renamed to Magento\Framework\Mview\View\ChangelogBatchWalker. |
 | Magento\Framework\Pricing\Price\Collection | Interface has been added. |
 | Magento\Framework\Pricing\Price\Collection::\_resetState | [public] Method has been added. |
 | Magento\Framework\Registry | Interface has been added. |
@@ -138,10 +139,10 @@
 | Magento\PaymentServicesPaypal\Block\Info | Class was added. |
 | Magento\PaymentServicesPaypal\Block\Message | Class was added. |
 | Magento\PaymentServicesPaypal\Block\SmartButtons | Class was added. |
-| Magento\PaymentServicesPaypal\Block\SmartButtonsCart | Class was added. |
-| Magento\PaymentServicesPaypal\Block\SmartButtonsProduct | Class was added. |
 | Magento\PaymentServicesPaypal\Block\SmartButtons\Review | Class was added. |
 | Magento\PaymentServicesPaypal\Block\SmartButtons\Review\Details | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtonsCart | Class was added. |
+| Magento\PaymentServicesPaypal\Block\SmartButtonsProduct | Class was added. |
 | Magento\PaymentServicesPaypal\Model\Api\Data\PaymentOrder | Class was added. |
 | Magento\PaymentServicesPaypal\Model\Api\PaymentOrderRequest | Class was added. |
 | Magento\PaymentServicesPaypal\Model\Api\PaymentSdkRequest | Class was added. |
@@ -149,16 +150,16 @@
 | Magento\Quote\Model\Quote\Address\Total\AbstractTotal | Interface has been added. |
 | Magento\Quote\Model\Quote\Address\Total\AbstractTotal::\_resetState | [public] Method has been added. |
 | Magento\SaaSCommon\Model\ResyncManager | Class was added. |
-| Magento\SalesRule\Model\ResourceModel\Rule\Collection::setValidationFilter | [public] Added optional parameter(s). |
-| Magento\SalesRule\Model\Rule::getSimpleAction | [public] Method has been added. |
-| Magento\SalesSequence\Model\Builder | Interface has been added. |
-| Magento\SalesSequence\Model\Builder::\_resetState | [public] Method has been added. |
 | Magento\Sales\Model\Order\Config | Interface has been added. |
 | Magento\Sales\Model\Order\Config::\_resetState | [public] Method has been added. |
 | Magento\Sales\Model\Order\Email\Container\Container | Interface has been added. |
 | Magento\Sales\Model\Order\Email\Container\Container::\_resetState | [public] Method has been added. |
 | Magento\Sales\Model\ResourceModel\EntityAbstract | Interface has been added. |
 | Magento\Sales\Model\ResourceModel\EntityAbstract::\_resetState | [public] Method has been added. |
+| Magento\SalesRule\Model\ResourceModel\Rule\Collection::setValidationFilter | [public] Added optional parameter(s). |
+| Magento\SalesRule\Model\Rule::getSimpleAction | [public] Method has been added. |
+| Magento\SalesSequence\Model\Builder | Interface has been added. |
+| Magento\SalesSequence\Model\Builder::\_resetState | [public] Method has been added. |
 | Magento\ServicesIdLayout\Block\Adminhtml\Index | Class was added. |
 | Magento\Shipping\Model\Carrier\AbstractCarrier::$\_result | [protected] Property has been added. |
 | Magento\Store\Model\App\Emulation | Interface has been added. |
@@ -174,6 +175,7 @@
 | --- | --- |
 | Magento\Catalog\Api\ProductAttributeIsFilterableManagementInterface | Interface was added. |
 | Magento\Framework\Indexer\StateInterface::STATUS\_SUSPENDED | Constant has been added. |
+| Magento\Framework\Mview\View\ChangeLogBatchWalkerInterface | Interface has been renamed to Magento\Framework\Mview\View\ChangelogBatchWalkerInterface. |
 | Magento\Framework\ObjectManager\ResetAfterRequestInterface | Interface was added. |
 | Magento\InventorySalesApi\Model\GetStockItemsDataInterface | Interface was added. |
 | Magento\PageCache\Model\VclGeneratorInterface::generateVcl | [public] Added optional parameter(s). |
@@ -187,9 +189,9 @@
 | Magento\SaaSCommon\Model\Http\ConverterInterface | Interface was added. |
 | Magento\ServicesId\Model\ServicesClientInterface | Interface was added. |
 | Magento\ServicesId\Model\ServicesConfigInterface | Interface was added. |
-| Magento\Vault\Api\Data\PaymentTokenInterface::WEBSITE\_ID | Constant has been added. |
 | Magento\Vault\Api\Data\PaymentTokenInterface::getWebsiteId | [public] Method has been added. |
 | Magento\Vault\Api\Data\PaymentTokenInterface::setWebsiteId | [public] Method has been added. |
+| Magento\Vault\Api\Data\PaymentTokenInterface::WEBSITE\_ID | Constant has been added. |
 
 #### Database changes {#ce-246-247-database}
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds undocumented backward incompatible changes to the reference documentation.
For more details, see the original contribution at #308.
This PR also fixes table sorting.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- [Backward-incompatible changes references](https://developer.adobe.com/commerce/php/development/backward-incompatible-changes/reference/#246---247)
