### PR TITLE
Add Backward incompatible changes reference reports

### DIFF
--- a/src/_includes/backward-incompatible-changes/commerce/2.4.7-2.4.8-beta1.md
+++ b/src/_includes/backward-incompatible-changes/commerce/2.4.7-2.4.8-beta1.md
@@ -1,0 +1,120 @@
+#### Class changes {#commerce-BICs-247-248-beta1-class}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\AdminUiSdkCustomFees\Block\Adminhtml\Sales\Order\Creditmemo\Totals | Class was added. |
+| Magento\AdminUiSdkCustomFees\Block\Adminhtml\Sales\Order\Invoice\Totals | Class was added. |
+| Magento\AdminUiSdkCustomFees\Block\Adminhtml\Sales\Order\Invoice\TotalsView | Class was added. |
+| Magento\AdminUiSdkCustomFees\Block\Adminhtml\Sales\Totals | Class was added. |
+| Magento\AdobeCommerceEventsClient\Event\Event::EVENT\_HIPAA\_AUDIT\_REQUIRED | Constant has been added. |
+| Magento\AdobeCommerceEventsClient\Event\Event::isHipaaAuditRequired | [public] Method has been added. |
+| Magento\AdobeCommerceEventsClient\Event\EventList | Interface has been added. |
+| Magento\AdobeCommerceWebhooksAdminUi\Block\Adminhtml\ValidationConfig | Class was removed. |
+| Magento\Framework\Amqp\Config | Interface has been added. |
+| Magento\Framework\Amqp\Config::\_resetState | [public] Method has been added. |
+| Magento\Framework\Data\Collection::getItemById | [public] Method return typing changed. |
+| Magento\Framework\Logger\Handler\Base::write | [protected] Method parameter typing changed. |
+| Magento\GiftMessage\Block\Cart\GiftOptions::\_\_construct | [public] Method parameter typing changed. |
+| Magento\GiftMessage\Block\Cart\Item\Renderer\Actions\GiftOptions::\_\_construct | [public] Method parameter typing changed. |
+| Magento\PageCache\Model\Config::VARNISH\_7\_CONFIGURATION\_PATH | Constant has been added. |
+| Magento\PaymentServicesBase\Block\Adminhtml\System\Config\Fieldset\Payment::productMeta | Property visibility has been changed to lower lever from [protected] to [private] |
+| Magento\PaymentServicesPaypal\Block\Cart\ValidationMessages::addQuoteMessages | Method visibility has been changed to lower lever from [protected] to [private] |
+
+#### Interface changes {#commerce-BICs-247-248-beta1-interface}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\AdminUiSdkCustomFees\Api\CustomFeesRepositoryInterface | Interface was added. |
+| Magento\AdminUiSdkCustomFees\Api\Data\CustomFeesInterface | Interface was added. |
+| Magento\AdobeCommerceEventsClient\Api\Data\EventDataInterface::isHipaaAuditRequired | [public] Method has been added. |
+| Magento\AdobeCommerceEventsClient\Api\Data\EventDataInterface::setHipaaAuditRequired | [public] Method has been added. |
+| Magento\AdobeCommerceEventsClient\Api\Data\EventInterface::FIELD\_HIPAA\_AUDIT\_REQUIRED | Constant has been added. |
+| Magento\AdobeCommerceEventsClient\Api\Data\EventInterface::isHipaaAuditRequired | [public] Method has been added. |
+| Magento\AdobeCommerceEventsClient\Api\Data\EventInterface::setHipaaAuditRequired | [public] Method has been added. |
+| Magento\AdobeCommerceEventsClient\Event\EventListInterface | Interface was added. |
+| Magento\AdobeCommerceWebhooksAdminUi\Api\HookRepositoryInterface | Interface was removed. |
+| Magento\CommerceBackendUix\Api\Data\MassActionFailedRequestInterface | Interface was added. |
+| Magento\CommerceBackendUix\Api\MassActionFailedRequestRepositoryInterface | Interface was added. |
+| Magento\Framework\Mview\ViewInterface::unsubscribe | [public] Added optional parameter(s). |
+| Magento\Framework\Mview\ViewInterface::unsubscribe | [public] Method return typing changed. |
+| Magento\Framework\Setup\ConsoleLoggerInterface | Interface was added. |
+| Magento\PaymentServicesPaypal\Api\Data\PaymentOrderDetailsInterface::getPaymentSourceDetails | [public] Method return typing changed. |
+| Magento\PaymentServicesPaypal\Api\Data\PaymentSdkParamsInterface::getParams | [public] Method return typing changed. |
+| Magento\PaymentServicesPaypal\Api\PaymentSdkRequestInterface::getByLocation | [public] Method return typing changed. |
+| Magento\PaymentServicesPaypal\Api\PaymentSdkRequestInterface::getByLocationAndMethodCode | [public] Method return typing changed. |
+
+#### Database changes {#commerce-BICs-247-248-beta1-database}
+
+| What changed | How it changed |
+| --- | --- |
+| admin\_ui\_sdk\_custom\_fees | Table was added |
+| admin\_ui\_sdk\_mass\_actions\_failed\_request | Table was added |
+| eav\_attribute\_option\_value/EAV\_ATTRIBUTE\_OPTION\_VALUE\_STORE\_ID\_OPTION\_ID | Unique key was added |
+| event\_data/hipaa\_audit\_required | Column was added |
+| webhooks\_configuration | Module db schema whitelist reduced (webhooks\_configuration). |
+| webhooks\_configuration | Table was dropped |
+| webhooks\_log | Table was added |
+
+#### Di changes {#commerce-BICs-247-248-beta1-di}
+
+| What changed | How it changed |
+| --- | --- |
+| WebhookFormDataGrid | Virtual Type was removed |
+| beforeSaveHookValidator | Virtual Type was removed |
+
+#### Layout changes {#commerce-BICs-247-248-beta1-layout}
+
+| What changed | How it changed |
+| --- | --- |
+| webhook-validation-config | Block was removed |
+| webhooks\_hook\_edit | An Update was removed |
+
+#### System changes {#commerce-BICs-247-248-beta1-system}
+
+| What changed | How it changed |
+| --- | --- |
+| admin\_ui\_sdk/general\_config/refresh\_registrations | A field-node was added |
+| adobe\_io\_events/integration/create\_event\_provider | A field-node was added |
+| adobe\_io\_events/integration/synchronize\_events | A field-node was added |
+| catalog/seo/product\_url\_transliteration | A field-node was added |
+| cataloginventory/options/not\_available\_message | A field-node was added |
+| commerce\_webhooks | A section-node was added |
+| commerce\_webhooks/db\_log | A group-node was added |
+| commerce\_webhooks/db\_log/db\_log\_enabled | A field-node was added |
+| commerce\_webhooks/db\_log/level | A field-node was added |
+| commerce\_webhooks/db\_log/retention\_period | A field-node was added |
+| commerce\_webhooks/digital\_signature | A group-node was added |
+| commerce\_webhooks/digital\_signature/enabled | A field-node was added |
+| commerce\_webhooks/digital\_signature/private\_key\_generate\_button | A field-node was added |
+| commerce\_webhooks/digital\_signature/public\_key | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/paypal\_l2\_l3\_send\_data | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/reset\_production\_merchant\_id | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/reset\_sandbox\_merchant\_id | A field-node was added |
+| recaptcha\_frontend | A section-node was added |
+| recaptcha\_frontend/type\_for | A group-node was added |
+| recaptcha\_frontend/type\_for/resend\_confirmation\_email | A field-node was added |
+| system/full\_page\_cache/varnish/export\_button\_version7 | A field-node was added |
+| twofactorauth/general/auth\_lock\_expire | A field-node was added |
+| twofactorauth/general/twofactorauth\_retry | A field-node was added |
+| twofactorauth/google/leeway | A field-node was added |
+| twofactorauth/google/otp\_window | A field-node was removed |
+
+#### Xsd changes {#commerce-BICs-247-248-beta1-xsd}
+
+| What changed | How it changed |
+| --- | --- |
+| module-adobe-commerce-events-client/etc/io\_events.xsd | A schema declaration was added |
+| module-adobe-commerce-events-client/etc/io\_events.xsd | A schema declaration was removed |
+| module-data-exporter/etc/et\_schema.xsd | A schema declaration was added |
+| module-data-exporter/etc/et\_schema.xsd | A schema declaration was removed |
+| module-elasticsearch/etc/esconfig.xsd | A schema declaration was added |
+| module-elasticsearch/etc/esconfig.xsd | A schema declaration was removed |
+| module-query-xml/etc/query.xsd | A schema declaration was added |
+| module-query-xml/etc/query.xsd | A schema declaration was removed |
+
+#### Class API membership changes {#commerce-BICs-247-248-beta1-class-api-membership}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\Customer\Model\ResourceModel\Customer\Collection | Class was added. |
+| Magento\SalesRule\Model\Validator | Class was added. |

--- a/src/_includes/backward-incompatible-changes/open-source/2.4.7-2.4.8-beta1.md
+++ b/src/_includes/backward-incompatible-changes/open-source/2.4.7-2.4.8-beta1.md
@@ -1,0 +1,67 @@
+#### Class changes {#open-source-BICs-247-248-beta1-class}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\Framework\Amqp\Config | Interface has been added. |
+| Magento\Framework\Amqp\Config::\_resetState | [public] Method has been added. |
+| Magento\Framework\Data\Collection::getItemById | [public] Method return typing changed. |
+| Magento\Framework\Logger\Handler\Base::write | [protected] Method parameter typing changed. |
+| Magento\GiftMessage\Block\Cart\GiftOptions::\_\_construct | [public] Method parameter typing changed. |
+| Magento\GiftMessage\Block\Cart\Item\Renderer\Actions\GiftOptions::\_\_construct | [public] Method parameter typing changed. |
+| Magento\PageCache\Model\Config::VARNISH\_7\_CONFIGURATION\_PATH | Constant has been added. |
+| Magento\PaymentServicesBase\Block\Adminhtml\System\Config\Fieldset\Payment::productMeta | Property visibility has been changed to lower lever from [protected] to [private] |
+| Magento\PaymentServicesPaypal\Block\Cart\ValidationMessages::addQuoteMessages | Method visibility has been changed to lower lever from [protected] to [private] |
+
+#### Interface changes {#open-source-BICs-247-248-beta1-interface}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\Framework\Mview\ViewInterface::unsubscribe | [public] Added optional parameter(s). |
+| Magento\Framework\Mview\ViewInterface::unsubscribe | [public] Method return typing changed. |
+| Magento\Framework\Setup\ConsoleLoggerInterface | Interface was added. |
+| Magento\PaymentServicesPaypal\Api\Data\PaymentOrderDetailsInterface::getPaymentSourceDetails | [public] Method return typing changed. |
+| Magento\PaymentServicesPaypal\Api\Data\PaymentSdkParamsInterface::getParams | [public] Method return typing changed. |
+| Magento\PaymentServicesPaypal\Api\PaymentSdkRequestInterface::getByLocation | [public] Method return typing changed. |
+| Magento\PaymentServicesPaypal\Api\PaymentSdkRequestInterface::getByLocationAndMethodCode | [public] Method return typing changed. |
+
+#### Database changes {#open-source-BICs-247-248-beta1-database}
+
+| What changed | How it changed |
+| --- | --- |
+| eav\_attribute\_option\_value/EAV\_ATTRIBUTE\_OPTION\_VALUE\_STORE\_ID\_OPTION\_ID | Unique key was added |
+
+#### System changes {#open-source-BICs-247-248-beta1-system}
+
+| What changed | How it changed |
+| --- | --- |
+| catalog/seo/product\_url\_transliteration | A field-node was added |
+| cataloginventory/options/not\_available\_message | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/paypal\_l2\_l3\_send\_data | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/reset\_production\_merchant\_id | A field-node was added |
+| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/reset\_sandbox\_merchant\_id | A field-node was added |
+| recaptcha\_frontend | A section-node was added |
+| recaptcha\_frontend/type\_for | A group-node was added |
+| recaptcha\_frontend/type\_for/resend\_confirmation\_email | A field-node was added |
+| system/full\_page\_cache/varnish/export\_button\_version7 | A field-node was added |
+| twofactorauth/general/auth\_lock\_expire | A field-node was added |
+| twofactorauth/general/twofactorauth\_retry | A field-node was added |
+| twofactorauth/google/leeway | A field-node was added |
+| twofactorauth/google/otp\_window | A field-node was removed |
+
+#### Xsd changes {#open-source-BICs-247-248-beta1-xsd}
+
+| What changed | How it changed |
+| --- | --- |
+| module-data-exporter/etc/et\_schema.xsd | A schema declaration was added |
+| module-data-exporter/etc/et\_schema.xsd | A schema declaration was removed |
+| module-elasticsearch/etc/esconfig.xsd | A schema declaration was added |
+| module-elasticsearch/etc/esconfig.xsd | A schema declaration was removed |
+| module-query-xml/etc/query.xsd | A schema declaration was added |
+| module-query-xml/etc/query.xsd | A schema declaration was removed |
+
+#### Class API membership changes {#open-source-BICs-247-248-beta1-class-api-membership}
+
+| What changed | How it changed |
+| --- | --- |
+| Magento\Customer\Model\ResourceModel\Customer\Collection | Class was added. |
+| Magento\SalesRule\Model\Validator | Class was added. |

--- a/src/pages/development/backward-incompatible-changes/reference.md
+++ b/src/pages/development/backward-incompatible-changes/reference.md
@@ -27,6 +27,22 @@ To view changes in functional tests, refer to [Backward incompatible changes in 
 
 Patch releases are primarily focused on delivering security and quality enhancements on a regular basis to help you keep your sites performing at their peak. On an exceptional basis, breaking changes or additional patches or hotfixes may be released to address security or compliance issues and high-impact quality issues. On the module level, these are mostly PATCH-level changes; sometimes MINOR-level changes. See [Release policy](https://experienceleague.adobe.com/docs/commerce-operations/release/policy.html).
 
+## 2.4.7 - 2.4.8-beta1
+
+### Adobe Commerce
+
+Adobe Commerce v2.4.8-beta1 (no B2B extension).
+
+import Ac248beta1 from '/src/_includes/backward-incompatible-changes/commerce/2.4.7-2.4.8-beta1.md'
+
+<Ac248beta1 />
+
+### Magento Open Source
+
+import Os248beta1 from '/src/_includes/backward-incompatible-changes/open-source/2.4.7-2.4.8-beta1.md'
+
+<Os248beta1 />
+
 ## 2.4.6 - 2.4.7
 
 ### Adobe Commerce


### PR DESCRIPTION
Added backward incompatible changes reference reports for 2.4.7-2.4.8-beta1 versions delta. To update the [actual topic](https://developer.adobe.com/commerce/php/development/backward-incompatible-changes/reference/), make sure that the reports are included in the topic.

Preview: https://commerce-docs.github.io/commerce-php/development/backward-incompatible-changes/reference/#247---248-beta1