### PR TITLE
fix: remove beta note from data encryption topic

### DIFF
--- a/src/pages/development/security/data-encryption.md
+++ b/src/pages/development/security/data-encryption.md
@@ -6,11 +6,7 @@ keywords:
   - Security
 ---
 
-import BetaNote from '/src/_includes/notes/beta.md'
-
 # Data re-encryption
-
-<BetaNote />
 
 Adobe Commerce and Magento Open Source provide functionality to re-encrypt certain encrypted system configuration, payment fields, and custom fields. These operations may be necessary after [rotating an encryption key](https://experienceleague.adobe.com/en/docs/commerce-admin/systems/security/encryption-key).
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes a beta note. This feature is also available in the latest security patches (Feb 2025) for supported release lines.

## Affected pages

- https://developer.adobe.com/commerce/php/development/security/data-encryption/