### PR TITLE
Don't run Add to project GH Action in forks

### DIFF
--- a/.github/workflows/add-to-project_job.yml
+++ b/.github/workflows/add-to-project_job.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   add-to-project:
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a condition for the Add to project job to run only in the GH Actions of the original repository and ignore forks.

Internal reference: COMDOX-594