### PR TITLE
Remove harmful warning Update plugins.md

### DIFF
--- a/src/pages/development/components/plugins.md
+++ b/src/pages/development/components/plugins.md
@@ -231,11 +231,6 @@ If an argument is optional in the observed method, then the after method should 
 
 The application runs the code in around methods before and after their observed methods. Using these methods allow you to override an observed method. Around methods must have the same name as the observed method with 'around' as the prefix.
 
-<InlineAlert variant="warning" slots="text"/>
-
-Avoid using around method plugins when they are not required because they increase stack traces and affect performance.
-The only use case for around method plugins is when the execution of all further plugins and original methods need termination.
-Use after method plugins if you require arguments for replacing or altering function results.
 
 Before the list of the original method's arguments, around methods receive a `callable` that will allow a call to the next method in the chain. When your code executes the `callable`, the application calls the next plugin or the observed function.
 


### PR DESCRIPTION
Align with Mage-OS.
Around plugins are good and explicitly show up in a stack trace, performance degradation is minuscule by comparison with hours of debugging and understanding combinations of plugins. https://devdocs.mage-os.org/docs/main/plugins#content-2-after-plugin

## Purpose of this pull request

This pull request (PR) removes harmful message that questions competence of those who write `around` plugins.
Having plugin in the stack eliminates hours of debugging. 

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- plugins

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- none

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-php/blob/main/.github/CONTRIBUTING.md) for more information.
-->
