### PR TITLE
Delete reviewdog from the PR testing workflow

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -6,7 +6,6 @@
   permissions:
     contents: read
     statuses: write
-    pull-requests: write
   
   jobs:
     testing:

--- a/.github/workflows/validate-pr_job.yml
+++ b/.github/workflows/validate-pr_job.yml
@@ -13,40 +13,14 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Setup reviewdog
-      uses: reviewdog/action-setup@v1.3.0
-      with:
-        reviewdog_version: v0.20.3
-
     - name: Load super-linter configuration
       shell: bash
       run: cat .github/super-linter.env >> "$GITHUB_ENV"
 
-    - name: Lint Code Base with super-linter and reviewdog
+    - name: Lint Code Base with super-linter
       uses: super-linter/super-linter/slim@v7.3.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Report linting results with reviewdog
-      shell: bash
-      run: |
-        TMPFILE=$(mktemp)
-        git diff > "${TMPFILE}"
-        if [ ! -s "${TMPFILE}" ]; then
-          echo "No changes detected, skipping reviewdog."
-          exit 0
-        fi
-        git stash --include-untracked
-        reviewdog                        \
-          -f=diff                        \
-          -f.diff.strip=1                \
-          -name="markdownlint-fix"       \
-          -reporter="github-pr-review"   \
-          -filter-mode="diff_context"    \
-          -fail-level=error < "${TMPFILE}"
-        git stash drop || true
-      env:
-        REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   remark-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) deletes reviewdog from the PR testing workflow since it needs more improvements such as support of forks and better reporting.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- none
