### PR TITLE
Convert BIC tables to grouped list to improve readability

### DIFF
--- a/src/_includes/backward-incompatible-changes/commerce/2.4.7-2.4.8.md
+++ b/src/_includes/backward-incompatible-changes/commerce/2.4.7-2.4.8.md
@@ -1,1009 +1,1075 @@
-#### Class changes {#commerce-b2b-BICs-247-248-stable-class}
+#### Class changes
 
-| What changed | How it changed |
-| --- | --- |
-| Magento\AdminGws\Model\Collections::\_\_construct | [public] Method parameter typing changed. |
-| Magento\AdminGws\Model\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\AdminNotification\Model\Feed::\_\_construct | [public] Method parameter typing changed. |
-| Magento\AdminNotification\Model\ResourceModel\System\Message\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\AdobeCommerceEventsClient\Block\Events\ModuleList::\_\_construct | [public] Method parameter typing changed. |
-| Magento\AdobeCommerceEventsClient\Event\Event::EVENT\_XML\_DEFINED | Constant has been added. |
-| Magento\AdobeCommerceEventsClient\Event\Event::\_\_construct | [public] Method parameter typing changed. |
-| Magento\AdobeCommerceEventsClient\Event\Event::isXmlDefined | [public] Method has been added. |
-| Magento\AdobeCommerceEventsClient\Event\EventList::\_\_construct | [public] Method parameter typing changed. |
-| Magento\AdobeIoEventsClient\Model\AdobeIOConfigurationProvider::\_\_construct | [public] Method parameter typing changed. |
-| Magento\AdobeIoEventsClient\Model\EventMetadataClient::\_\_construct | [public] Method parameter typing changed. |
-| Magento\AdvancedCheckout\Block\Adminhtml\Manage\Items::\_\_construct | [public] Method parameter typing changed. |
-| Magento\AdvancedCheckout\Model\Cart::\_\_construct | [public] Method parameter typing changed. |
-| Magento\AdvancedCheckout\Model\Cart::saveAffectedProducts | [public] Method parameter typing changed. |
-| Magento\AdvancedSearch\Model\ResourceModel\Index::\_\_construct | [public] Method parameter typing changed. |
-| Magento\AdvancedSearch\Model\ResourceModel\Search\Grid\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\App\AbstractAction::\_forward | [protected] Method parameter typing changed. |
-| Magento\Backend\App\Area\FrontNameResolver::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Block\Context::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Block\Media\Uploader::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Block\Menu::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Block\System\Store\Edit::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Block\Template\Context::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Block\Widget\Context::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Block\Widget\Form::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Block\Widget\Grid\Export::\_getRowCollection | [protected] Method parameter typing changed. |
-| Magento\Backend\Block\Widget\Grid\Massaction::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Controller\Adminhtml\Auth\Login::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Helper\Dashboard\Order::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Model\Auth::throwException | [public] Method parameter typing changed. |
-| Magento\Backend\Model\Auth\Session::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Model\Menu::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Model\Url::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backup\Model\Config\Backend\Cron::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Banner\Model\Banner::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Bundle\Block\Adminhtml\Sales\Order\View\Items\Renderer::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Bundle\Block\Sales\Order\Items\Renderer::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Bundle\Helper\Catalog\Product\Configuration::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Bundle\Model\Option::setProductLinks | [public] Method parameter typing changed. |
-| Magento\Bundle\Model\Product\Price::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Bundle\Model\Product\Type::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Bundle\Model\ResourceModel\Selection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Bundle\Model\ResourceModel\Selection\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Bundle\Model\Selection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Bundle\Pricing\Price\ConfiguredPrice::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Captcha\Model\DefaultModel::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogEvent\Model\Category\EventList::getEventCollection | [public] Method parameter typing changed. |
-| Magento\CatalogEvent\Model\Event::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogEvent\Model\ResourceModel\Event\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogImportExport\Model\Import\Product::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogImportExport\Model\Import\Product\Option::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogImportExport\Model\Import\Product\Type\AbstractType::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogImportExport\Model\Import\Uploader::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogInventory\Model\Adminhtml\Stock\Item::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogInventory\Model\ResourceModel\Indexer\Stock\DefaultStock::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogInventory\Model\Source\Stock::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogPermissions\Model\Indexer\AbstractAction::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogPermissions\Model\Indexer\Category\Action\Full::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogPermissions\Model\Indexer\Category\Action\Rows::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogPermissions\Model\Indexer\Product\Action\Rows::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogPermissions\Model\Indexer\System\Config\Mode::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogPermissions\Model\ResourceModel\Permission\Index::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogRule\Model\Indexer\IndexBuilder::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogRule\Model\Indexer\IndexBuilder::applyAllRules | [protected] Method parameter typing changed. |
-| Magento\CatalogRule\Model\Indexer\IndexBuilder::getRuleProductsStmt | [protected] Method parameter typing changed. |
-| Magento\CatalogRule\Model\ResourceModel\Rule\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogSearch\Model\Adminhtml\System\Config\Backend\Engine::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogSearch\Model\Advanced::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogSearch\Model\Indexer\Fulltext::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogSearch\Model\Indexer\Fulltext::executeByDimensions | [public] Method parameter typing changed. |
-| Magento\CatalogSearch\Model\Indexer\Fulltext\Action\DataProvider::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogSearch\Model\Indexer\Fulltext\Action\Full::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogSearch\Model\Indexer\IndexStructure::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogSearch\Model\ResourceModel\Advanced\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogSearch\Model\ResourceModel\Fulltext::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogSearch\Model\ResourceModel\Search\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogSearch\Model\Search\RequestGenerator::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogWidget\Model\Rule::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Block\Adminhtml\Product\Composite\Configure::setProduct | [public] Method parameter typing changed. |
-| Magento\Catalog\Block\Adminhtml\Product\Edit\Action\Attribute\Tab\Attributes::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Block\Category\View::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Block\Product\ImageFactory::create | [public] Method parameter typing changed. |
-| Magento\Catalog\Block\Product\ProductList\Toolbar::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Block\Product\View\Gallery::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Block\Product\View\Options::setProduct | [public] Method parameter typing changed. |
-| Magento\Catalog\Block\Product\View\Options\AbstractOptions::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Block\Product\View\Options\AbstractOptions::setProduct | [public] Method parameter typing changed. |
-| Magento\Catalog\Block\Product\View\Options\Type\Select::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Controller\Adminhtml\Product\Initialization\Helper::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Helper\Image::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Helper\Product\ProductList::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\AbstractModel::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\AbstractModel::getAttributeDefaultValue | [public] Method return typing changed. |
-| Magento\Catalog\Model\Category::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Category::setChildrenData | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Category\Attribute\Backend\Image::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Category\DataProvider::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Design::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Indexer\Category\Product\AbstractAction::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product::setMediaGalleryEntries | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product::setOptions | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product::setProductLinks | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product::setTierPrices | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Action::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Attribute\Backend\Price::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Compare\Item::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Compare\Item::bindCustomerLogout | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Compare\ListCompare::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Gallery\CreateHandler::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Gallery\Processor::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Gallery\UpdateHandler::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Link::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Option::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Option::setProduct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Option::setValues | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Option\Value::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Type\AbstractType::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Type\Price::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Type\Price::setTierPrices | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Url::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\AbstractResource::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\Category\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\Collection\AbstractCollection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\Eav\Attribute::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\Layer\Filter\Price::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\Product::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\Product\Attribute\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\Product\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\Product\Compare\Item\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\Product\Gallery::loadDataFromTableByValueId | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\Product\Indexer\Price\DefaultPrice::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\Product\Link\Product\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\Product\Option\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\System\Config\Backend\Catalog\Url\Rewrite\Suffix::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Pricing\Price\TierPrice::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Ui\Component\ColumnFactory::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Ui\Component\Listing\Columns\Websites::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AdvancedPricing::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Categories::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Eav::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\General::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Ui\DataProvider\Product\ProductCustomOptionsDataProvider::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Ui\DataProvider\Product\ProductDataProvider::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Checkout\Block\Cart\Item\Renderer::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Checkout\Block\Cart\Shipping::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Checkout\Block\Cart\Sidebar::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Checkout\Block\Onepage::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Checkout\Model\Cart\ImageProvider::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Checkout\Model\Session::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Tree::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Cms\Model\Page::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Cms\Model\Wysiwyg\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Cms\Model\Wysiwyg\Images\Storage::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Company\Block\Company\Login\Info::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Company\Block\Company\Register\Link::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\App\Config\Type\System::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Block\System\Config\Edit::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Block\System\Config\Form::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Console\Command\ConfigSetCommand::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Console\Command\ConfigSet\DefaultProcessor::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Admin\Custom::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Admin\Usecustom::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Admin\Usesecretkey::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Baseurl::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Currency\Allow::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Currency\Base::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Currency\Cron::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Encrypted::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\File::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Image\Adapter::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Locale::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Log\Cron::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Secure::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Serialized::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Store::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Export\Comment::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Loader::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Source\Locale\Currency::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Structure\Data::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\TypePool::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\ResourceModel\Config::\_construct | [protected] Method parameter typing changed. |
-| Magento\ConfigurableProduct\Block\Adminhtml\Product\Composite\Fieldset\Configurable::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ConfigurableProduct\Block\Adminhtml\Product\Steps\Bulk::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ConfigurableProduct\Block\Product\View\Type\Configurable::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ConfigurableProduct\Helper\Data::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ConfigurableProduct\Model\Product\Type\Configurable::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable\Attribute\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Cron\Model\Schedule::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CurrencySymbol\Model\System\Currencysymbol::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CustomerBalance\Block\Adminhtml\Sales\Order\Creditmemo\Controls::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CustomerCustomAttributes\Block\Adminhtml\Customer\Address\Attribute\Edit\Tab\General::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CustomerCustomAttributes\Block\Adminhtml\Customer\Attribute\Edit\Js::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CustomerCustomAttributes\Block\Adminhtml\Customer\Attribute\Edit\Tab\Main::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CustomerSegment\Model\Condition\Combine\AbstractCombine::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CustomerSegment\Model\Customer::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CustomerSegment\Model\ResourceModel\Customer::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CustomerSegment\Model\ResourceModel\Segment::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CustomerSegment\Model\Segment::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Block\Account\AuthenticationPopup::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Block\Address\Book::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Block\Address\Book::getAddressHtml | [public] Method parameter typing changed. |
-| Magento\Customer\Block\Address\Edit::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Block\Adminhtml\Edit\Tab\Newsletter\Grid::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Block\CustomerScopeData::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Block\Form\Register::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\CustomerData\SectionPool::getSectionsData | [public] Method parameter typing changed. |
-| Magento\Customer\Model\Address::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Model\Address\AbstractAddress::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Model\Customer::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Model\Customer\DataProvider::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Model\Data\Address::setRegion | [public] Method parameter typing changed. |
-| Magento\Customer\Model\Group::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Model\ResourceModel\Customer::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Model\Session::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Model\Url::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Deploy\Package\Package::aggregate | [public] Method parameter typing changed. |
-| Magento\Directory\Model\Country::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Directory\Model\Currency::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Directory\Model\ResourceModel\Country::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Directory\Model\ResourceModel\Country\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Directory\Model\ResourceModel\Region\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Downloadable\Model\Link::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Downloadable\Model\Link::setLinkFileContent | [public] Method parameter typing changed. |
-| Magento\Downloadable\Model\Link::setSampleFileContent | [public] Method parameter typing changed. |
-| Magento\Downloadable\Model\Product\Type::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Downloadable\Model\ResourceModel\Sample\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Downloadable\Model\Sales\Order\Pdf\Items\Creditmemo::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Downloadable\Model\Sales\Order\Pdf\Items\Invoice::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Downloadable\Model\Sample::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Downloadable\Model\Sample::setSampleFileContent | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\AbstractEntity::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Attribute::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Attribute\AbstractAttribute::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Attribute\AbstractAttribute::setFrontendLabels | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Attribute\AbstractAttribute::setOptions | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Attribute\AbstractAttribute::setValidationRules | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Attribute\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Attribute\Frontend\AbstractFrontend::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Attribute\Group::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Attribute\Option::setStoreLabels | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Attribute\Source\Table::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Collection\AbstractCollection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Collection\VersionControl\AbstractCollection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Type::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Form\Element::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Form\Fieldset::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\ResourceModel\Attribute\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\ResourceModel\Entity\Attribute::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\ResourceModel\Entity\Attribute\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\ResourceModel\Form\Attribute\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\ResourceModel\Form\Fieldset\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Setup\EavSetup::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Elasticsearch\Model\ResourceModel\Index::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Elasticsearch\SearchAdapter\Dynamic\DataProvider::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Email\Model\AbstractTemplate::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Email\Model\BackendTemplate::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Email\Model\Template::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Email\Model\Template\Filter::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Amqp\Config | Interface has been added. |
-| Magento\Framework\Amqp\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Amqp\Config::\_resetState | [public] Method has been added. |
-| Magento\Framework\Api\Search\FilterGroup::setFilters | [public] Method parameter typing changed. |
-| Magento\Framework\App\Action\Action::\_forward | [protected] Method parameter typing changed. |
-| Magento\Framework\App\Bootstrap::create | [public] Method parameter typing changed. |
-| Magento\Framework\App\Config\Value::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\App\Http\Context::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\App\Request\Http::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\App\Response\Http::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Config\Data::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Config\Data\Scoped::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Controller\Result\Json::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\DB\Adapter\Pdo\Mysql::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\DB\Adapter\Pdo\MysqlFactory::create | [public] Method parameter typing changed. |
-| Magento\Framework\DB\Ddl\Table::\_\_construct | [public] Method has been added. |
-| Magento\Framework\Data\Collection::getItemById | [public] Method return typing changed. |
-| Magento\Framework\Data\Collection\AbstractDb::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Data\Collection\Filesystem::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Data\Form::setElementRenderer | [public] Method parameter typing changed. |
-| Magento\Framework\Data\Form::setFieldsetElementRenderer | [public] Method parameter typing changed. |
-| Magento\Framework\Data\Form::setFieldsetRenderer | [public] Method parameter typing changed. |
-| Magento\Framework\Exception\AbstractAggregateException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Exception\AlreadyExistsException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Exception\BulkException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Exception\InputException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Exception\InputException::invalidFieldValue | [public] Method parameter typing changed. |
-| Magento\Framework\Exception\LocalizedException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Exception\NoSuchEntityException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Exception\SerializationException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Exception\TemporaryState\CouldNotSaveException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\File\Uploader::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Filter\Template::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\ForeignKey\Migration\AbstractCommand::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\GraphQl\Exception\GraphQlAuthenticationException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\GraphQl\Exception\GraphQlInputException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\HTTP\PhpEnvironment\RemoteAddress::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Logger\Handler\Base::write | [protected] Method parameter typing changed. |
-| Magento\Framework\Mail\Template\TransportBuilder::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Model\AbstractExtensibleModel::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Model\AbstractModel::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Module\Setup\Migration::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Pricing\Price\Pool::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Pricing\Render::renderAmount | [public] Method parameter typing changed. |
-| Magento\Framework\Pricing\Render\RendererPool::createAmountRender | [public] Method parameter typing changed. |
-| Magento\Framework\Pricing\Render\RendererPool::getAdjustmentRenders | [public] Method parameter typing changed. |
-| Magento\Framework\Profiler::start | [public] Method parameter typing changed. |
-| Magento\Framework\Profiler\Driver\Standard\Stat::getFilteredTimerIds | [public] Method parameter typing changed. |
-| Magento\Framework\Search\Adapter\Mysql\TemporaryStorage::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Setup\Declaration\Schema\Diff\Diff::register | [public] Method parameter typing changed. |
-| Magento\Framework\Setup\Declaration\Schema\Dto\Table::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Setup\Declaration\Schema\ElementHistory::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Validation\ValidationException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Validator\AbstractValidator::setDefaultTranslator | [public] Method parameter typing changed. |
-| Magento\Framework\Validator\Exception::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\View\Context::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\View\Element\Context::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\View\Element\Template\Context::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\View\Element\UiComponentFactory::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult::setItems | [public] Method parameter typing changed. |
-| Magento\Framework\View\Layout\Data\Structure::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\View\Layout\GeneratorPool::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\View\Page\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\View\Result\Page::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Webapi\ErrorProcessor::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Webapi\ServiceInputProcessor::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Webapi\ServiceOutputProcessor::\_\_construct | [public] Method parameter typing changed. |
-| Magento\FunctionalTestingFramework\ObjectManager::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GiftCardAccount\Model\Giftcardaccount::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GiftCard\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Giftcard::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GiftMessage\Block\Cart\GiftOptions::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GiftMessage\Block\Cart\Item\Renderer\Actions\GiftOptions::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GiftMessage\Model\Message::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GiftRegistry\Block\Customer\Address\Edit::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GiftRegistry\Block\Email\Items::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GiftRegistry\Block\Search\Advanced::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GiftRegistry\Model\Entity::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GiftRegistry\Model\Item::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GiftRegistry\Model\Person::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GiftRegistry\Model\ResourceModel\Entity\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GiftRegistry\Model\ResourceModel\Item\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GiftRegistry\Model\Type::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GiftWrapping\Block\Checkout\Options::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GoogleAdwords\Model\Config\Backend\AbstractConversion::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GoogleAnalytics\Block\Ga::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GoogleOptimizer\Helper\Data::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GoogleOptimizer\Helper\Form::addGoogleoptimizerFields | [public] Method parameter typing changed. |
-| Magento\GoogleTagManager\Block\Adminhtml\Banner\Edit\Tab\Ga::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GoogleTagManager\Block\ListJson::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GraphQl\Controller\GraphQl::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GroupedProduct\Model\Product\Type\Grouped::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ImportExport\Model\Import::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ImportExport\Model\Import\AbstractEntity::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ImportExport\Model\Import\AbstractEntity::getBehavior | [public] Method parameter typing changed. |
-| Magento\InstantPurchase\Model\InstantPurchaseOption::\_\_construct | [public] Method parameter typing changed. |
-| Magento\InstantPurchase\Model\InstantPurchaseOptionFactory::create | [public] Method parameter typing changed. |
-| Magento\Integration\Model\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Integration\Model\Integration::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Integration\Model\IntegrationConfig::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Integration\Model\Oauth\Consumer::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Integration\Model\Oauth\Token::\_\_construct | [public] Method parameter typing changed. |
-| Magento\InventoryAdminUi\Ui\DataProvider\SourceDataProvider::\_\_construct | [public] Method parameter typing changed. |
-| Magento\InventoryAdminUi\Ui\DataProvider\StockDataProvider::\_\_construct | [public] Method parameter typing changed. |
-| Magento\InventoryShippingAdminUi\Block\Adminhtml\Order\View\ShipButton::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Inventory\Model\ResourceModel\Source\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Invitation\Block\Form::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Invitation\Model\Invitation::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Invitation\Model\ResourceModel\Invitation\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Logging\Block\Adminhtml\Details::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Logging\Model\Event::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Logging\Model\Event\Changes::\_\_construct | [public] Method parameter typing changed. |
-| Magento\MediaStorage\Model\File\Storage::\_\_construct | [public] Method parameter typing changed. |
-| Magento\MediaStorage\Model\File\Storage\Database::\_\_construct | [public] Method parameter typing changed. |
-| Magento\MediaStorage\Model\File\Storage\Directory\Database::\_\_construct | [public] Method parameter typing changed. |
-| Magento\MediaStorage\Model\File\Uploader::\_\_construct | [public] Method parameter typing changed. |
-| Magento\MediaStorage\Model\ResourceModel\File\Storage\Database::\_\_construct | [public] Method parameter typing changed. |
-| Magento\MessageQueue\Model\ConsumerRunner::\_\_construct | [public] Method parameter typing changed. |
-| Magento\MultipleWishlist\Model\ResourceModel\Item\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Multishipping\Model\Checkout\Type\Multishipping::\_\_construct | [public] Method parameter typing changed. |
-| Magento\NegotiableQuoteDuplicate\Block\Quote\Info\Duplicate | Class was added. |
-| Magento\NegotiableQuoteRequisitionList\Block\Quote\Item\Actions\MoveToRequisitionList | Class was added. |
-| Magento\NegotiableQuoteTemplate\Block\Adminhtml\Template\View | Class was added. |
-| Magento\NegotiableQuoteTemplate\Block\Customer\Account\Link\QuoteTemplate | Class was added. |
-| Magento\NegotiableQuoteTemplate\Block\Quote\Action\CreateTemplate | Class was added. |
-| Magento\NegotiableQuoteTemplate\Block\Template\View | Class was added. |
-| Magento\NegotiableQuote\Block\Adminhtml\Quote\View::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Newsletter\Model\Problem::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Newsletter\Model\Queue::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Newsletter\Model\ResourceModel\Problem\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Newsletter\Model\ResourceModel\Queue\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Newsletter\Model\ResourceModel\Subscriber::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Newsletter\Model\ResourceModel\Subscriber\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Newsletter\Model\Subscriber::\_\_construct | [public] Method parameter typing changed. |
-| Magento\PageBuilder\Block\WysiwygSetup::\_\_construct | [public] Method parameter typing changed. |
-| Magento\PageBuilder\Component\Form\Element\Wysiwyg::\_\_construct | [public] Method parameter typing changed. |
-| Magento\PageBuilder\Controller\ContentType\Preview::\_\_construct | [public] Method parameter typing changed. |
-| Magento\PageBuilder\Model\Stage\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\PageBuilder\Model\Stage\Renderer\CmsStaticBlock::\_\_construct | [public] Method parameter typing changed. |
-| Magento\PageBuilder\Model\Stage\Renderer\WidgetDirective::\_\_construct | [public] Method parameter typing changed. |
-| Magento\PageCache\Model\Config::VARNISH\_7\_CONFIGURATION\_PATH | Constant has been added. |
-| Magento\PageCache\Model\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\PaymentServicesPaypal\Block\SmartButtons::\_\_construct | [public] Method parameter typing changed. |
-| Magento\PaymentServicesPaypal\Block\SmartButtons::doesQuoteExist | [public] Method has been added. |
-| Magento\PaymentServicesPaypal\Model\Api\PaymentOrderRequest::create | [public] Method parameter typing changed. |
-| Magento\PaymentServicesPaypal\Model\Api\PaymentOrderRequest::createGuest | [public] Method parameter typing changed. |
-| Magento\Payment\Gateway\Command\CommandManager::execute | [public] Method parameter typing changed. |
-| Magento\Payment\Gateway\Command\CommandManager::executeByCode | [public] Method parameter typing changed. |
-| Magento\Payment\Gateway\Command\GatewayCommand::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Payment\Gateway\Http\Client\Soap::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Payment\Gateway\Http\Client\Zend::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Payment\Helper\Data::getInfoBlock | [public] Method parameter typing changed. |
-| Magento\Payment\Model\Info::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Payment\Model\MethodList::getAvailableMethods | [public] Method parameter typing changed. |
-| Magento\Payment\Model\Method\AbstractMethod::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Payment\Model\Method\AbstractMethod::isAvailable | [public] Method parameter typing changed. |
-| Magento\Payment\Model\Method\Adapter::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Payment\Model\Method\Adapter::isAvailable | [public] Method parameter typing changed. |
-| Magento\Payment\Model\Method\Free::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Payment\Model\Method\Free::isAvailable | [public] Method parameter typing changed. |
-| Magento\Payment\Model\Method\Logger::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Payment\Model\Method\Logger::debug | [public] Method parameter typing changed. |
-| Magento\Paypal\Block\PayLater\Banner::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Paypal\Model\Api\ProcessableException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Paypal\Model\Billing\AbstractAgreement::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Paypal\Model\Billing\Agreement::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Paypal\Model\ResourceModel\Billing\Agreement\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Persistent\Model\Session::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ProductAlert\Model\Email::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ProductAlert\Model\Price::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ProductAlert\Model\Stock::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ProductVideo\Block\Product\View\Gallery::\_\_construct | [public] Method parameter typing changed. |
-| Magento\PurchaseOrderRule\Block\RuleFieldset\Condition::\_\_construct | [public] Method parameter typing changed. |
-| Magento\PurchaseOrderRule\Block\RuleFieldset\ViewCondition::\_\_construct | [public] Method parameter typing changed. |
-| Magento\PurchaseOrder\Block\PurchaseOrder\Info\Buttons::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Cart\Data\CartItem::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote::assignCustomerWithAddressChange | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote::setBillingAddress | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote::setCurrency | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote::setCustomer | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote::setItems | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote::setShippingAddress | [public] Method parameter typing changed. |
-| Magento\Quote\Model\QuoteValidator::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote\Address::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote\Address::requestShippingRates | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote\Address\Total::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote\Item::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote\Item\AbstractItem::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote\Payment::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Quote\Model\ResourceModel\Quote\Item\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Block\Adminhtml\Grid::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Block\Adminhtml\Grid\Column\Renderer\Currency::\_\_construct | [public] Method has been removed. |
-| Magento\Reports\Controller\Adminhtml\Report\AbstractReport::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Model\Event::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Model\Product\Index\AbstractIndex::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Model\Product\Index\Compared::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Model\ResourceModel\Customer\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Model\ResourceModel\Event::getCurrentStoreIds | [public] Method parameter typing changed. |
-| Magento\Reports\Model\ResourceModel\Order\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Model\ResourceModel\Product\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Model\ResourceModel\Product\Index\Collection\AbstractCollection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Model\ResourceModel\Product\Lowstock\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Model\ResourceModel\Quote\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Model\ResourceModel\Quote\Item\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Model\ResourceModel\Review\Customer\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Model\ResourceModel\Wishlist\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\RequisitionList\Block\Requisition\View\Item::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ResourceConnections\DB\Adapter\Pdo\MysqlProxy::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Review\Block\Form::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Review\Model\Rating::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Review\Model\ResourceModel\Rating::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Review\Model\ResourceModel\Rating\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Review\Model\ResourceModel\Rating\Option\Vote\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Review\Model\ResourceModel\Review\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Review\Model\ResourceModel\Review\Product\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Review\Model\ResourceModel\Review\Product\Collection::\_applyStoresFilterToSelect | [protected] Method parameter typing changed. |
-| Magento\Review\Model\Review::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reward\Model\ResourceModel\Reward\History\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reward\Model\Reward::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reward\Model\Reward\History::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reward\Model\Reward\Rate::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Rma\Block\Adminhtml\Rma\Edit\Tab\General\Shipping\Methods::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Rma\Block\Adminhtml\Rma\Edit\Tab\General\Shippingmethod::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Rma\Block\Adminhtml\Rma\Item\Attribute\Edit\Js::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Rma\Block\Adminhtml\Rma\Item\Attribute\Edit\Tab\Main::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Rma\Block\Returns\Tracking\Package::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Rma\Model\Shipping::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Robots\Block\Data::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Robots\Model\Config\Value::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Rss\Model\Rss::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Rule\Model\AbstractModel::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Rule\Model\Condition\Product\AbstractProduct::\_\_construct | [public] Method parameter typing changed. |
-| Magento\SaaSCommon\Model\ResyncManager::DEFAULT\_RESYNC\_ENTITY\_TYPE | Constant has been added. |
-| Magento\SaaSCommon\Model\ResyncManager::partialResyncByIds | [public] Method has been added. |
-| Magento\SalesRule\Model\ResourceModel\Rule\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\SalesRule\Model\ResourceModel\Rule\Collection::setValidationFilter | [public] Method parameter typing changed. |
-| Magento\SalesRule\Model\Rule::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Block\Adminhtml\Order\Create\Search\Grid::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Block\Order\Info\Buttons\Rss::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Block\Order\Items::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Block\Order\Recent::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\AbstractModel::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\AdminOrder\Create::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Config\Ordered::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order::setBillingAddress | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order::setPayment | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order::setShippingAddress | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order::setStatusHistories | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Address::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Creditmemo::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\CreditmemoDocumentFactory::createFromInvoice | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\CreditmemoDocumentFactory::createFromOrder | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\CreditmemoFactory::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Creditmemo\Comment::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Creditmemo\Item::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Creditmemo\Notifier::notify | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Email\Sender\InvoiceSender::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Invoice::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\InvoiceDocumentFactory::create | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Invoice\Item::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Invoice\Notifier::notify | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Item::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Item::setProductOptions | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Payment::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Payment\Info::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Payment\Transaction::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Pdf\AbstractPdf::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Pdf\Items\AbstractItems::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Shipment::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Shipment::setPackages | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\ShipmentDocumentFactory::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\ShipmentDocumentFactory::create | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\ShipmentFactory::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Shipment\Item::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Shipment\Notifier::notify | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Shipment\Track::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Status\History::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\ResourceModel\Collection\AbstractCollection::setItems | [public] Method parameter typing changed. |
-| Magento\Sales\Model\ResourceModel\Collection\AbstractCollection::setSearchCriteria | [public] Method parameter typing changed. |
-| Magento\Sales\Model\ResourceModel\Order\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ScheduledImportExport\Model\Scheduled\Operation::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Search\Model\Query::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Search\Model\QueryFactory::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Search\Model\ResourceModel\Query\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Search\Model\SearchEngine\Config\Data::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Search\Model\SynonymReader::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Search\Model\Synonym\MergeConflictException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Security\Model\AdminSessionInfo::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Security\Model\ResourceModel\AdminSessionInfo\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Security\Model\ResourceModel\PasswordResetRequestEvent\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\SendFriend\Model\SendFriend::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Setup\Module\SetupFactory::create | [public] Method parameter typing changed. |
-| Magento\Shipping\Model\Carrier\AbstractCarrier::\_getAllowedContainers | [protected] Method parameter typing changed. |
-| Magento\Shipping\Model\Carrier\AbstractCarrier::getContainerTypes | [public] Method parameter typing changed. |
-| Magento\Shipping\Model\Carrier\AbstractCarrier::getDeliveryConfirmationTypes | [public] Method parameter typing changed. |
-| Magento\Sitemap\Model\ResourceModel\Catalog\Product::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sitemap\Model\ResourceModel\Cms\Page::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sitemap\Model\Sitemap::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Staging\Block\Adminhtml\Update\Preview::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Store\Block\Switcher::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Store\Model\Group::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Store\Model\Store::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Store\Model\StoreIsInactiveException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Store\Model\Website::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Swatches\Block\Product\Renderer\Configurable::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Swatches\Block\Product\Renderer\Listing\Configurable::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Swatches\Helper\Media::\_\_construct | [public] Method parameter typing changed. |
-| Magento\TargetRule\Block\Checkout\Cart\Crosssell::\_\_construct | [public] Method parameter typing changed. |
-| Magento\TargetRule\Model\Actions\Condition\Combine::\_\_construct | [public] Method parameter typing changed. |
-| Magento\TargetRule\Model\Index::\_\_construct | [public] Method parameter typing changed. |
-| Magento\TargetRule\Model\Rule::\_\_construct | [public] Method parameter typing changed. |
-| Magento\TargetRule\Model\Rule\Condition\Combine::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Tax\Helper\Data::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Theme\Block\Adminhtml\Wysiwyg\Files\Tree::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Theme\Block\Html\Breadcrumbs::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Theme\Block\Html\Header::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Theme\Helper\Storage::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Ui\Component\Filters\Type\Select::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Ui\Component\Listing\Columns\Date::\_\_construct | [public] Method parameter typing changed. |
-| Magento\UrlRewrite\Model\Exception\UrlAlreadyExistsException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\UrlRewrite\Model\ResourceModel\UrlRewriteCollection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\UrlRewrite\Model\UrlRewrite::\_\_construct | [public] Method parameter typing changed. |
-| Magento\UrlRewrite\Service\V1\Data\UrlRewrite::\_\_construct | [public] Method parameter typing changed. |
-| Magento\User\Model\ResourceModel\User::\_\_construct | [public] Method parameter typing changed. |
-| Magento\User\Model\User::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Variable\Model\Variable::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Variable\Model\Variable\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Vault\Model\Method\Vault::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Vault\Model\Method\Vault::isAvailable | [public] Method parameter typing changed. |
-| Magento\VersionsCms\Block\Adminhtml\Cms\Hierarchy\Manage::\_\_construct | [public] Method parameter typing changed. |
-| Magento\VersionsCms\Block\Cms\Page::\_\_construct | [public] Method parameter typing changed. |
-| Magento\VersionsCms\Block\Hierarchy\Head::\_\_construct | [public] Method parameter typing changed. |
-| Magento\VersionsCms\Block\Hierarchy\Menu::\_\_construct | [public] Method parameter typing changed. |
-| Magento\VersionsCms\Block\Hierarchy\Pagination::\_\_construct | [public] Method parameter typing changed. |
-| Magento\VersionsCms\Model\Hierarchy\Node::\_\_construct | [public] Method parameter typing changed. |
-| Magento\VersionsCms\Model\ResourceModel\Hierarchy\Node\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\VisualMerchandiser\Block\Adminhtml\Category\Merchandiser\Tile::\_\_construct | [public] Method parameter typing changed. |
-| Magento\VisualMerchandiser\Model\Rules::\_\_construct | [public] Method parameter typing changed. |
-| Magento\VisualMerchandiser\Model\Rules\Factory::\_\_construct | [public] Method parameter typing changed. |
-| Magento\VisualMerchandiser\Model\Sorting::\_\_construct | [public] Method parameter typing changed. |
-| Magento\VisualMerchandiser\Model\Sorting\SortAbstract::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Webapi\Model\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\WebsiteRestriction\Model\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Weee\Helper\Data::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Weee\Model\Tax::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Widget\Model\Widget\Instance::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Image::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Wishlist\Block\Share\Email\Items::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Wishlist\Helper\Data::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Wishlist\Model\Item::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Wishlist\Model\Item\Option::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Wishlist\Model\ResourceModel\Item\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Wishlist\Model\Wishlist::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Wishlist\Model\Wishlist\Data\WishlistItem::\_\_construct | [public] Method parameter typing changed. |
+##### Class was added
 
-#### Interface changes {#commerce-b2b-BICs-247-248-stable-interface}
+- Magento\NegotiableQuoteDuplicate\Block\Quote\Info\Duplicate
+- Magento\NegotiableQuoteRequisitionList\Block\Quote\Item\Actions\MoveToRequisitionList
+- Magento\NegotiableQuoteTemplate\Block\Adminhtml\Template\View
+- Magento\NegotiableQuoteTemplate\Block\Customer\Account\Link\QuoteTemplate
+- Magento\NegotiableQuoteTemplate\Block\Quote\Action\CreateTemplate
+- Magento\NegotiableQuoteTemplate\Block\Template\View
 
-| What changed | How it changed |
-| --- | --- |
-| Magento\AdminUiSdkCustomFees\Api\CustomFeesRepositoryInterface::getByCreditMemoId | [public] Method has been added. |
-| Magento\AdminUiSdkCustomFees\Api\CustomFeesRepositoryInterface::getByInvoiceId | [public] Method has been added. |
-| Magento\AdminUiSdkCustomFees\Api\CustomFeesRepositoryInterface::getByOrderId | [public] Method return typing changed. |
-| Magento\AdobeCommerceEventsClient\Api\EventSubscriberInterface::unsubscribe | [public] Method has been added. |
-| Magento\AdobeCommerceEventsClient\Api\EventSubscriptionListInterface | Interface was added. |
-| Magento\AdobeCommerceEventsClient\Api\EventUpdaterInterface | Interface was added. |
-| Magento\AdobeCommerceEventsClient\Event\EventRetrieverInterface::getEventsWithLimit | [public] Method parameter typing changed. |
-| Magento\AdobeCommerceEventsClient\Event\EventSubscriptionUpdaterInterface | Interface was added. |
-| Magento\AdobeCommerceWebhooks\Api\Data\HookFieldInterface | Interface was added. |
-| Magento\AdobeCommerceWebhooks\Api\Data\HookHeaderInterface | Interface was added. |
-| Magento\AdobeCommerceWebhooks\Api\Data\HookRuleInterface | Interface was added. |
-| Magento\AdobeCommerceWebhooks\Api\Data\WebhookDataInterface | Interface was added. |
-| Magento\AdobeCommerceWebhooks\Api\WebhookSubscriptionListInterface | Interface was added. |
-| Magento\AdobeImsApi\Api\FlushUserTokensInterface::execute | [public] Method parameter typing changed. |
-| Magento\AdobeImsApi\Api\GetAccessTokenInterface::execute | [public] Method parameter typing changed. |
-| Magento\AdobeImsApi\Api\UserAuthorizedInterface::execute | [public] Method parameter typing changed. |
-| Magento\AdobeStockClientApi\Api\Client\FilesInterface::execute | [public] Method parameter typing changed. |
-| Magento\AdobeStockImageApi\Api\SaveLicensedImageInterface::execute | [public] Method parameter typing changed. |
-| Magento\Bundle\Api\Data\OptionInterface::setProductLinks | [public] Method parameter typing changed. |
-| Magento\CatalogGraphQl\Model\Resolver\Categories\DataProvider\Category\CollectionProcessorInterface::process | [public] Method parameter typing changed. |
-| Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product\CollectionProcessorInterface::process | [public] Method parameter typing changed. |
-| Magento\Catalog\Api\Data\CategoryTreeInterface::setChildrenData | [public] Method parameter typing changed. |
-| Magento\Catalog\Api\Data\ProductAttributeMediaGalleryEntryInterface::setTypes | [public] Method parameter typing changed. |
-| Magento\Catalog\Api\Data\ProductCustomOptionInterface::setValues | [public] Method parameter typing changed. |
-| Magento\Catalog\Api\Data\ProductInterface::setMediaGalleryEntries | [public] Method parameter typing changed. |
-| Magento\Catalog\Api\Data\ProductInterface::setOptions | [public] Method parameter typing changed. |
-| Magento\Catalog\Api\Data\ProductInterface::setProductLinks | [public] Method parameter typing changed. |
-| Magento\Catalog\Api\Data\ProductInterface::setTierPrices | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\CatalogPriceInterface::getCatalogPrice | [public] Method parameter typing changed. |
-| Magento\Checkout\Api\GuestPaymentInformationManagementInterface::savePaymentInformation | [public] Method parameter typing changed. |
-| Magento\Checkout\Api\GuestPaymentInformationManagementInterface::savePaymentInformationAndPlaceOrder | [public] Method parameter typing changed. |
-| Magento\Checkout\Api\PaymentInformationManagementInterface::savePaymentInformation | [public] Method parameter typing changed. |
-| Magento\Checkout\Api\PaymentInformationManagementInterface::savePaymentInformationAndPlaceOrder | [public] Method parameter typing changed. |
-| Magento\CommerceBackendUix\Api\Data\LogInterface | Interface was added. |
-| Magento\CommerceBackendUix\Api\LogRepositoryInterface | Interface was added. |
-| Magento\CompanyCredit\Api\CreditBalanceManagementInterface::decrease | [public] Method parameter typing changed. |
-| Magento\CompanyCredit\Api\CreditBalanceManagementInterface::increase | [public] Method parameter typing changed. |
-| Magento\CompanyRelation\Api\Data\RelationInterface | Interface was added. |
-| Magento\CompanyRelation\Api\Data\RelationSearchResultInterface | Interface was added. |
-| Magento\CompanyRelation\Api\RelationManagerInterface | Interface was added. |
-| Magento\Company\Api\CompanyCustomerAssignmentInterface | Interface was added. |
-| Magento\Company\Api\CompanyUserRepositoryInterface | Interface was added. |
-| Magento\Company\Api\Data\CompanyCustomerInterface::IS\_DEFAULT | Constant has been added. |
-| Magento\Company\Api\Data\CompanyCustomerInterface::getIsDefault | [public] Method has been added. |
-| Magento\Company\Api\Data\CompanyCustomerInterface::setIsDefault | [public] Method has been added. |
-| Magento\Company\Api\Data\CompanyCustomerSearchResultsInterface | Interface was added. |
-| Magento\Company\Api\Data\StructureInterface | Added parent to interface. |
-| Magento\Company\Api\Data\StructureInterface::COMPANY\_ID | Constant has been added. |
-| Magento\Company\Api\Data\StructureInterface::getCompanyId | [public] Method has been added. |
-| Magento\Company\Api\Data\StructureInterface::getExtensionAttributes | [public] Method has been added. |
-| Magento\Company\Api\Data\StructureInterface::setCompanyId | [public] Method has been added. |
-| Magento\Company\Api\Data\StructureInterface::setExtensionAttributes | [public] Method has been added. |
-| Magento\ConfigurableProduct\Api\Data\OptionInterface::setValues | [public] Method parameter typing changed. |
-| Magento\Customer\Api\AccountDelegationInterface::createRedirectForNew | [public] Method parameter typing changed. |
-| Magento\Customer\Api\Data\AddressInterface::setRegion | [public] Method parameter typing changed. |
-| Magento\Customer\Api\Data\AttributeMetadataInterface::setOptions | [public] Method parameter typing changed. |
-| Magento\Customer\Api\Data\CustomerInterface::setAddresses | [public] Method parameter typing changed. |
-| Magento\Customer\Api\Data\OptionInterface::setOptions | [public] Method parameter typing changed. |
-| Magento\Customer\CustomerData\SectionPoolInterface::getSectionsData | [public] Method parameter typing changed. |
-| Magento\Directory\Api\Data\CurrencyInformationInterface::setAvailableCurrencyCodes | [public] Method parameter typing changed. |
-| Magento\Directory\Api\Data\CurrencyInformationInterface::setExchangeRates | [public] Method parameter typing changed. |
-| Magento\Downloadable\Api\Data\LinkInterface::setLinkFileContent | [public] Method parameter typing changed. |
-| Magento\Downloadable\Api\Data\LinkInterface::setSampleFileContent | [public] Method parameter typing changed. |
-| Magento\Downloadable\Api\Data\SampleInterface::setSampleFileContent | [public] Method parameter typing changed. |
-| Magento\Eav\Api\Data\AttributeInterface::setFrontendLabels | [public] Method parameter typing changed. |
-| Magento\Eav\Api\Data\AttributeInterface::setOptions | [public] Method parameter typing changed. |
-| Magento\Eav\Api\Data\AttributeInterface::setValidationRules | [public] Method parameter typing changed. |
-| Magento\Eav\Api\Data\AttributeOptionInterface::setStoreLabels | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\AttributeLoaderInterface::loadAllAttributes | [public] Method parameter typing changed. |
-| Magento\Framework\Api\ImageProcessorInterface::save | [public] Method parameter typing changed. |
-| Magento\Framework\Api\SearchCriteriaInterface::setFilterGroups | [public] Method parameter typing changed. |
-| Magento\Framework\Api\SearchCriteriaInterface::setSortOrders | [public] Method parameter typing changed. |
-| Magento\Framework\Api\Search\SearchResultInterface::setItems | [public] Method parameter typing changed. |
-| Magento\Framework\App\ResourceConnection\ConnectionAdapterInterface::getConnection | [public] Method parameter typing changed. |
-| Magento\Framework\Filesystem\Directory\WriteInterface::copyFile | [public] Method parameter typing changed. |
-| Magento\Framework\Filesystem\Directory\WriteInterface::createSymlink | [public] Method parameter typing changed. |
-| Magento\Framework\Filesystem\Directory\WriteInterface::renameFile | [public] Method parameter typing changed. |
-| Magento\Framework\Filesystem\DriverInterface::copy | [public] Method parameter typing changed. |
-| Magento\Framework\Filesystem\DriverInterface::rename | [public] Method parameter typing changed. |
-| Magento\Framework\Filesystem\DriverInterface::symlink | [public] Method parameter typing changed. |
-| Magento\Framework\GraphQl\Query\ResolverInterface::resolve | [public] Method parameter typing changed. |
-| Magento\Framework\Mview\ViewInterface::unsubscribe | [public] Added optional parameter(s). |
-| Magento\Framework\Mview\ViewInterface::unsubscribe | [public] Method return typing changed. |
-| Magento\Framework\Oauth\NonceGeneratorInterface::generateNonce | [public] Method parameter typing changed. |
-| Magento\Framework\Profiler\DriverInterface::start | [public] Method parameter typing changed. |
-| Magento\Framework\Session\SessionManagerInterface::destroy | [public] Method parameter typing changed. |
-| Magento\Framework\Setup\ConsoleLoggerInterface | Interface was added. |
-| Magento\Framework\Setup\Declaration\Schema\Diff\DiffInterface::register | [public] Method parameter typing changed. |
-| Magento\Framework\Stdlib\CookieManagerInterface::deleteCookie | [public] Method parameter typing changed. |
-| Magento\Framework\Stdlib\CookieManagerInterface::setPublicCookie | [public] Method parameter typing changed. |
-| Magento\Framework\Stdlib\CookieManagerInterface::setSensitiveCookie | [public] Method parameter typing changed. |
-| Magento\Framework\Stdlib\Cookie\CookieScopeInterface::getCookieMetadata | [public] Method parameter typing changed. |
-| Magento\Framework\Stdlib\Cookie\CookieScopeInterface::getPublicCookieMetadata | [public] Method parameter typing changed. |
-| Magento\Framework\Stdlib\Cookie\CookieScopeInterface::getSensitiveCookieMetadata | [public] Method parameter typing changed. |
-| Magento\Framework\View\Design\FileResolution\Fallback\ResolverInterface::resolve | [public] Method parameter typing changed. |
-| Magento\GiftCard\Api\Data\GiftcardAmountInterface::setExtensionAttributes | [public] Method parameter typing changed. |
-| Magento\GiftWrapping\Api\Data\WrappingInterface::getWrappingId | [public] Method return typing changed. |
-| Magento\GiftWrapping\Api\Data\WrappingInterface::setWebsiteIds | [public] Method parameter typing changed. |
-| Magento\GiftWrapping\Api\Data\WrappingSearchResultsInterface::setItems | [public] Method parameter typing changed. |
-| Magento\ImportJsonApi\Api\Data\SourceDataInterface::setItems | [public] Method parameter typing changed. |
-| Magento\InventoryApi\Api\SourceRepositoryInterface::getList | [public] Method parameter typing changed. |
-| Magento\InventoryApi\Api\StockRepositoryInterface::getList | [public] Method parameter typing changed. |
-| Magento\InventoryReservationsApi\Model\ReservationBuilderInterface::setMetadata | [public] Method parameter typing changed. |
-| Magento\Inventory\Model\Source\Command\GetListInterface::execute | [public] Method parameter typing changed. |
-| Magento\Inventory\Model\Stock\Command\GetListInterface::execute | [public] Method parameter typing changed. |
-| Magento\NegotiableQuoteDuplicate\Api\DuplicateNegotiableQuoteInterface | Interface was added. |
-| Magento\NegotiableQuoteTemplate\Api\Data\ReferenceDocumentLinkInterface | Interface was added. |
-| Magento\NegotiableQuoteTemplate\Api\Data\TemplateInterface | Interface was added. |
-| Magento\NegotiableQuoteTemplate\Api\Template\Actions\AcceptInterface | Interface was added. |
-| Magento\NegotiableQuoteTemplate\Api\Template\Actions\CancelInterface | Interface was added. |
-| Magento\NegotiableQuoteTemplate\Api\Template\Actions\CreateInterface | Interface was added. |
-| Magento\NegotiableQuoteTemplate\Api\Template\Actions\DeclineInterface | Interface was added. |
-| Magento\NegotiableQuoteTemplate\Api\Template\Actions\DeleteInterface | Interface was added. |
-| Magento\NegotiableQuoteTemplate\Api\Template\Actions\EditParentQuoteInterface | Interface was added. |
-| Magento\NegotiableQuoteTemplate\Api\Template\Actions\ExpireInterface | Interface was added. |
-| Magento\NegotiableQuoteTemplate\Api\Template\Actions\GenerateQuoteInterface | Interface was added. |
-| Magento\NegotiableQuoteTemplate\Api\Template\Actions\OpenInterface | Interface was added. |
-| Magento\NegotiableQuoteTemplate\Api\Template\Actions\RemoveItemInterface | Interface was added. |
-| Magento\NegotiableQuoteTemplate\Api\Template\Actions\SellerSendInterface | Interface was added. |
-| Magento\NegotiableQuoteTemplate\Api\Template\Actions\SendInterface | Interface was added. |
-| Magento\NegotiableQuoteTemplate\Api\Template\Actions\UpdateInterface | Interface was added. |
-| Magento\NegotiableQuoteTemplate\Api\Template\DraftManagementInterface | Interface was added. |
-| Magento\NegotiableQuoteTemplate\Api\Template\ReferenceDocumentLinkRepositoryInterface | Interface was added. |
-| Magento\NegotiableQuoteTemplate\Api\Template\RepositoryInterface | Interface was added. |
-| Magento\NegotiableQuoteTemplate\Model\Template\ParentQuote\Messages\LabelProviderInterface | Interface was added. |
-| Magento\NegotiableQuote\Api\Data\NegotiableQuoteInterface::STATUS\_DRAFT\_BY\_CUSTOMER | Constant has been added. |
-| Magento\NegotiableQuote\Api\Data\NegotiableQuoteInterface::STATUS\_TEMPLATE\_QUOTE | Constant has been added. |
-| Magento\NegotiableQuote\Api\Data\NegotiableQuoteItemInterface::IS\_DISCOUNTING\_LOCKED | Constant has been added. |
-| Magento\NegotiableQuote\Api\Data\NegotiableQuoteItemInterface::MAX\_QTY | Constant has been added. |
-| Magento\NegotiableQuote\Api\Data\NegotiableQuoteItemInterface::MIN\_QTY | Constant has been added. |
-| Magento\NegotiableQuote\Api\NegotiableQuoteBuyerDraftManagementInterface | Interface was added. |
-| Magento\NegotiableQuote\Api\PaymentInformationManagementInterface::savePaymentInformation | [public] Method parameter typing changed. |
-| Magento\NegotiableQuote\Api\PaymentInformationManagementInterface::savePaymentInformationAndPlaceOrder | [public] Method parameter typing changed. |
-| Magento\NegotiableQuote\Api\RenameNegotiableQuoteInterface | Interface was added. |
-| Magento\PageBuilder\Model\Dom\Adapter\DocumentInterface::createElement | [public] Method parameter typing changed. |
-| Magento\PageBuilder\Model\Dom\Adapter\DocumentInterface::saveHTML | [public] Method parameter typing changed. |
-| Magento\PaymentServicesPaypal\Api\PaymentOrderRequestInterface::create | [public] Method parameter typing changed. |
-| Magento\PaymentServicesPaypal\Api\PaymentOrderRequestInterface::createGuest | [public] Method parameter typing changed. |
-| Magento\Payment\Gateway\Command\CommandManagerInterface::execute | [public] Method parameter typing changed. |
-| Magento\Payment\Gateway\Command\CommandManagerInterface::executeByCode | [public] Method parameter typing changed. |
-| Magento\Payment\Model\MethodInterface::isAvailable | [public] Method parameter typing changed. |
-| Magento\PurchaseOrder\Api\Data\PurchaseOrderSearchResultsInterface::setItems | [public] Method parameter typing changed. |
-| Magento\PurchaseOrder\Api\PurchaseOrderPaymentInformationManagementInterface::savePaymentInformationAndPlacePurchaseOrder | [public] Method parameter typing changed. |
-| Magento\Quote\Api\CartManagementInterface::placeOrder | [public] Method parameter typing changed. |
-| Magento\Quote\Api\CartTotalManagementInterface::collectTotals | [public] Method parameter typing changed. |
-| Magento\Quote\Api\Data\CartInterface::setBillingAddress | [public] Method parameter typing changed. |
-| Magento\Quote\Api\Data\CartInterface::setCurrency | [public] Method parameter typing changed. |
-| Magento\Quote\Api\Data\CartInterface::setCustomer | [public] Method parameter typing changed. |
-| Magento\Quote\Api\Data\CartInterface::setItems | [public] Method parameter typing changed. |
-| Magento\Quote\Api\Data\TotalsInterface::setItems | [public] Method parameter typing changed. |
-| Magento\Quote\Api\GuestCartManagementInterface::placeOrder | [public] Method parameter typing changed. |
-| Magento\Quote\Api\GuestCartTotalManagementInterface::collectTotals | [public] Method parameter typing changed. |
-| Magento\Rma\Api\Data\CommentSearchResultInterface::setItems | [public] Method parameter typing changed. |
-| Magento\Rma\Api\Data\RmaInterface::setComments | [public] Method parameter typing changed. |
-| Magento\Rma\Api\Data\RmaInterface::setItems | [public] Method parameter typing changed. |
-| Magento\Rma\Api\Data\RmaInterface::setTracks | [public] Method parameter typing changed. |
-| Magento\Rma\Api\Data\RmaSearchResultInterface::setItems | [public] Method parameter typing changed. |
-| Magento\Rma\Api\Data\TrackSearchResultInterface::setItems | [public] Method parameter typing changed. |
-| Magento\SalesRule\Api\Data\ConditionInterface::setConditions | [public] Method parameter typing changed. |
-| Magento\SalesRule\Api\Data\CouponSearchResultInterface::setItems | [public] Method parameter typing changed. |
-| Magento\SalesRule\Api\Data\RuleInterface::setActionCondition | [public] Method parameter typing changed. |
-| Magento\SalesRule\Api\Data\RuleInterface::setCondition | [public] Method parameter typing changed. |
-| Magento\SalesRule\Api\Data\RuleInterface::setProductIds | [public] Method parameter typing changed. |
-| Magento\SalesRule\Api\Data\RuleInterface::setStoreLabels | [public] Method parameter typing changed. |
-| Magento\SalesRule\Api\Data\RuleSearchResultInterface::setItems | [public] Method parameter typing changed. |
-| Magento\Sales\Api\Data\OrderInterface::setBillingAddress | [public] Method parameter typing changed. |
-| Magento\Sales\Api\Data\OrderInterface::setPayment | [public] Method parameter typing changed. |
-| Magento\Sales\Api\Data\OrderInterface::setStatusHistories | [public] Method parameter typing changed. |
-| Magento\Sales\Api\Data\OrderSearchResultInterface::setItems | [public] Method parameter typing changed. |
-| Magento\Sales\Api\Data\ShipmentInterface::setPackages | [public] Method parameter typing changed. |
-| Magento\Sales\Api\InvoiceOrderInterface::execute | [public] Method parameter typing changed. |
-| Magento\Sales\Api\RefundInvoiceInterface::execute | [public] Method parameter typing changed. |
-| Magento\Sales\Api\RefundOrderInterface::execute | [public] Method parameter typing changed. |
-| Magento\Sales\Api\ShipOrderInterface::execute | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Creditmemo\ItemCreationValidatorInterface::validate | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Creditmemo\NotifierInterface::notify | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Creditmemo\SenderInterface::send | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Invoice\NotifierInterface::notify | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Invoice\SenderInterface::send | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Shipment\NotifierInterface::notify | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Shipment\SenderInterface::send | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Validation\InvoiceOrderInterface::validate | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Validation\RefundInvoiceInterface::validate | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Validation\RefundOrderInterface::validate | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Validation\ShipOrderInterface::validate | [public] Method parameter typing changed. |
-| Magento\Shipping\Model\Carrier\AbstractCarrierInterface::getContainerTypes | [public] Method parameter typing changed. |
-| Magento\Shipping\Model\Carrier\AbstractCarrierInterface::getDeliveryConfirmationTypes | [public] Method parameter typing changed. |
-| Magento\Store\Api\StoreConfigManagerInterface::getStoreConfigs | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\AppliedTaxInterface::setRates | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\OrderTaxDetailsInterface::setAppliedTaxes | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\OrderTaxDetailsInterface::setItems | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\OrderTaxDetailsItemInterface::setAppliedTaxes | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\QuoteDetailsInterface::setBillingAddress | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\QuoteDetailsInterface::setCustomerTaxClassKey | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\QuoteDetailsInterface::setItems | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\QuoteDetailsInterface::setShippingAddress | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\QuoteDetailsItemInterface::setTaxClassKey | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\TaxDetailsInterface::setAppliedTaxes | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\TaxDetailsInterface::setItems | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\TaxDetailsItemInterface::setAppliedTaxes | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\TaxRateInterface::setTitles | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\TaxRuleInterface::setCustomerTaxClassIds | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\TaxRuleInterface::setProductTaxClassIds | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\TaxRuleInterface::setTaxRateIds | [public] Method parameter typing changed. |
-| Magento\TwoFactorAuth\Api\DuoAuthenticateInterface::createAdminAccessTokenWithCredentialsAndPasscode | [public] Method has been added. |
-| Magento\TwoFactorAuth\Api\DuoConfigureInterface::duoActivate | [public] Method has been added. |
-| Magento\TwoFactorAuth\Api\DuoConfigureInterface::getDuoConfigurationData | [public] Method has been added. |
-| Magento\VersionsCms\Api\Data\HierarchyNodeSearchResultsInterface::setItems | [public] Method parameter typing changed. |
+##### Constant has been added
 
-#### Database changes {#commerce-b2b-BICs-247-248-stable-database}
+- Magento\AdobeCommerceEventsClient\Event\Event::EVENT_XML_DEFINED
+- Magento\PageCache\Model\Config::VARNISH_7_CONFIGURATION_PATH
+- Magento\SaaSCommon\Model\ResyncManager::DEFAULT_RESYNC_ENTITY_TYPE
 
-| What changed | How it changed |
-| --- | --- |
-| admin\_ui\_sdk\_logs | Table was added |
-| company\_advanced\_customer\_entity/COMPANY\_ADVANCED\_CUSTOMER\_ENTITY\_CUSTOMER\_ID | Unique key was removed |
-| company\_advanced\_customer\_entity/PRIMARY | Primary key was added |
-| company\_advanced\_customer\_entity/is\_default | Column was added |
-| company\_quote\_link | Table was added |
-| company\_relation | Table was added |
-| company\_structure/COMPANY\_STRUCTURE\_COMPANY\_ID\_COMPANY\_ENTITY\_ID | Foreign key was added |
-| company\_structure/company\_id | Column was added |
-| eav\_attribute\_option\_value/EAV\_ATTRIBUTE\_OPTION\_VALUE\_STORE\_ID\_OPTION\_ID | Unique key was added |
-| magento\_rma/confirmation\_key | Column was added |
-| negotiable\_quote\_item/is\_discounting\_locked | Column was added |
-| negotiable\_quote\_item/max\_qty | Column was added |
-| negotiable\_quote\_item/min\_qty | Column was added |
-| negotiable\_quote\_template | Table was added |
-| negotiable\_quote\_template\_grid | Table was added |
-| negotiable\_quote\_template\_reference\_document\_link | Table was added |
-| negotiable\_template\_generated\_quote | Table was added |
-| sales\_creditmemo\_comment/SALES\_CREDITMEMO\_COMMENT\_ENTITY\_ID\_USER\_ID\_USER\_TYPE | Unique key was added |
-| sales\_creditmemo\_comment/updated\_at | Column was added |
-| sales\_creditmemo\_comment/user\_id | Column was added |
-| sales\_creditmemo\_comment/user\_type | Column was added |
-| sales\_invoice\_comment/SALES\_INVOICE\_COMMENT\_ENTITY\_ID\_USER\_ID\_USER\_TYPE | Unique key was added |
-| sales\_invoice\_comment/updated\_at | Column was added |
-| sales\_invoice\_comment/user\_id | Column was added |
-| sales\_invoice\_comment/user\_type | Column was added |
-| sales\_order\_confirm\_cancel | Table was added |
-| sales\_order\_status\_change\_history | Table was added |
-| sales\_shipment\_comment/SALES\_SHIPMENT\_COMMENT\_ENTITY\_ID\_USER\_ID\_USER\_TYPE | Unique key was added |
-| sales\_shipment\_comment/updated\_at | Column was added |
-| sales\_shipment\_comment/user\_id | Column was added |
-| sales\_shipment\_comment/user\_type | Column was added |
+##### Interface has been added
 
-#### Di changes {#commerce-b2b-BICs-247-248-stable-di}
+- Magento\Framework\Amqp\Config
 
-| What changed | How it changed |
-| --- | --- |
-| Magento\Elasticsearch7\Model\Adapter\FieldMapper\ProductFieldMapper | Virtual Type was removed |
-| Magento\Elasticsearch7\Model\Client\ElasticsearchFactory | Virtual Type was removed |
-| Magento\Elasticsearch7\Model\DataProvider\Suggestions | Virtual Type was removed |
-| Magento\Elasticsearch7\Setup\InstallConfig | Virtual Type was removed |
-| Magento\NegotiableQuote\Model\ResourceModel\Grid\Collection | Virtual Type was removed |
-| \Magento\Elasticsearch7\Model\Adapter\FieldMapper\Product\FieldProvider\FieldName\Resolver\CompositeResolver | Virtual Type was removed |
-| bannerNotificationRegistration | Virtual Type was removed |
-| customFeeRegistration | Virtual Type was removed |
-| customerGridColumnRegistration | Virtual Type was removed |
-| customerMassActionRegistration | Virtual Type was removed |
-| orderGridColumnRegistration | Virtual Type was removed |
-| orderMassActionRegistration | Virtual Type was removed |
-| orderViewButtonRegistration | Virtual Type was removed |
-| productGridColumnRegistration | Virtual Type was removed |
-| productMassActionRegistration | Virtual Type was removed |
-| type | Virtual Type was changed |
+##### [protected] Method parameter typing changed
 
-#### Layout changes {#commerce-b2b-BICs-247-248-stable-layout}
+- Magento\Backend\App\AbstractAction::_forward
+- Magento\Backend\Block\Widget\Grid\Export::_getRowCollection
+- Magento\CatalogRule\Model\Indexer\IndexBuilder::applyAllRules
+- Magento\CatalogRule\Model\Indexer\IndexBuilder::getRuleProductsStmt
+- Magento\Config\Model\ResourceModel\Config::_construct
+- Magento\Framework\App\Action\Action::_forward
+- Magento\Framework\Logger\Handler\Base::write
+- Magento\Review\Model\ResourceModel\Review\Product\Collection::_applyStoresFilterToSelect
+- Magento\Shipping\Model\Carrier\AbstractCarrier::_getAllowedContainers
 
-| What changed | How it changed |
-| --- | --- |
-| uix.menu.placeholder | Block was removed |
+##### [public] Method has been added
 
-#### System changes {#commerce-b2b-BICs-247-248-stable-system}
+- Magento\AdobeCommerceEventsClient\Event\Event::isXmlDefined
+- Magento\Framework\Amqp\Config::_resetState
+- Magento\Framework\DB\Ddl\Table::__construct
+- Magento\PaymentServicesPaypal\Block\SmartButtons::doesQuoteExist
+- Magento\SaaSCommon\Model\ResyncManager::partialResyncByIds
 
-| What changed | How it changed |
-| --- | --- |
-| admin\_ui\_sdk/database\_logging/enable\_database\_logging | A field-node was added |
-| admin\_ui\_sdk/database\_logging/logs\_level | A field-node was added |
-| admin\_ui\_sdk/database\_logging/retention\_period | A field-node was added |
-| admin\_ui\_sdk/local\_testing/app\_status | A field-node was added |
-| admin\_ui\_sdk/local\_testing/enable\_local\_testing | A field-node was removed |
-| admin\_ui\_sdk/local\_testing/enable\_testing | A field-node was added |
-| admin\_ui\_sdk/local\_testing/testing\_mode | A field-node was added |
-| carriers/fedex/enabled\_tracking\_api | A field-node was added |
-| carriers/fedex/tracking\_api\_key | A field-node was added |
-| carriers/fedex/tracking\_api\_secret\_key | A field-node was added |
-| catalog/rule/share\_all\_catalog\_rules | A field-node was added |
-| catalog/rule/share\_applied\_catalog\_rules | A field-node was added |
-| catalog/search/elasticsearch7\_enable\_auth | A field-node was removed |
-| catalog/search/elasticsearch7\_index\_prefix | A field-node was removed |
-| catalog/search/elasticsearch7\_minimum\_should\_match | A field-node was removed |
-| catalog/search/elasticsearch7\_password | A field-node was removed |
-| catalog/search/elasticsearch7\_server\_hostname | A field-node was removed |
-| catalog/search/elasticsearch7\_server\_port | A field-node was removed |
-| catalog/search/elasticsearch7\_server\_timeout | A field-node was removed |
-| catalog/search/elasticsearch7\_test\_connect\_wizard | A field-node was removed |
-| catalog/search/elasticsearch7\_username | A field-node was removed |
-| catalog/search/elasticsearch8\_enable\_auth | A field-node was added |
-| catalog/search/elasticsearch8\_index\_prefix | A field-node was added |
-| catalog/search/elasticsearch8\_minimum\_should\_match | A field-node was added |
-| catalog/search/elasticsearch8\_password | A field-node was added |
-| catalog/search/elasticsearch8\_server\_hostname | A field-node was added |
-| catalog/search/elasticsearch8\_server\_port | A field-node was added |
-| catalog/search/elasticsearch8\_server\_timeout | A field-node was added |
-| catalog/search/elasticsearch8\_test\_connect\_wizard | A field-node was added |
-| catalog/search/elasticsearch8\_username | A field-node was added |
-| catalog/seo/product\_rewrite\_context | A field-node was added |
-| catalog/seo/product\_url\_transliteration | A field-node was added |
-| cataloginventory/options/not\_available\_message | A field-node was added |
-| commerce\_webhooks/db\_log/db\_log\_full\_message | A field-node was added |
-| customer/account\_information/graphql\_share\_all\_customer\_groups | A field-node was added |
-| customer/account\_information/graphql\_share\_customer\_group | A field-node was added |
-| customer/magento\_customersegment/share\_active\_segments | A field-node was added |
-| customer/magento\_customersegment/share\_segments\_list | A field-node was added |
-| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/mba\_scoping\_level | A field-node was added |
-| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/paypal\_merchant\_id | A field-node was added |
-| promo/graphql/share\_all\_sales\_rule | A field-node was added |
-| promo/graphql/share\_applied\_sales\_rule | A field-node was added |
-| recaptcha\_frontend/type\_for/resend\_confirmation\_email | A field-node was added |
-| sales\_email/quote\_templates/accepted\_by\_buyer | A field-node was added |
-| sales\_email/quote\_templates/canceled\_by\_buyer | A field-node was added |
-| sales\_email/quote\_templates/canceled\_by\_seller | A field-node was added |
-| sales\_email/quote\_templates/copy\_method | A field-node was added |
-| sales\_email/quote\_templates/copy\_to | A field-node was added |
-| sales\_email/quote\_templates/declined\_by\_seller | A field-node was added |
-| sales\_email/quote\_templates/enabled | A field-node was added |
-| sales\_email/quote\_templates/expired | A field-node was added |
-| sales\_email/quote\_templates/linked\_quote\_ordered | A field-node was added |
-| sales\_email/quote\_templates/sent\_by\_buyer\_after\_create | A field-node was added |
-| sales\_email/quote\_templates/sent\_by\_buyer\_after\_update | A field-node was added |
-| sales\_email/quote\_templates/sent\_by\_seller\_after\_create | A field-node was added |
-| sales\_email/quote\_templates/sent\_by\_seller\_after\_update | A field-node was added |
-| system/full\_page\_cache/varnish/export\_button\_version7 | A field-node was added |
-| twofactorauth/duo/client\_id | A field-node was added |
-| twofactorauth/duo/client\_secret | A field-node was added |
-| twofactorauth/general/auth\_lock\_expire | A field-node was added |
-| twofactorauth/general/twofactorauth\_retry | A field-node was added |
-| twofactorauth/google/leeway | A field-node was added |
-| twofactorauth/google/otp\_window | A field-node was removed |
+##### [public] Method has been removed
 
-#### Xsd changes {#commerce-b2b-BICs-247-248-stable-xsd}
+- Magento\Reports\Block\Adminhtml\Grid\Column\Renderer\Currency::__construct
 
-| What changed | How it changed |
-| --- | --- |
-| magento/module-data-exporter/etc/et\_schema.xsd | A schema declaration was added |
-| magento/module-data-exporter/etc/et\_schema.xsd | A schema declaration was removed |
-| magento/module-elasticsearch/etc/esconfig.xsd | A schema declaration was added |
-| magento/module-elasticsearch/etc/esconfig.xsd | A schema declaration was removed |
+##### [public] Method parameter typing changed
 
-#### Class API membership changes {#commerce-b2b-BICs-247-248-stable-class-api-membership}
+- Magento\AdminGws\Model\Collections::__construct
+- Magento\AdminGws\Model\Config::__construct
+- Magento\AdminNotification\Model\Feed::__construct
+- Magento\AdminNotification\Model\ResourceModel\System\Message\Collection::__construct
+- Magento\AdobeCommerceEventsClient\Block\Events\ModuleList::__construct
+- Magento\AdobeCommerceEventsClient\Event\Event::__construct
+- Magento\AdobeCommerceEventsClient\Event\EventList::__construct
+- Magento\AdobeIoEventsClient\Model\AdobeIOConfigurationProvider::__construct
+- Magento\AdobeIoEventsClient\Model\EventMetadataClient::__construct
+- Magento\AdvancedCheckout\Block\Adminhtml\Manage\Items::__construct
+- Magento\AdvancedCheckout\Model\Cart::__construct
+- Magento\AdvancedCheckout\Model\Cart::saveAffectedProducts
+- Magento\AdvancedSearch\Model\ResourceModel\Index::__construct
+- Magento\AdvancedSearch\Model\ResourceModel\Search\Grid\Collection::__construct
+- Magento\Backend\App\Area\FrontNameResolver::__construct
+- Magento\Backend\Block\Context::__construct
+- Magento\Backend\Block\Media\Uploader::__construct
+- Magento\Backend\Block\Menu::__construct
+- Magento\Backend\Block\System\Store\Edit::__construct
+- Magento\Backend\Block\Template\Context::__construct
+- Magento\Backend\Block\Widget\Context::__construct
+- Magento\Backend\Block\Widget\Form::__construct
+- Magento\Backend\Block\Widget\Grid\Massaction::__construct
+- Magento\Backend\Controller\Adminhtml\Auth\Login::__construct
+- Magento\Backend\Helper\Dashboard\Order::__construct
+- Magento\Backend\Model\Auth::throwException
+- Magento\Backend\Model\Auth\Session::__construct
+- Magento\Backend\Model\Menu::__construct
+- Magento\Backend\Model\Url::__construct
+- Magento\Backup\Model\Config\Backend\Cron::__construct
+- Magento\Banner\Model\Banner::__construct
+- Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer::__construct
+- Magento\Bundle\Block\Adminhtml\Sales\Order\View\Items\Renderer::__construct
+- Magento\Bundle\Block\Sales\Order\Items\Renderer::__construct
+- Magento\Bundle\Helper\Catalog\Product\Configuration::__construct
+- Magento\Bundle\Model\Option::setProductLinks
+- Magento\Bundle\Model\Product\Price::__construct
+- Magento\Bundle\Model\Product\Type::__construct
+- Magento\Bundle\Model\ResourceModel\Selection::__construct
+- Magento\Bundle\Model\ResourceModel\Selection\Collection::__construct
+- Magento\Bundle\Model\Selection::__construct
+- Magento\Bundle\Pricing\Price\ConfiguredPrice::__construct
+- Magento\Captcha\Model\DefaultModel::__construct
+- Magento\CatalogEvent\Model\Category\EventList::getEventCollection
+- Magento\CatalogEvent\Model\Event::__construct
+- Magento\CatalogEvent\Model\ResourceModel\Event\Collection::__construct
+- Magento\CatalogImportExport\Model\Import\Product::__construct
+- Magento\CatalogImportExport\Model\Import\Product\Option::__construct
+- Magento\CatalogImportExport\Model\Import\Product\Type\AbstractType::__construct
+- Magento\CatalogImportExport\Model\Import\Uploader::__construct
+- Magento\CatalogInventory\Model\Adminhtml\Stock\Item::__construct
+- Magento\CatalogInventory\Model\ResourceModel\Indexer\Stock\DefaultStock::__construct
+- Magento\CatalogInventory\Model\Source\Stock::__construct
+- Magento\CatalogPermissions\Model\Indexer\AbstractAction::__construct
+- Magento\CatalogPermissions\Model\Indexer\Category\Action\Full::__construct
+- Magento\CatalogPermissions\Model\Indexer\Category\Action\Rows::__construct
+- Magento\CatalogPermissions\Model\Indexer\Product\Action\Rows::__construct
+- Magento\CatalogPermissions\Model\Indexer\System\Config\Mode::__construct
+- Magento\CatalogPermissions\Model\ResourceModel\Permission\Index::__construct
+- Magento\CatalogRule\Model\Indexer\IndexBuilder::__construct
+- Magento\CatalogRule\Model\ResourceModel\Rule\Collection::__construct
+- Magento\CatalogSearch\Model\Adminhtml\System\Config\Backend\Engine::__construct
+- Magento\CatalogSearch\Model\Advanced::__construct
+- Magento\CatalogSearch\Model\Indexer\Fulltext::__construct
+- Magento\CatalogSearch\Model\Indexer\Fulltext::executeByDimensions
+- Magento\CatalogSearch\Model\Indexer\Fulltext\Action\DataProvider::__construct
+- Magento\CatalogSearch\Model\Indexer\Fulltext\Action\Full::__construct
+- Magento\CatalogSearch\Model\Indexer\IndexStructure::__construct
+- Magento\CatalogSearch\Model\ResourceModel\Advanced\Collection::__construct
+- Magento\CatalogSearch\Model\ResourceModel\Fulltext::__construct
+- Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection::__construct
+- Magento\CatalogSearch\Model\ResourceModel\Search\Collection::__construct
+- Magento\CatalogSearch\Model\Search\RequestGenerator::__construct
+- Magento\CatalogWidget\Model\Rule::__construct
+- Magento\Catalog\Block\Adminhtml\Product\Composite\Configure::setProduct
+- Magento\Catalog\Block\Adminhtml\Product\Edit\Action\Attribute\Tab\Attributes::__construct
+- Magento\Catalog\Block\Category\View::__construct
+- Magento\Catalog\Block\Product\ImageFactory::create
+- Magento\Catalog\Block\Product\ProductList\Toolbar::__construct
+- Magento\Catalog\Block\Product\View\Gallery::__construct
+- Magento\Catalog\Block\Product\View\Options::setProduct
+- Magento\Catalog\Block\Product\View\Options\AbstractOptions::__construct
+- Magento\Catalog\Block\Product\View\Options\AbstractOptions::setProduct
+- Magento\Catalog\Block\Product\View\Options\Type\Select::__construct
+- Magento\Catalog\Controller\Adminhtml\Product\Initialization\Helper::__construct
+- Magento\Catalog\Helper\Image::__construct
+- Magento\Catalog\Helper\Product\ProductList::__construct
+- Magento\Catalog\Model\AbstractModel::__construct
+- Magento\Catalog\Model\Category::__construct
+- Magento\Catalog\Model\Category::setChildrenData
+- Magento\Catalog\Model\Category\Attribute\Backend\Image::__construct
+- Magento\Catalog\Model\Category\DataProvider::__construct
+- Magento\Catalog\Model\Config::__construct
+- Magento\Catalog\Model\Design::__construct
+- Magento\Catalog\Model\Indexer\Category\Product\AbstractAction::__construct
+- Magento\Catalog\Model\Product::__construct
+- Magento\Catalog\Model\Product::setMediaGalleryEntries
+- Magento\Catalog\Model\Product::setOptions
+- Magento\Catalog\Model\Product::setProductLinks
+- Magento\Catalog\Model\Product::setTierPrices
+- Magento\Catalog\Model\Product\Action::__construct
+- Magento\Catalog\Model\Product\Attribute\Backend\Price::__construct
+- Magento\Catalog\Model\Product\Compare\Item::__construct
+- Magento\Catalog\Model\Product\Compare\Item::bindCustomerLogout
+- Magento\Catalog\Model\Product\Compare\ListCompare::__construct
+- Magento\Catalog\Model\Product\Gallery\CreateHandler::__construct
+- Magento\Catalog\Model\Product\Gallery\Processor::__construct
+- Magento\Catalog\Model\Product\Gallery\UpdateHandler::__construct
+- Magento\Catalog\Model\Product\Link::__construct
+- Magento\Catalog\Model\Product\Option::__construct
+- Magento\Catalog\Model\Product\Option::setProduct
+- Magento\Catalog\Model\Product\Option::setValues
+- Magento\Catalog\Model\Product\Option\Value::__construct
+- Magento\Catalog\Model\Product\Type\AbstractType::__construct
+- Magento\Catalog\Model\Product\Type\Price::__construct
+- Magento\Catalog\Model\Product\Type\Price::setTierPrices
+- Magento\Catalog\Model\Product\Url::__construct
+- Magento\Catalog\Model\ResourceModel\AbstractResource::__construct
+- Magento\Catalog\Model\ResourceModel\Category\Collection::__construct
+- Magento\Catalog\Model\ResourceModel\Collection\AbstractCollection::__construct
+- Magento\Catalog\Model\ResourceModel\Eav\Attribute::__construct
+- Magento\Catalog\Model\ResourceModel\Layer\Filter\Price::__construct
+- Magento\Catalog\Model\ResourceModel\Product::__construct
+- Magento\Catalog\Model\ResourceModel\Product\Attribute\Collection::__construct
+- Magento\Catalog\Model\ResourceModel\Product\Collection::__construct
+- Magento\Catalog\Model\ResourceModel\Product\Compare\Item\Collection::__construct
+- Magento\Catalog\Model\ResourceModel\Product\Gallery::loadDataFromTableByValueId
+- Magento\Catalog\Model\ResourceModel\Product\Indexer\Price\DefaultPrice::__construct
+- Magento\Catalog\Model\ResourceModel\Product\Link\Product\Collection::__construct
+- Magento\Catalog\Model\ResourceModel\Product\Option\Collection::__construct
+- Magento\Catalog\Model\System\Config\Backend\Catalog\Url\Rewrite\Suffix::__construct
+- Magento\Catalog\Pricing\Price\TierPrice::__construct
+- Magento\Catalog\Ui\Component\ColumnFactory::__construct
+- Magento\Catalog\Ui\Component\Listing\Columns\Websites::__construct
+- Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AdvancedPricing::__construct
+- Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Categories::__construct
+- Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Eav::__construct
+- Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\General::__construct
+- Magento\Catalog\Ui\DataProvider\Product\ProductCustomOptionsDataProvider::__construct
+- Magento\Catalog\Ui\DataProvider\Product\ProductDataProvider::__construct
+- Magento\Checkout\Block\Cart\Item\Renderer::__construct
+- Magento\Checkout\Block\Cart\Shipping::__construct
+- Magento\Checkout\Block\Cart\Sidebar::__construct
+- Magento\Checkout\Block\Onepage::__construct
+- Magento\Checkout\Model\Cart\ImageProvider::__construct
+- Magento\Checkout\Model\Session::__construct
+- Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Tree::__construct
+- Magento\Cms\Model\Page::__construct
+- Magento\Cms\Model\Wysiwyg\Config::__construct
+- Magento\Cms\Model\Wysiwyg\Images\Storage::__construct
+- Magento\Company\Block\Company\Login\Info::__construct
+- Magento\Company\Block\Company\Register\Link::__construct
+- Magento\Config\App\Config\Type\System::__construct
+- Magento\Config\Block\System\Config\Edit::__construct
+- Magento\Config\Block\System\Config\Form::__construct
+- Magento\Config\Console\Command\ConfigSetCommand::__construct
+- Magento\Config\Console\Command\ConfigSet\DefaultProcessor::__construct
+- Magento\Config\Model\Config::__construct
+- Magento\Config\Model\Config\Backend\Admin\Custom::__construct
+- Magento\Config\Model\Config\Backend\Admin\Usecustom::__construct
+- Magento\Config\Model\Config\Backend\Admin\Usesecretkey::__construct
+- Magento\Config\Model\Config\Backend\Baseurl::__construct
+- Magento\Config\Model\Config\Backend\Currency\Allow::__construct
+- Magento\Config\Model\Config\Backend\Currency\Base::__construct
+- Magento\Config\Model\Config\Backend\Currency\Cron::__construct
+- Magento\Config\Model\Config\Backend\Encrypted::__construct
+- Magento\Config\Model\Config\Backend\File::__construct
+- Magento\Config\Model\Config\Backend\Image\Adapter::__construct
+- Magento\Config\Model\Config\Backend\Locale::__construct
+- Magento\Config\Model\Config\Backend\Log\Cron::__construct
+- Magento\Config\Model\Config\Backend\Secure::__construct
+- Magento\Config\Model\Config\Backend\Serialized::__construct
+- Magento\Config\Model\Config\Backend\Store::__construct
+- Magento\Config\Model\Config\Export\Comment::__construct
+- Magento\Config\Model\Config\Loader::__construct
+- Magento\Config\Model\Config\Source\Locale\Currency::__construct
+- Magento\Config\Model\Config\Structure\Data::__construct
+- Magento\Config\Model\Config\TypePool::__construct
+- Magento\ConfigurableProduct\Block\Adminhtml\Product\Composite\Fieldset\Configurable::__construct
+- Magento\ConfigurableProduct\Block\Adminhtml\Product\Steps\Bulk::__construct
+- Magento\ConfigurableProduct\Block\Product\View\Type\Configurable::__construct
+- Magento\ConfigurableProduct\Helper\Data::__construct
+- Magento\ConfigurableProduct\Model\Product\Type\Configurable::__construct
+- Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable\Attribute\Collection::__construct
+- Magento\Cron\Model\Schedule::__construct
+- Magento\CurrencySymbol\Model\System\Currencysymbol::__construct
+- Magento\CustomerBalance\Block\Adminhtml\Sales\Order\Creditmemo\Controls::__construct
+- Magento\CustomerCustomAttributes\Block\Adminhtml\Customer\Address\Attribute\Edit\Tab\General::__construct
+- Magento\CustomerCustomAttributes\Block\Adminhtml\Customer\Attribute\Edit\Js::__construct
+- Magento\CustomerCustomAttributes\Block\Adminhtml\Customer\Attribute\Edit\Tab\Main::__construct
+- Magento\CustomerSegment\Model\Condition\Combine\AbstractCombine::__construct
+- Magento\CustomerSegment\Model\Customer::__construct
+- Magento\CustomerSegment\Model\ResourceModel\Customer::__construct
+- Magento\CustomerSegment\Model\ResourceModel\Segment::__construct
+- Magento\CustomerSegment\Model\Segment::__construct
+- Magento\Customer\Block\Account\AuthenticationPopup::__construct
+- Magento\Customer\Block\Address\Book::__construct
+- Magento\Customer\Block\Address\Book::getAddressHtml
+- Magento\Customer\Block\Address\Edit::__construct
+- Magento\Customer\Block\Adminhtml\Edit\Tab\Newsletter\Grid::__construct
+- Magento\Customer\Block\CustomerScopeData::__construct
+- Magento\Customer\Block\Form\Register::__construct
+- Magento\Customer\CustomerData\SectionPool::getSectionsData
+- Magento\Customer\Model\Address::__construct
+- Magento\Customer\Model\Address\AbstractAddress::__construct
+- Magento\Customer\Model\Customer::__construct
+- Magento\Customer\Model\Customer\DataProvider::__construct
+- Magento\Customer\Model\Data\Address::setRegion
+- Magento\Customer\Model\Group::__construct
+- Magento\Customer\Model\ResourceModel\Customer::__construct
+- Magento\Customer\Model\Session::__construct
+- Magento\Customer\Model\Url::__construct
+- Magento\Deploy\Package\Package::aggregate
+- Magento\Directory\Model\Country::__construct
+- Magento\Directory\Model\Currency::__construct
+- Magento\Directory\Model\ResourceModel\Country::__construct
+- Magento\Directory\Model\ResourceModel\Country\Collection::__construct
+- Magento\Directory\Model\ResourceModel\Region\Collection::__construct
+- Magento\Downloadable\Model\Link::__construct
+- Magento\Downloadable\Model\Link::setLinkFileContent
+- Magento\Downloadable\Model\Link::setSampleFileContent
+- Magento\Downloadable\Model\Product\Type::__construct
+- Magento\Downloadable\Model\ResourceModel\Sample\Collection::__construct
+- Magento\Downloadable\Model\Sales\Order\Pdf\Items\Creditmemo::__construct
+- Magento\Downloadable\Model\Sales\Order\Pdf\Items\Invoice::__construct
+- Magento\Downloadable\Model\Sample::__construct
+- Magento\Downloadable\Model\Sample::setSampleFileContent
+- Magento\Eav\Model\Config::__construct
+- Magento\Eav\Model\Entity\AbstractEntity::__construct
+- Magento\Eav\Model\Entity\Attribute::__construct
+- Magento\Eav\Model\Entity\Attribute\AbstractAttribute::__construct
+- Magento\Eav\Model\Entity\Attribute\AbstractAttribute::setFrontendLabels
+- Magento\Eav\Model\Entity\Attribute\AbstractAttribute::setOptions
+- Magento\Eav\Model\Entity\Attribute\AbstractAttribute::setValidationRules
+- Magento\Eav\Model\Entity\Attribute\Config::__construct
+- Magento\Eav\Model\Entity\Attribute\Frontend\AbstractFrontend::__construct
+- Magento\Eav\Model\Entity\Attribute\Group::__construct
+- Magento\Eav\Model\Entity\Attribute\Option::setStoreLabels
+- Magento\Eav\Model\Entity\Attribute\Source\Table::__construct
+- Magento\Eav\Model\Entity\Collection\AbstractCollection::__construct
+- Magento\Eav\Model\Entity\Collection\VersionControl\AbstractCollection::__construct
+- Magento\Eav\Model\Entity\Type::__construct
+- Magento\Eav\Model\Form\Element::__construct
+- Magento\Eav\Model\Form\Fieldset::__construct
+- Magento\Eav\Model\ResourceModel\Attribute\Collection::__construct
+- Magento\Eav\Model\ResourceModel\Entity\Attribute::__construct
+- Magento\Eav\Model\ResourceModel\Entity\Attribute\Collection::__construct
+- Magento\Eav\Model\ResourceModel\Form\Attribute\Collection::__construct
+- Magento\Eav\Model\ResourceModel\Form\Fieldset\Collection::__construct
+- Magento\Eav\Setup\EavSetup::__construct
+- Magento\Elasticsearch\Model\ResourceModel\Index::__construct
+- Magento\Elasticsearch\SearchAdapter\Dynamic\DataProvider::__construct
+- Magento\Email\Model\AbstractTemplate::__construct
+- Magento\Email\Model\BackendTemplate::__construct
+- Magento\Email\Model\Template::__construct
+- Magento\Email\Model\Template\Filter::__construct
+- Magento\Framework\Amqp\Config::__construct
+- Magento\Framework\Api\Search\FilterGroup::setFilters
+- Magento\Framework\App\Bootstrap::create
+- Magento\Framework\App\Config\Value::__construct
+- Magento\Framework\App\Http\Context::__construct
+- Magento\Framework\App\Request\Http::__construct
+- Magento\Framework\App\Response\Http::__construct
+- Magento\Framework\Config\Data::__construct
+- Magento\Framework\Config\Data\Scoped::__construct
+- Magento\Framework\Controller\Result\Json::__construct
+- Magento\Framework\DB\Adapter\Pdo\Mysql::__construct
+- Magento\Framework\DB\Adapter\Pdo\MysqlFactory::create
+- Magento\Framework\Data\Collection\AbstractDb::__construct
+- Magento\Framework\Data\Collection\Filesystem::__construct
+- Magento\Framework\Data\Form::setElementRenderer
+- Magento\Framework\Data\Form::setFieldsetElementRenderer
+- Magento\Framework\Data\Form::setFieldsetRenderer
+- Magento\Framework\Exception\AbstractAggregateException::__construct
+- Magento\Framework\Exception\AlreadyExistsException::__construct
+- Magento\Framework\Exception\BulkException::__construct
+- Magento\Framework\Exception\InputException::__construct
+- Magento\Framework\Exception\InputException::invalidFieldValue
+- Magento\Framework\Exception\LocalizedException::__construct
+- Magento\Framework\Exception\NoSuchEntityException::__construct
+- Magento\Framework\Exception\SerializationException::__construct
+- Magento\Framework\Exception\TemporaryState\CouldNotSaveException::__construct
+- Magento\Framework\File\Uploader::__construct
+- Magento\Framework\Filter\Template::__construct
+- Magento\Framework\ForeignKey\Migration\AbstractCommand::__construct
+- Magento\Framework\GraphQl\Exception\GraphQlAuthenticationException::__construct
+- Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException::__construct
+- Magento\Framework\GraphQl\Exception\GraphQlInputException::__construct
+- Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException::__construct
+- Magento\Framework\HTTP\PhpEnvironment\RemoteAddress::__construct
+- Magento\Framework\Mail\Template\TransportBuilder::__construct
+- Magento\Framework\Model\AbstractExtensibleModel::__construct
+- Magento\Framework\Model\AbstractModel::__construct
+- Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection::__construct
+- Magento\Framework\Module\Setup\Migration::__construct
+- Magento\Framework\Pricing\Price\Pool::__construct
+- Magento\Framework\Pricing\Render::renderAmount
+- Magento\Framework\Pricing\Render\RendererPool::createAmountRender
+- Magento\Framework\Pricing\Render\RendererPool::getAdjustmentRenders
+- Magento\Framework\Profiler::start
+- Magento\Framework\Profiler\Driver\Standard\Stat::getFilteredTimerIds
+- Magento\Framework\Search\Adapter\Mysql\TemporaryStorage::__construct
+- Magento\Framework\Setup\Declaration\Schema\Diff\Diff::register
+- Magento\Framework\Setup\Declaration\Schema\Dto\Table::__construct
+- Magento\Framework\Setup\Declaration\Schema\ElementHistory::__construct
+- Magento\Framework\Validation\ValidationException::__construct
+- Magento\Framework\Validator\AbstractValidator::setDefaultTranslator
+- Magento\Framework\Validator\Exception::__construct
+- Magento\Framework\View\Context::__construct
+- Magento\Framework\View\Element\Context::__construct
+- Magento\Framework\View\Element\Template\Context::__construct
+- Magento\Framework\View\Element\UiComponentFactory::__construct
+- Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult::setItems
+- Magento\Framework\View\Layout\Data\Structure::__construct
+- Magento\Framework\View\Layout\GeneratorPool::__construct
+- Magento\Framework\View\Page\Config::__construct
+- Magento\Framework\View\Result\Page::__construct
+- Magento\Framework\Webapi\ErrorProcessor::__construct
+- Magento\Framework\Webapi\ServiceInputProcessor::__construct
+- Magento\Framework\Webapi\ServiceOutputProcessor::__construct
+- Magento\FunctionalTestingFramework\ObjectManager::__construct
+- Magento\GiftCardAccount\Model\Giftcardaccount::__construct
+- Magento\GiftCard\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Giftcard::__construct
+- Magento\GiftMessage\Block\Cart\GiftOptions::__construct
+- Magento\GiftMessage\Block\Cart\Item\Renderer\Actions\GiftOptions::__construct
+- Magento\GiftMessage\Model\Message::__construct
+- Magento\GiftRegistry\Block\Customer\Address\Edit::__construct
+- Magento\GiftRegistry\Block\Email\Items::__construct
+- Magento\GiftRegistry\Block\Search\Advanced::__construct
+- Magento\GiftRegistry\Model\Entity::__construct
+- Magento\GiftRegistry\Model\Item::__construct
+- Magento\GiftRegistry\Model\Person::__construct
+- Magento\GiftRegistry\Model\ResourceModel\Entity\Collection::__construct
+- Magento\GiftRegistry\Model\ResourceModel\Item\Collection::__construct
+- Magento\GiftRegistry\Model\Type::__construct
+- Magento\GiftWrapping\Block\Checkout\Options::__construct
+- Magento\GoogleAdwords\Model\Config\Backend\AbstractConversion::__construct
+- Magento\GoogleAnalytics\Block\Ga::__construct
+- Magento\GoogleOptimizer\Helper\Data::__construct
+- Magento\GoogleOptimizer\Helper\Form::addGoogleoptimizerFields
+- Magento\GoogleTagManager\Block\Adminhtml\Banner\Edit\Tab\Ga::__construct
+- Magento\GoogleTagManager\Block\ListJson::__construct
+- Magento\GraphQl\Controller\GraphQl::__construct
+- Magento\GroupedProduct\Model\Product\Type\Grouped::__construct
+- Magento\ImportExport\Model\Import::__construct
+- Magento\ImportExport\Model\Import\AbstractEntity::__construct
+- Magento\ImportExport\Model\Import\AbstractEntity::getBehavior
+- Magento\InstantPurchase\Model\InstantPurchaseOption::__construct
+- Magento\InstantPurchase\Model\InstantPurchaseOptionFactory::create
+- Magento\Integration\Model\Config::__construct
+- Magento\Integration\Model\Integration::__construct
+- Magento\Integration\Model\IntegrationConfig::__construct
+- Magento\Integration\Model\Oauth\Consumer::__construct
+- Magento\Integration\Model\Oauth\Token::__construct
+- Magento\InventoryAdminUi\Ui\DataProvider\SourceDataProvider::__construct
+- Magento\InventoryAdminUi\Ui\DataProvider\StockDataProvider::__construct
+- Magento\InventoryShippingAdminUi\Block\Adminhtml\Order\View\ShipButton::__construct
+- Magento\Inventory\Model\ResourceModel\Source\Collection::__construct
+- Magento\Invitation\Block\Form::__construct
+- Magento\Invitation\Model\Invitation::__construct
+- Magento\Invitation\Model\ResourceModel\Invitation\Collection::__construct
+- Magento\Logging\Block\Adminhtml\Details::__construct
+- Magento\Logging\Model\Event::__construct
+- Magento\Logging\Model\Event\Changes::__construct
+- Magento\MediaStorage\Model\File\Storage::__construct
+- Magento\MediaStorage\Model\File\Storage\Database::__construct
+- Magento\MediaStorage\Model\File\Storage\Directory\Database::__construct
+- Magento\MediaStorage\Model\File\Uploader::__construct
+- Magento\MediaStorage\Model\ResourceModel\File\Storage\Database::__construct
+- Magento\MessageQueue\Model\ConsumerRunner::__construct
+- Magento\MultipleWishlist\Model\ResourceModel\Item\Collection::__construct
+- Magento\Multishipping\Model\Checkout\Type\Multishipping::__construct
+- Magento\NegotiableQuote\Block\Adminhtml\Quote\View::__construct
+- Magento\Newsletter\Model\Problem::__construct
+- Magento\Newsletter\Model\Queue::__construct
+- Magento\Newsletter\Model\ResourceModel\Problem\Collection::__construct
+- Magento\Newsletter\Model\ResourceModel\Queue\Collection::__construct
+- Magento\Newsletter\Model\ResourceModel\Subscriber::__construct
+- Magento\Newsletter\Model\ResourceModel\Subscriber\Collection::__construct
+- Magento\Newsletter\Model\Subscriber::__construct
+- Magento\PageBuilder\Block\WysiwygSetup::__construct
+- Magento\PageBuilder\Component\Form\Element\Wysiwyg::__construct
+- Magento\PageBuilder\Controller\ContentType\Preview::__construct
+- Magento\PageBuilder\Model\Stage\Config::__construct
+- Magento\PageBuilder\Model\Stage\Renderer\CmsStaticBlock::__construct
+- Magento\PageBuilder\Model\Stage\Renderer\WidgetDirective::__construct
+- Magento\PageCache\Model\Config::__construct
+- Magento\PaymentServicesPaypal\Block\SmartButtons::__construct
+- Magento\PaymentServicesPaypal\Model\Api\PaymentOrderRequest::create
+- Magento\PaymentServicesPaypal\Model\Api\PaymentOrderRequest::createGuest
+- Magento\Payment\Gateway\Command\CommandManager::execute
+- Magento\Payment\Gateway\Command\CommandManager::executeByCode
+- Magento\Payment\Gateway\Command\GatewayCommand::__construct
+- Magento\Payment\Gateway\Http\Client\Soap::__construct
+- Magento\Payment\Gateway\Http\Client\Zend::__construct
+- Magento\Payment\Helper\Data::getInfoBlock
+- Magento\Payment\Model\Info::__construct
+- Magento\Payment\Model\MethodList::getAvailableMethods
+- Magento\Payment\Model\Method\AbstractMethod::__construct
+- Magento\Payment\Model\Method\AbstractMethod::isAvailable
+- Magento\Payment\Model\Method\Adapter::__construct
+- Magento\Payment\Model\Method\Adapter::isAvailable
+- Magento\Payment\Model\Method\Free::__construct
+- Magento\Payment\Model\Method\Free::isAvailable
+- Magento\Payment\Model\Method\Logger::__construct
+- Magento\Payment\Model\Method\Logger::debug
+- Magento\Paypal\Block\PayLater\Banner::__construct
+- Magento\Paypal\Model\Api\ProcessableException::__construct
+- Magento\Paypal\Model\Billing\AbstractAgreement::__construct
+- Magento\Paypal\Model\Billing\Agreement::__construct
+- Magento\Paypal\Model\ResourceModel\Billing\Agreement\Collection::__construct
+- Magento\Persistent\Model\Session::__construct
+- Magento\ProductAlert\Model\Email::__construct
+- Magento\ProductAlert\Model\Price::__construct
+- Magento\ProductAlert\Model\Stock::__construct
+- Magento\ProductVideo\Block\Product\View\Gallery::__construct
+- Magento\PurchaseOrderRule\Block\RuleFieldset\Condition::__construct
+- Magento\PurchaseOrderRule\Block\RuleFieldset\ViewCondition::__construct
+- Magento\PurchaseOrder\Block\PurchaseOrder\Info\Buttons::__construct
+- Magento\Quote\Model\Cart\Data\CartItem::__construct
+- Magento\Quote\Model\Quote::__construct
+- Magento\Quote\Model\Quote::assignCustomerWithAddressChange
+- Magento\Quote\Model\Quote::setBillingAddress
+- Magento\Quote\Model\Quote::setCurrency
+- Magento\Quote\Model\Quote::setCustomer
+- Magento\Quote\Model\Quote::setItems
+- Magento\Quote\Model\Quote::setShippingAddress
+- Magento\Quote\Model\QuoteValidator::__construct
+- Magento\Quote\Model\Quote\Address::__construct
+- Magento\Quote\Model\Quote\Address::requestShippingRates
+- Magento\Quote\Model\Quote\Address\Total::__construct
+- Magento\Quote\Model\Quote\Item::__construct
+- Magento\Quote\Model\Quote\Item\AbstractItem::__construct
+- Magento\Quote\Model\Quote\Payment::__construct
+- Magento\Quote\Model\ResourceModel\Quote\Item\Collection::__construct
+- Magento\Reports\Block\Adminhtml\Grid::__construct
+- Magento\Reports\Controller\Adminhtml\Report\AbstractReport::__construct
+- Magento\Reports\Model\Event::__construct
+- Magento\Reports\Model\Product\Index\AbstractIndex::__construct
+- Magento\Reports\Model\Product\Index\Compared::__construct
+- Magento\Reports\Model\ResourceModel\Customer\Collection::__construct
+- Magento\Reports\Model\ResourceModel\Event::getCurrentStoreIds
+- Magento\Reports\Model\ResourceModel\Order\Collection::__construct
+- Magento\Reports\Model\ResourceModel\Product\Collection::__construct
+- Magento\Reports\Model\ResourceModel\Product\Index\Collection\AbstractCollection::__construct
+- Magento\Reports\Model\ResourceModel\Product\Lowstock\Collection::__construct
+- Magento\Reports\Model\ResourceModel\Quote\Collection::__construct
+- Magento\Reports\Model\ResourceModel\Quote\Item\Collection::__construct
+- Magento\Reports\Model\ResourceModel\Review\Customer\Collection::__construct
+- Magento\Reports\Model\ResourceModel\Wishlist\Collection::__construct
+- Magento\RequisitionList\Block\Requisition\View\Item::__construct
+- Magento\ResourceConnections\DB\Adapter\Pdo\MysqlProxy::__construct
+- Magento\Review\Block\Form::__construct
+- Magento\Review\Model\Rating::__construct
+- Magento\Review\Model\ResourceModel\Rating::__construct
+- Magento\Review\Model\ResourceModel\Rating\Collection::__construct
+- Magento\Review\Model\ResourceModel\Rating\Option\Vote\Collection::__construct
+- Magento\Review\Model\ResourceModel\Review\Collection::__construct
+- Magento\Review\Model\ResourceModel\Review\Product\Collection::__construct
+- Magento\Review\Model\Review::__construct
+- Magento\Reward\Model\ResourceModel\Reward\History\Collection::__construct
+- Magento\Reward\Model\Reward::__construct
+- Magento\Reward\Model\Reward\History::__construct
+- Magento\Reward\Model\Reward\Rate::__construct
+- Magento\Rma\Block\Adminhtml\Rma\Edit\Tab\General\Shipping\Methods::__construct
+- Magento\Rma\Block\Adminhtml\Rma\Edit\Tab\General\Shippingmethod::__construct
+- Magento\Rma\Block\Adminhtml\Rma\Item\Attribute\Edit\Js::__construct
+- Magento\Rma\Block\Adminhtml\Rma\Item\Attribute\Edit\Tab\Main::__construct
+- Magento\Rma\Block\Returns\Tracking\Package::__construct
+- Magento\Rma\Model\Shipping::__construct
+- Magento\Robots\Block\Data::__construct
+- Magento\Robots\Model\Config\Value::__construct
+- Magento\Rss\Model\Rss::__construct
+- Magento\Rule\Model\AbstractModel::__construct
+- Magento\Rule\Model\Condition\Product\AbstractProduct::__construct
+- Magento\SalesRule\Model\ResourceModel\Rule\Collection::__construct
+- Magento\SalesRule\Model\ResourceModel\Rule\Collection::setValidationFilter
+- Magento\SalesRule\Model\Rule::__construct
+- Magento\Sales\Block\Adminhtml\Order\Create\Search\Grid::__construct
+- Magento\Sales\Block\Order\Info\Buttons\Rss::__construct
+- Magento\Sales\Block\Order\Items::__construct
+- Magento\Sales\Block\Order\Recent::__construct
+- Magento\Sales\Model\AbstractModel::__construct
+- Magento\Sales\Model\AdminOrder\Create::__construct
+- Magento\Sales\Model\Config\Ordered::__construct
+- Magento\Sales\Model\Order::__construct
+- Magento\Sales\Model\Order::setBillingAddress
+- Magento\Sales\Model\Order::setPayment
+- Magento\Sales\Model\Order::setShippingAddress
+- Magento\Sales\Model\Order::setStatusHistories
+- Magento\Sales\Model\Order\Address::__construct
+- Magento\Sales\Model\Order\Config::__construct
+- Magento\Sales\Model\Order\Creditmemo::__construct
+- Magento\Sales\Model\Order\CreditmemoDocumentFactory::createFromInvoice
+- Magento\Sales\Model\Order\CreditmemoDocumentFactory::createFromOrder
+- Magento\Sales\Model\Order\CreditmemoFactory::__construct
+- Magento\Sales\Model\Order\Creditmemo\Comment::__construct
+- Magento\Sales\Model\Order\Creditmemo\Item::__construct
+- Magento\Sales\Model\Order\Creditmemo\Notifier::notify
+- Magento\Sales\Model\Order\Email\Sender\InvoiceSender::__construct
+- Magento\Sales\Model\Order\Invoice::__construct
+- Magento\Sales\Model\Order\InvoiceDocumentFactory::create
+- Magento\Sales\Model\Order\Invoice\Item::__construct
+- Magento\Sales\Model\Order\Invoice\Notifier::notify
+- Magento\Sales\Model\Order\Item::__construct
+- Magento\Sales\Model\Order\Item::setProductOptions
+- Magento\Sales\Model\Order\Payment::__construct
+- Magento\Sales\Model\Order\Payment\Info::__construct
+- Magento\Sales\Model\Order\Payment\Transaction::__construct
+- Magento\Sales\Model\Order\Pdf\AbstractPdf::__construct
+- Magento\Sales\Model\Order\Pdf\Items\AbstractItems::__construct
+- Magento\Sales\Model\Order\Shipment::__construct
+- Magento\Sales\Model\Order\Shipment::setPackages
+- Magento\Sales\Model\Order\ShipmentDocumentFactory::__construct
+- Magento\Sales\Model\Order\ShipmentDocumentFactory::create
+- Magento\Sales\Model\Order\ShipmentFactory::__construct
+- Magento\Sales\Model\Order\Shipment\Item::__construct
+- Magento\Sales\Model\Order\Shipment\Notifier::notify
+- Magento\Sales\Model\Order\Shipment\Track::__construct
+- Magento\Sales\Model\Order\Status\History::__construct
+- Magento\Sales\Model\ResourceModel\Collection\AbstractCollection::setItems
+- Magento\Sales\Model\ResourceModel\Collection\AbstractCollection::setSearchCriteria
+- Magento\Sales\Model\ResourceModel\Order\Collection::__construct
+- Magento\ScheduledImportExport\Model\Scheduled\Operation::__construct
+- Magento\Search\Model\Query::__construct
+- Magento\Search\Model\QueryFactory::__construct
+- Magento\Search\Model\ResourceModel\Query\Collection::__construct
+- Magento\Search\Model\SearchEngine\Config\Data::__construct
+- Magento\Search\Model\SynonymReader::__construct
+- Magento\Search\Model\Synonym\MergeConflictException::__construct
+- Magento\Security\Model\AdminSessionInfo::__construct
+- Magento\Security\Model\ResourceModel\AdminSessionInfo\Collection::__construct
+- Magento\Security\Model\ResourceModel\PasswordResetRequestEvent\Collection::__construct
+- Magento\SendFriend\Model\SendFriend::__construct
+- Magento\Setup\Module\SetupFactory::create
+- Magento\Shipping\Model\Carrier\AbstractCarrier::getContainerTypes
+- Magento\Shipping\Model\Carrier\AbstractCarrier::getDeliveryConfirmationTypes
+- Magento\Sitemap\Model\ResourceModel\Catalog\Product::__construct
+- Magento\Sitemap\Model\ResourceModel\Cms\Page::__construct
+- Magento\Sitemap\Model\Sitemap::__construct
+- Magento\Staging\Block\Adminhtml\Update\Preview::__construct
+- Magento\Store\Block\Switcher::__construct
+- Magento\Store\Model\Group::__construct
+- Magento\Store\Model\Store::__construct
+- Magento\Store\Model\StoreIsInactiveException::__construct
+- Magento\Store\Model\Website::__construct
+- Magento\Swatches\Block\Product\Renderer\Configurable::__construct
+- Magento\Swatches\Block\Product\Renderer\Listing\Configurable::__construct
+- Magento\Swatches\Helper\Media::__construct
+- Magento\TargetRule\Block\Checkout\Cart\Crosssell::__construct
+- Magento\TargetRule\Model\Actions\Condition\Combine::__construct
+- Magento\TargetRule\Model\Index::__construct
+- Magento\TargetRule\Model\Rule::__construct
+- Magento\TargetRule\Model\Rule\Condition\Combine::__construct
+- Magento\Tax\Helper\Data::__construct
+- Magento\Theme\Block\Adminhtml\Wysiwyg\Files\Tree::__construct
+- Magento\Theme\Block\Html\Breadcrumbs::__construct
+- Magento\Theme\Block\Html\Header::__construct
+- Magento\Theme\Helper\Storage::__construct
+- Magento\Ui\Component\Filters\Type\Select::__construct
+- Magento\Ui\Component\Listing\Columns\Date::__construct
+- Magento\UrlRewrite\Model\Exception\UrlAlreadyExistsException::__construct
+- Magento\UrlRewrite\Model\ResourceModel\UrlRewriteCollection::__construct
+- Magento\UrlRewrite\Model\UrlRewrite::__construct
+- Magento\UrlRewrite\Service\V1\Data\UrlRewrite::__construct
+- Magento\User\Model\ResourceModel\User::__construct
+- Magento\User\Model\User::__construct
+- Magento\Variable\Model\Variable::__construct
+- Magento\Variable\Model\Variable\Config::__construct
+- Magento\Vault\Model\Method\Vault::__construct
+- Magento\Vault\Model\Method\Vault::isAvailable
+- Magento\VersionsCms\Block\Adminhtml\Cms\Hierarchy\Manage::__construct
+- Magento\VersionsCms\Block\Cms\Page::__construct
+- Magento\VersionsCms\Block\Hierarchy\Head::__construct
+- Magento\VersionsCms\Block\Hierarchy\Menu::__construct
+- Magento\VersionsCms\Block\Hierarchy\Pagination::__construct
+- Magento\VersionsCms\Model\Hierarchy\Node::__construct
+- Magento\VersionsCms\Model\ResourceModel\Hierarchy\Node\Collection::__construct
+- Magento\VisualMerchandiser\Block\Adminhtml\Category\Merchandiser\Tile::__construct
+- Magento\VisualMerchandiser\Model\Rules::__construct
+- Magento\VisualMerchandiser\Model\Rules\Factory::__construct
+- Magento\VisualMerchandiser\Model\Sorting::__construct
+- Magento\VisualMerchandiser\Model\Sorting\SortAbstract::__construct
+- Magento\Webapi\Model\Config::__construct
+- Magento\WebsiteRestriction\Model\Config::__construct
+- Magento\Weee\Helper\Data::__construct
+- Magento\Weee\Model\Tax::__construct
+- Magento\Widget\Model\Widget\Instance::__construct
+- Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Image::__construct
+- Magento\Wishlist\Block\Share\Email\Items::__construct
+- Magento\Wishlist\Helper\Data::__construct
+- Magento\Wishlist\Model\Item::__construct
+- Magento\Wishlist\Model\Item\Option::__construct
+- Magento\Wishlist\Model\ResourceModel\Item\Collection::__construct
+- Magento\Wishlist\Model\Wishlist::__construct
+- Magento\Wishlist\Model\Wishlist\Data\WishlistItem::__construct
 
-| What changed | How it changed |
-| --- | --- |
-| Magento\AdvancedCheckout\Block\Adminhtml\Sku\AbstractSku | Class was added. |
-| Magento\CatalogInventory\Model\Stock\Item | Class was added. |
-| Magento\Catalog\Block\Adminhtml\Category\Tab\Product | Class was added. |
-| Magento\Customer\Model\ResourceModel\Customer\Collection | Class was added. |
-| Magento\Downloadable\Model\Sales\Order\Pdf\Items\AbstractItems | Class was added. |
-| Magento\Framework\Api\SearchCriteria | Class was added. |
-| Magento\Framework\Data\Form\Element\Editor | Class was added. |
-| Magento\Framework\Data\Structure | Class was added. |
-| Magento\Framework\Flag | Class was added. |
-| Magento\Framework\Locale\Resolver | Class was added. |
-| Magento\Framework\Model\ResourceModel\Db\VersionControl\Collection | Class was added. |
-| Magento\Framework\Session\SessionManager | Class was added. |
-| Magento\Framework\Url | Class was added. |
-| Magento\GiftRegistry\Block\Form\Element | Class was added. |
-| Magento\MediaStorage\Model\File\Storage\Database\AbstractDatabase | Class was added. |
-| Magento\NegotiableQuote\Block\Quote\AbstractQuote | Class was added. |
-| Magento\PageBuilder\Block\Adminhtml\Stage\Render | Class was removed. |
-| Magento\SalesRule\Model\Validator | Class was added. |
-| Magento\Sales\Model\Order\Total\Config\Base | Class was added. |
-| Magento\Sales\Model\ResourceModel\Report\Bestsellers\Collection | Class was added. |
-| Magento\Sales\Model\ResourceModel\Report\Collection\AbstractCollection | Class was added. |
-| Magento\TargetRule\Block\Catalog\Product\ProductList\AbstractProductList | Class was added. |
-| Magento\Ui\DataProvider\ModifierPoolDataProvider | Class was added. |
-| Magento\Wishlist\Block\AbstractBlock | Class was added. |
+##### [public] Method return typing changed
+
+- Magento\Catalog\Model\AbstractModel::getAttributeDefaultValue
+- Magento\Framework\Data\Collection::getItemById
+
+#### Interface changes
+
+##### Added parent to interface
+
+- Magento\Company\Api\Data\StructureInterface
+
+##### Constant has been added
+
+- Magento\Company\Api\Data\CompanyCustomerInterface::IS_DEFAULT
+- Magento\Company\Api\Data\StructureInterface::COMPANY_ID
+- Magento\NegotiableQuote\Api\Data\NegotiableQuoteInterface::STATUS_DRAFT_BY_CUSTOMER
+- Magento\NegotiableQuote\Api\Data\NegotiableQuoteInterface::STATUS_TEMPLATE_QUOTE
+- Magento\NegotiableQuote\Api\Data\NegotiableQuoteItemInterface::IS_DISCOUNTING_LOCKED
+- Magento\NegotiableQuote\Api\Data\NegotiableQuoteItemInterface::MAX_QTY
+- Magento\NegotiableQuote\Api\Data\NegotiableQuoteItemInterface::MIN_QTY
+
+##### Interface was added
+
+- Magento\AdobeCommerceEventsClient\Api\EventSubscriptionListInterface
+- Magento\AdobeCommerceEventsClient\Api\EventUpdaterInterface
+- Magento\AdobeCommerceEventsClient\Event\EventSubscriptionUpdaterInterface
+- Magento\AdobeCommerceWebhooks\Api\Data\HookFieldInterface
+- Magento\AdobeCommerceWebhooks\Api\Data\HookHeaderInterface
+- Magento\AdobeCommerceWebhooks\Api\Data\HookRuleInterface
+- Magento\AdobeCommerceWebhooks\Api\Data\WebhookDataInterface
+- Magento\AdobeCommerceWebhooks\Api\WebhookSubscriptionListInterface
+- Magento\CommerceBackendUix\Api\Data\LogInterface
+- Magento\CommerceBackendUix\Api\LogRepositoryInterface
+- Magento\CompanyRelation\Api\Data\RelationInterface
+- Magento\CompanyRelation\Api\Data\RelationSearchResultInterface
+- Magento\CompanyRelation\Api\RelationManagerInterface
+- Magento\Company\Api\CompanyCustomerAssignmentInterface
+- Magento\Company\Api\CompanyUserRepositoryInterface
+- Magento\Company\Api\Data\CompanyCustomerSearchResultsInterface
+- Magento\Framework\Setup\ConsoleLoggerInterface
+- Magento\NegotiableQuoteDuplicate\Api\DuplicateNegotiableQuoteInterface
+- Magento\NegotiableQuoteTemplate\Api\Data\ReferenceDocumentLinkInterface
+- Magento\NegotiableQuoteTemplate\Api\Data\TemplateInterface
+- Magento\NegotiableQuoteTemplate\Api\Template\Actions\AcceptInterface
+- Magento\NegotiableQuoteTemplate\Api\Template\Actions\CancelInterface
+- Magento\NegotiableQuoteTemplate\Api\Template\Actions\CreateInterface
+- Magento\NegotiableQuoteTemplate\Api\Template\Actions\DeclineInterface
+- Magento\NegotiableQuoteTemplate\Api\Template\Actions\DeleteInterface
+- Magento\NegotiableQuoteTemplate\Api\Template\Actions\EditParentQuoteInterface
+- Magento\NegotiableQuoteTemplate\Api\Template\Actions\ExpireInterface
+- Magento\NegotiableQuoteTemplate\Api\Template\Actions\GenerateQuoteInterface
+- Magento\NegotiableQuoteTemplate\Api\Template\Actions\OpenInterface
+- Magento\NegotiableQuoteTemplate\Api\Template\Actions\RemoveItemInterface
+- Magento\NegotiableQuoteTemplate\Api\Template\Actions\SellerSendInterface
+- Magento\NegotiableQuoteTemplate\Api\Template\Actions\SendInterface
+- Magento\NegotiableQuoteTemplate\Api\Template\Actions\UpdateInterface
+- Magento\NegotiableQuoteTemplate\Api\Template\DraftManagementInterface
+- Magento\NegotiableQuoteTemplate\Api\Template\ReferenceDocumentLinkRepositoryInterface
+- Magento\NegotiableQuoteTemplate\Api\Template\RepositoryInterface
+- Magento\NegotiableQuoteTemplate\Model\Template\ParentQuote\Messages\LabelProviderInterface
+- Magento\NegotiableQuote\Api\NegotiableQuoteBuyerDraftManagementInterface
+- Magento\NegotiableQuote\Api\RenameNegotiableQuoteInterface
+
+##### [public] Added optional parameter(s)
+
+- Magento\Framework\Mview\ViewInterface::unsubscribe
+
+##### [public] Method has been added
+
+- Magento\AdminUiSdkCustomFees\Api\CustomFeesRepositoryInterface::getByCreditMemoId
+- Magento\AdminUiSdkCustomFees\Api\CustomFeesRepositoryInterface::getByInvoiceId
+- Magento\AdobeCommerceEventsClient\Api\EventSubscriberInterface::unsubscribe
+- Magento\Company\Api\Data\CompanyCustomerInterface::getIsDefault
+- Magento\Company\Api\Data\CompanyCustomerInterface::setIsDefault
+- Magento\Company\Api\Data\StructureInterface::getCompanyId
+- Magento\Company\Api\Data\StructureInterface::getExtensionAttributes
+- Magento\Company\Api\Data\StructureInterface::setCompanyId
+- Magento\Company\Api\Data\StructureInterface::setExtensionAttributes
+- Magento\TwoFactorAuth\Api\DuoAuthenticateInterface::createAdminAccessTokenWithCredentialsAndPasscode
+- Magento\TwoFactorAuth\Api\DuoConfigureInterface::duoActivate
+- Magento\TwoFactorAuth\Api\DuoConfigureInterface::getDuoConfigurationData
+
+##### [public] Method parameter typing changed
+
+- Magento\AdobeCommerceEventsClient\Event\EventRetrieverInterface::getEventsWithLimit
+- Magento\AdobeImsApi\Api\FlushUserTokensInterface::execute
+- Magento\AdobeImsApi\Api\GetAccessTokenInterface::execute
+- Magento\AdobeImsApi\Api\UserAuthorizedInterface::execute
+- Magento\AdobeStockClientApi\Api\Client\FilesInterface::execute
+- Magento\AdobeStockImageApi\Api\SaveLicensedImageInterface::execute
+- Magento\Bundle\Api\Data\OptionInterface::setProductLinks
+- Magento\CatalogGraphQl\Model\Resolver\Categories\DataProvider\Category\CollectionProcessorInterface::process
+- Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product\CollectionProcessorInterface::process
+- Magento\Catalog\Api\Data\CategoryTreeInterface::setChildrenData
+- Magento\Catalog\Api\Data\ProductAttributeMediaGalleryEntryInterface::setTypes
+- Magento\Catalog\Api\Data\ProductCustomOptionInterface::setValues
+- Magento\Catalog\Api\Data\ProductInterface::setMediaGalleryEntries
+- Magento\Catalog\Api\Data\ProductInterface::setOptions
+- Magento\Catalog\Api\Data\ProductInterface::setProductLinks
+- Magento\Catalog\Api\Data\ProductInterface::setTierPrices
+- Magento\Catalog\Model\Product\CatalogPriceInterface::getCatalogPrice
+- Magento\Checkout\Api\GuestPaymentInformationManagementInterface::savePaymentInformation
+- Magento\Checkout\Api\GuestPaymentInformationManagementInterface::savePaymentInformationAndPlaceOrder
+- Magento\Checkout\Api\PaymentInformationManagementInterface::savePaymentInformation
+- Magento\Checkout\Api\PaymentInformationManagementInterface::savePaymentInformationAndPlaceOrder
+- Magento\CompanyCredit\Api\CreditBalanceManagementInterface::decrease
+- Magento\CompanyCredit\Api\CreditBalanceManagementInterface::increase
+- Magento\ConfigurableProduct\Api\Data\OptionInterface::setValues
+- Magento\Customer\Api\AccountDelegationInterface::createRedirectForNew
+- Magento\Customer\Api\Data\AddressInterface::setRegion
+- Magento\Customer\Api\Data\AttributeMetadataInterface::setOptions
+- Magento\Customer\Api\Data\CustomerInterface::setAddresses
+- Magento\Customer\Api\Data\OptionInterface::setOptions
+- Magento\Customer\CustomerData\SectionPoolInterface::getSectionsData
+- Magento\Directory\Api\Data\CurrencyInformationInterface::setAvailableCurrencyCodes
+- Magento\Directory\Api\Data\CurrencyInformationInterface::setExchangeRates
+- Magento\Downloadable\Api\Data\LinkInterface::setLinkFileContent
+- Magento\Downloadable\Api\Data\LinkInterface::setSampleFileContent
+- Magento\Downloadable\Api\Data\SampleInterface::setSampleFileContent
+- Magento\Eav\Api\Data\AttributeInterface::setFrontendLabels
+- Magento\Eav\Api\Data\AttributeInterface::setOptions
+- Magento\Eav\Api\Data\AttributeInterface::setValidationRules
+- Magento\Eav\Api\Data\AttributeOptionInterface::setStoreLabels
+- Magento\Eav\Model\Entity\AttributeLoaderInterface::loadAllAttributes
+- Magento\Framework\Api\ImageProcessorInterface::save
+- Magento\Framework\Api\SearchCriteriaInterface::setFilterGroups
+- Magento\Framework\Api\SearchCriteriaInterface::setSortOrders
+- Magento\Framework\Api\Search\SearchResultInterface::setItems
+- Magento\Framework\App\ResourceConnection\ConnectionAdapterInterface::getConnection
+- Magento\Framework\Filesystem\Directory\WriteInterface::copyFile
+- Magento\Framework\Filesystem\Directory\WriteInterface::createSymlink
+- Magento\Framework\Filesystem\Directory\WriteInterface::renameFile
+- Magento\Framework\Filesystem\DriverInterface::copy
+- Magento\Framework\Filesystem\DriverInterface::rename
+- Magento\Framework\Filesystem\DriverInterface::symlink
+- Magento\Framework\GraphQl\Query\ResolverInterface::resolve
+- Magento\Framework\Oauth\NonceGeneratorInterface::generateNonce
+- Magento\Framework\Profiler\DriverInterface::start
+- Magento\Framework\Session\SessionManagerInterface::destroy
+- Magento\Framework\Setup\Declaration\Schema\Diff\DiffInterface::register
+- Magento\Framework\Stdlib\CookieManagerInterface::deleteCookie
+- Magento\Framework\Stdlib\CookieManagerInterface::setPublicCookie
+- Magento\Framework\Stdlib\CookieManagerInterface::setSensitiveCookie
+- Magento\Framework\Stdlib\Cookie\CookieScopeInterface::getCookieMetadata
+- Magento\Framework\Stdlib\Cookie\CookieScopeInterface::getPublicCookieMetadata
+- Magento\Framework\Stdlib\Cookie\CookieScopeInterface::getSensitiveCookieMetadata
+- Magento\Framework\View\Design\FileResolution\Fallback\ResolverInterface::resolve
+- Magento\GiftCard\Api\Data\GiftcardAmountInterface::setExtensionAttributes
+- Magento\GiftWrapping\Api\Data\WrappingInterface::setWebsiteIds
+- Magento\GiftWrapping\Api\Data\WrappingSearchResultsInterface::setItems
+- Magento\ImportJsonApi\Api\Data\SourceDataInterface::setItems
+- Magento\InventoryApi\Api\SourceRepositoryInterface::getList
+- Magento\InventoryApi\Api\StockRepositoryInterface::getList
+- Magento\InventoryReservationsApi\Model\ReservationBuilderInterface::setMetadata
+- Magento\Inventory\Model\Source\Command\GetListInterface::execute
+- Magento\Inventory\Model\Stock\Command\GetListInterface::execute
+- Magento\NegotiableQuote\Api\PaymentInformationManagementInterface::savePaymentInformation
+- Magento\NegotiableQuote\Api\PaymentInformationManagementInterface::savePaymentInformationAndPlaceOrder
+- Magento\PageBuilder\Model\Dom\Adapter\DocumentInterface::createElement
+- Magento\PageBuilder\Model\Dom\Adapter\DocumentInterface::saveHTML
+- Magento\PaymentServicesPaypal\Api\PaymentOrderRequestInterface::create
+- Magento\PaymentServicesPaypal\Api\PaymentOrderRequestInterface::createGuest
+- Magento\Payment\Gateway\Command\CommandManagerInterface::execute
+- Magento\Payment\Gateway\Command\CommandManagerInterface::executeByCode
+- Magento\Payment\Model\MethodInterface::isAvailable
+- Magento\PurchaseOrder\Api\Data\PurchaseOrderSearchResultsInterface::setItems
+- Magento\PurchaseOrder\Api\PurchaseOrderPaymentInformationManagementInterface::savePaymentInformationAndPlacePurchaseOrder
+- Magento\Quote\Api\CartManagementInterface::placeOrder
+- Magento\Quote\Api\CartTotalManagementInterface::collectTotals
+- Magento\Quote\Api\Data\CartInterface::setBillingAddress
+- Magento\Quote\Api\Data\CartInterface::setCurrency
+- Magento\Quote\Api\Data\CartInterface::setCustomer
+- Magento\Quote\Api\Data\CartInterface::setItems
+- Magento\Quote\Api\Data\TotalsInterface::setItems
+- Magento\Quote\Api\GuestCartManagementInterface::placeOrder
+- Magento\Quote\Api\GuestCartTotalManagementInterface::collectTotals
+- Magento\Rma\Api\Data\CommentSearchResultInterface::setItems
+- Magento\Rma\Api\Data\RmaInterface::setComments
+- Magento\Rma\Api\Data\RmaInterface::setItems
+- Magento\Rma\Api\Data\RmaInterface::setTracks
+- Magento\Rma\Api\Data\RmaSearchResultInterface::setItems
+- Magento\Rma\Api\Data\TrackSearchResultInterface::setItems
+- Magento\SalesRule\Api\Data\ConditionInterface::setConditions
+- Magento\SalesRule\Api\Data\CouponSearchResultInterface::setItems
+- Magento\SalesRule\Api\Data\RuleInterface::setActionCondition
+- Magento\SalesRule\Api\Data\RuleInterface::setCondition
+- Magento\SalesRule\Api\Data\RuleInterface::setProductIds
+- Magento\SalesRule\Api\Data\RuleInterface::setStoreLabels
+- Magento\SalesRule\Api\Data\RuleSearchResultInterface::setItems
+- Magento\Sales\Api\Data\OrderInterface::setBillingAddress
+- Magento\Sales\Api\Data\OrderInterface::setPayment
+- Magento\Sales\Api\Data\OrderInterface::setStatusHistories
+- Magento\Sales\Api\Data\OrderSearchResultInterface::setItems
+- Magento\Sales\Api\Data\ShipmentInterface::setPackages
+- Magento\Sales\Api\InvoiceOrderInterface::execute
+- Magento\Sales\Api\RefundInvoiceInterface::execute
+- Magento\Sales\Api\RefundOrderInterface::execute
+- Magento\Sales\Api\ShipOrderInterface::execute
+- Magento\Sales\Model\Order\Creditmemo\ItemCreationValidatorInterface::validate
+- Magento\Sales\Model\Order\Creditmemo\NotifierInterface::notify
+- Magento\Sales\Model\Order\Creditmemo\SenderInterface::send
+- Magento\Sales\Model\Order\Invoice\NotifierInterface::notify
+- Magento\Sales\Model\Order\Invoice\SenderInterface::send
+- Magento\Sales\Model\Order\Shipment\NotifierInterface::notify
+- Magento\Sales\Model\Order\Shipment\SenderInterface::send
+- Magento\Sales\Model\Order\Validation\InvoiceOrderInterface::validate
+- Magento\Sales\Model\Order\Validation\RefundInvoiceInterface::validate
+- Magento\Sales\Model\Order\Validation\RefundOrderInterface::validate
+- Magento\Sales\Model\Order\Validation\ShipOrderInterface::validate
+- Magento\Shipping\Model\Carrier\AbstractCarrierInterface::getContainerTypes
+- Magento\Shipping\Model\Carrier\AbstractCarrierInterface::getDeliveryConfirmationTypes
+- Magento\Store\Api\StoreConfigManagerInterface::getStoreConfigs
+- Magento\Tax\Api\Data\AppliedTaxInterface::setRates
+- Magento\Tax\Api\Data\OrderTaxDetailsInterface::setAppliedTaxes
+- Magento\Tax\Api\Data\OrderTaxDetailsInterface::setItems
+- Magento\Tax\Api\Data\OrderTaxDetailsItemInterface::setAppliedTaxes
+- Magento\Tax\Api\Data\QuoteDetailsInterface::setBillingAddress
+- Magento\Tax\Api\Data\QuoteDetailsInterface::setCustomerTaxClassKey
+- Magento\Tax\Api\Data\QuoteDetailsInterface::setItems
+- Magento\Tax\Api\Data\QuoteDetailsInterface::setShippingAddress
+- Magento\Tax\Api\Data\QuoteDetailsItemInterface::setTaxClassKey
+- Magento\Tax\Api\Data\TaxDetailsInterface::setAppliedTaxes
+- Magento\Tax\Api\Data\TaxDetailsInterface::setItems
+- Magento\Tax\Api\Data\TaxDetailsItemInterface::setAppliedTaxes
+- Magento\Tax\Api\Data\TaxRateInterface::setTitles
+- Magento\Tax\Api\Data\TaxRuleInterface::setCustomerTaxClassIds
+- Magento\Tax\Api\Data\TaxRuleInterface::setProductTaxClassIds
+- Magento\Tax\Api\Data\TaxRuleInterface::setTaxRateIds
+- Magento\VersionsCms\Api\Data\HierarchyNodeSearchResultsInterface::setItems
+
+##### [public] Method return typing changed
+
+- Magento\AdminUiSdkCustomFees\Api\CustomFeesRepositoryInterface::getByOrderId
+- Magento\Framework\Mview\ViewInterface::unsubscribe
+- Magento\GiftWrapping\Api\Data\WrappingInterface::getWrappingId
+
+#### Database changes
+
+##### Column was added
+
+- company_advanced_customer_entity/is_default
+- company_structure/company_id
+- magento_rma/confirmation_key
+- negotiable_quote_item/is_discounting_locked
+- negotiable_quote_item/max_qty
+- negotiable_quote_item/min_qty
+- sales_creditmemo_comment/updated_at
+- sales_creditmemo_comment/user_id
+- sales_creditmemo_comment/user_type
+- sales_invoice_comment/updated_at
+- sales_invoice_comment/user_id
+- sales_invoice_comment/user_type
+- sales_shipment_comment/updated_at
+- sales_shipment_comment/user_id
+- sales_shipment_comment/user_type
+
+##### Foreign key was added
+
+- company_structure/COMPANY_STRUCTURE_COMPANY_ID_COMPANY_ENTITY_ID
+
+##### Primary key was added
+
+- company_advanced_customer_entity/PRIMARY
+
+##### Table was added
+
+- admin_ui_sdk_logs
+- company_quote_link
+- company_relation
+- negotiable_quote_template
+- negotiable_quote_template_grid
+- negotiable_quote_template_reference_document_link
+- negotiable_template_generated_quote
+- sales_order_confirm_cancel
+- sales_order_status_change_history
+
+##### Unique key was added
+
+- eav_attribute_option_value/EAV_ATTRIBUTE_OPTION_VALUE_STORE_ID_OPTION_ID
+- sales_creditmemo_comment/SALES_CREDITMEMO_COMMENT_ENTITY_ID_USER_ID_USER_TYPE
+- sales_invoice_comment/SALES_INVOICE_COMMENT_ENTITY_ID_USER_ID_USER_TYPE
+- sales_shipment_comment/SALES_SHIPMENT_COMMENT_ENTITY_ID_USER_ID_USER_TYPE
+
+##### Unique key was removed
+
+- company_advanced_customer_entity/COMPANY_ADVANCED_CUSTOMER_ENTITY_CUSTOMER_ID
+
+#### Di changes
+
+##### Virtual Type was changed
+
+- type
+
+##### Virtual Type was removed
+
+- Magento\Elasticsearch7\Model\Adapter\FieldMapper\ProductFieldMapper
+- Magento\Elasticsearch7\Model\Client\ElasticsearchFactory
+- Magento\Elasticsearch7\Model\DataProvider\Suggestions
+- Magento\Elasticsearch7\Setup\InstallConfig
+- Magento\NegotiableQuote\Model\ResourceModel\Grid\Collection
+- \Magento\Elasticsearch7\Model\Adapter\FieldMapper\Product\FieldProvider\FieldName\Resolver\CompositeResolver
+- bannerNotificationRegistration
+- customFeeRegistration
+- customerGridColumnRegistration
+- customerMassActionRegistration
+- orderGridColumnRegistration
+- orderMassActionRegistration
+- orderViewButtonRegistration
+- productGridColumnRegistration
+- productMassActionRegistration
+
+#### Layout changes
+
+##### Block was removed
+
+- uix.menu.placeholder
+
+#### System changes
+
+##### A field-node was added
+
+- admin_ui_sdk/database_logging/enable_database_logging
+- admin_ui_sdk/database_logging/logs_level
+- admin_ui_sdk/database_logging/retention_period
+- admin_ui_sdk/local_testing/app_status
+- admin_ui_sdk/local_testing/enable_testing
+- admin_ui_sdk/local_testing/testing_mode
+- carriers/fedex/enabled_tracking_api
+- carriers/fedex/tracking_api_key
+- carriers/fedex/tracking_api_secret_key
+- catalog/rule/share_all_catalog_rules
+- catalog/rule/share_applied_catalog_rules
+- catalog/search/elasticsearch8_enable_auth
+- catalog/search/elasticsearch8_index_prefix
+- catalog/search/elasticsearch8_minimum_should_match
+- catalog/search/elasticsearch8_password
+- catalog/search/elasticsearch8_server_hostname
+- catalog/search/elasticsearch8_server_port
+- catalog/search/elasticsearch8_server_timeout
+- catalog/search/elasticsearch8_test_connect_wizard
+- catalog/search/elasticsearch8_username
+- catalog/seo/product_rewrite_context
+- catalog/seo/product_url_transliteration
+- cataloginventory/options/not_available_message
+- commerce_webhooks/db_log/db_log_full_message
+- customer/account_information/graphql_share_all_customer_groups
+- customer/account_information/graphql_share_customer_group
+- customer/magento_customersegment/share_active_segments
+- customer/magento_customersegment/share_segments_list
+- payment/recommended_solutions/magento_payments_legacy/general_configuration/mba_scoping_level
+- payment/recommended_solutions/magento_payments_legacy/general_configuration/paypal_merchant_id
+- promo/graphql/share_all_sales_rule
+- promo/graphql/share_applied_sales_rule
+- recaptcha_frontend/type_for/resend_confirmation_email
+- sales_email/quote_templates/accepted_by_buyer
+- sales_email/quote_templates/canceled_by_buyer
+- sales_email/quote_templates/canceled_by_seller
+- sales_email/quote_templates/copy_method
+- sales_email/quote_templates/copy_to
+- sales_email/quote_templates/declined_by_seller
+- sales_email/quote_templates/enabled
+- sales_email/quote_templates/expired
+- sales_email/quote_templates/linked_quote_ordered
+- sales_email/quote_templates/sent_by_buyer_after_create
+- sales_email/quote_templates/sent_by_buyer_after_update
+- sales_email/quote_templates/sent_by_seller_after_create
+- sales_email/quote_templates/sent_by_seller_after_update
+- system/full_page_cache/varnish/export_button_version7
+- twofactorauth/duo/client_id
+- twofactorauth/duo/client_secret
+- twofactorauth/general/auth_lock_expire
+- twofactorauth/general/twofactorauth_retry
+- twofactorauth/google/leeway
+
+##### A field-node was removed
+
+- admin_ui_sdk/local_testing/enable_local_testing
+- catalog/search/elasticsearch7_enable_auth
+- catalog/search/elasticsearch7_index_prefix
+- catalog/search/elasticsearch7_minimum_should_match
+- catalog/search/elasticsearch7_password
+- catalog/search/elasticsearch7_server_hostname
+- catalog/search/elasticsearch7_server_port
+- catalog/search/elasticsearch7_server_timeout
+- catalog/search/elasticsearch7_test_connect_wizard
+- catalog/search/elasticsearch7_username
+- twofactorauth/google/otp_window
+
+#### Xsd changes
+
+##### A schema declaration was added
+
+- var/jenkins/workspace/gendocs-core-BIC-reference/commerce/commerce-b2b-after/app/code/magento/module-data-exporter/etc/et_schema.xsd
+- var/jenkins/workspace/gendocs-core-BIC-reference/commerce/commerce-b2b-after/app/code/magento/module-elasticsearch/etc/esconfig.xsd
+
+##### A schema declaration was removed
+
+- var/jenkins/workspace/gendocs-core-BIC-reference/commerce/commerce-b2b-before/app/code/magento/module-data-exporter/etc/et_schema.xsd
+- var/jenkins/workspace/gendocs-core-BIC-reference/commerce/commerce-b2b-before/app/code/magento/module-elasticsearch/etc/esconfig.xsd
+
+#### Class API membership changes
+
+##### Class was added
+
+- Magento\AdvancedCheckout\Block\Adminhtml\Sku\AbstractSku
+- Magento\CatalogInventory\Model\Stock\Item
+- Magento\Catalog\Block\Adminhtml\Category\Tab\Product
+- Magento\Customer\Model\ResourceModel\Customer\Collection
+- Magento\Downloadable\Model\Sales\Order\Pdf\Items\AbstractItems
+- Magento\Framework\Api\SearchCriteria
+- Magento\Framework\Data\Form\Element\Editor
+- Magento\Framework\Data\Structure
+- Magento\Framework\Flag
+- Magento\Framework\Locale\Resolver
+- Magento\Framework\Model\ResourceModel\Db\VersionControl\Collection
+- Magento\Framework\Session\SessionManager
+- Magento\Framework\Url
+- Magento\GiftRegistry\Block\Form\Element
+- Magento\MediaStorage\Model\File\Storage\Database\AbstractDatabase
+- Magento\NegotiableQuote\Block\Quote\AbstractQuote
+- Magento\SalesRule\Model\Validator
+- Magento\Sales\Model\Order\Total\Config\Base
+- Magento\Sales\Model\ResourceModel\Report\Bestsellers\Collection
+- Magento\Sales\Model\ResourceModel\Report\Collection\AbstractCollection
+- Magento\TargetRule\Block\Catalog\Product\ProductList\AbstractProductList
+- Magento\Ui\DataProvider\ModifierPoolDataProvider
+- Magento\Wishlist\Block\AbstractBlock
+
+##### Class was removed
+
+- Magento\PageBuilder\Block\Adminhtml\Stage\Render

--- a/src/_includes/backward-incompatible-changes/open-source/2.4.7-2.4.8.md
+++ b/src/_includes/backward-incompatible-changes/open-source/2.4.7-2.4.8.md
@@ -1,777 +1,822 @@
-#### Class changes {#open-source-BICs-247-248-stable-class}
+#### Class changes
 
-| What changed | How it changed |
-| --- | --- |
-| Magento\AdminNotification\Model\Feed::\_\_construct | [public] Method parameter typing changed. |
-| Magento\AdminNotification\Model\ResourceModel\System\Message\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\AdvancedSearch\Model\ResourceModel\Index::\_\_construct | [public] Method parameter typing changed. |
-| Magento\AdvancedSearch\Model\ResourceModel\Search\Grid\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\App\AbstractAction::\_forward | [protected] Method parameter typing changed. |
-| Magento\Backend\App\Area\FrontNameResolver::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Block\Context::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Block\Media\Uploader::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Block\Menu::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Block\System\Store\Edit::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Block\Template\Context::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Block\Widget\Context::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Block\Widget\Form::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Block\Widget\Grid\Export::\_getRowCollection | [protected] Method parameter typing changed. |
-| Magento\Backend\Block\Widget\Grid\Massaction::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Controller\Adminhtml\Auth\Login::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Helper\Dashboard\Order::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Model\Auth::throwException | [public] Method parameter typing changed. |
-| Magento\Backend\Model\Auth\Session::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Model\Menu::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backend\Model\Url::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Backup\Model\Config\Backend\Cron::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Bundle\Block\Adminhtml\Sales\Order\View\Items\Renderer::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Bundle\Block\Sales\Order\Items\Renderer::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Bundle\Helper\Catalog\Product\Configuration::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Bundle\Model\Option::setProductLinks | [public] Method parameter typing changed. |
-| Magento\Bundle\Model\Product\Price::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Bundle\Model\Product\Type::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Bundle\Model\ResourceModel\Selection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Bundle\Model\ResourceModel\Selection\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Bundle\Model\Selection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Bundle\Pricing\Price\ConfiguredPrice::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Captcha\Model\DefaultModel::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogImportExport\Model\Import\Product::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogImportExport\Model\Import\Product\Option::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogImportExport\Model\Import\Product\Type\AbstractType::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogImportExport\Model\Import\Uploader::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogInventory\Model\Adminhtml\Stock\Item::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogInventory\Model\ResourceModel\Indexer\Stock\DefaultStock::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogInventory\Model\Source\Stock::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogRule\Model\Indexer\IndexBuilder::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogRule\Model\Indexer\IndexBuilder::applyAllRules | [protected] Method parameter typing changed. |
-| Magento\CatalogRule\Model\Indexer\IndexBuilder::getRuleProductsStmt | [protected] Method parameter typing changed. |
-| Magento\CatalogRule\Model\ResourceModel\Rule\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogSearch\Model\Adminhtml\System\Config\Backend\Engine::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogSearch\Model\Advanced::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogSearch\Model\Indexer\Fulltext::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogSearch\Model\Indexer\Fulltext::executeByDimensions | [public] Method parameter typing changed. |
-| Magento\CatalogSearch\Model\Indexer\Fulltext\Action\DataProvider::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogSearch\Model\Indexer\Fulltext\Action\Full::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogSearch\Model\Indexer\IndexStructure::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogSearch\Model\ResourceModel\Advanced\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogSearch\Model\ResourceModel\Fulltext::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogSearch\Model\ResourceModel\Search\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogSearch\Model\Search\RequestGenerator::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CatalogWidget\Model\Rule::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Block\Adminhtml\Product\Composite\Configure::setProduct | [public] Method parameter typing changed. |
-| Magento\Catalog\Block\Adminhtml\Product\Edit\Action\Attribute\Tab\Attributes::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Block\Category\View::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Block\Product\ImageFactory::create | [public] Method parameter typing changed. |
-| Magento\Catalog\Block\Product\ProductList\Toolbar::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Block\Product\View\Gallery::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Block\Product\View\Options::setProduct | [public] Method parameter typing changed. |
-| Magento\Catalog\Block\Product\View\Options\AbstractOptions::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Block\Product\View\Options\AbstractOptions::setProduct | [public] Method parameter typing changed. |
-| Magento\Catalog\Block\Product\View\Options\Type\Select::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Controller\Adminhtml\Product\Initialization\Helper::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Helper\Image::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Helper\Product\ProductList::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\AbstractModel::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\AbstractModel::getAttributeDefaultValue | [public] Method return typing changed. |
-| Magento\Catalog\Model\Category::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Category::setChildrenData | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Category\Attribute\Backend\Image::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Category\DataProvider::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Design::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Indexer\Category\Product\AbstractAction::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product::setMediaGalleryEntries | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product::setOptions | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product::setProductLinks | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product::setTierPrices | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Action::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Attribute\Backend\Price::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Compare\Item::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Compare\Item::bindCustomerLogout | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Compare\ListCompare::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Gallery\CreateHandler::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Gallery\Processor::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Gallery\UpdateHandler::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Link::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Option::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Option::setProduct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Option::setValues | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Option\Value::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Type\AbstractType::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Type\Price::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Type\Price::setTierPrices | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\Url::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\AbstractResource::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\Category\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\Collection\AbstractCollection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\Eav\Attribute::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\Layer\Filter\Price::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\Product::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\Product\Attribute\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\Product\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\Product\Compare\Item\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\Product\Gallery::loadDataFromTableByValueId | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\Product\Indexer\Price\DefaultPrice::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\Product\Link\Product\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\ResourceModel\Product\Option\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\System\Config\Backend\Catalog\Url\Rewrite\Suffix::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Pricing\Price\TierPrice::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Ui\Component\ColumnFactory::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Ui\Component\Listing\Columns\Websites::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AdvancedPricing::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Categories::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Eav::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\General::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Ui\DataProvider\Product\ProductCustomOptionsDataProvider::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Catalog\Ui\DataProvider\Product\ProductDataProvider::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Checkout\Block\Cart\Item\Renderer::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Checkout\Block\Cart\Shipping::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Checkout\Block\Cart\Sidebar::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Checkout\Block\Onepage::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Checkout\Model\Cart\ImageProvider::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Checkout\Model\Session::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Tree::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Cms\Model\Page::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Cms\Model\Wysiwyg\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Cms\Model\Wysiwyg\Images\Storage::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\App\Config\Type\System::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Block\System\Config\Edit::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Block\System\Config\Form::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Console\Command\ConfigSetCommand::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Console\Command\ConfigSet\DefaultProcessor::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Admin\Custom::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Admin\Usecustom::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Admin\Usesecretkey::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Baseurl::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Currency\Allow::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Currency\Base::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Currency\Cron::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Encrypted::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\File::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Image\Adapter::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Locale::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Log\Cron::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Secure::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Serialized::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Backend\Store::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Export\Comment::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Loader::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Source\Locale\Currency::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\Structure\Data::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\Config\TypePool::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Config\Model\ResourceModel\Config::\_construct | [protected] Method parameter typing changed. |
-| Magento\ConfigurableProduct\Block\Adminhtml\Product\Composite\Fieldset\Configurable::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ConfigurableProduct\Block\Adminhtml\Product\Steps\Bulk::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ConfigurableProduct\Block\Product\View\Type\Configurable::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ConfigurableProduct\Helper\Data::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ConfigurableProduct\Model\Product\Type\Configurable::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable\Attribute\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Cron\Model\Schedule::\_\_construct | [public] Method parameter typing changed. |
-| Magento\CurrencySymbol\Model\System\Currencysymbol::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Block\Account\AuthenticationPopup::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Block\Address\Book::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Block\Address\Book::getAddressHtml | [public] Method parameter typing changed. |
-| Magento\Customer\Block\Address\Edit::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Block\Adminhtml\Edit\Tab\Newsletter\Grid::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Block\CustomerScopeData::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Block\Form\Register::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\CustomerData\SectionPool::getSectionsData | [public] Method parameter typing changed. |
-| Magento\Customer\Model\Address::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Model\Address\AbstractAddress::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Model\Customer::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Model\Customer\DataProvider::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Model\Data\Address::setRegion | [public] Method parameter typing changed. |
-| Magento\Customer\Model\Group::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Model\ResourceModel\Customer::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Model\Session::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Customer\Model\Url::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Deploy\Package\Package::aggregate | [public] Method parameter typing changed. |
-| Magento\Directory\Model\Country::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Directory\Model\Currency::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Directory\Model\ResourceModel\Country::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Directory\Model\ResourceModel\Country\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Directory\Model\ResourceModel\Region\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Downloadable\Model\Link::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Downloadable\Model\Link::setLinkFileContent | [public] Method parameter typing changed. |
-| Magento\Downloadable\Model\Link::setSampleFileContent | [public] Method parameter typing changed. |
-| Magento\Downloadable\Model\Product\Type::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Downloadable\Model\ResourceModel\Sample\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Downloadable\Model\Sales\Order\Pdf\Items\Creditmemo::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Downloadable\Model\Sales\Order\Pdf\Items\Invoice::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Downloadable\Model\Sample::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Downloadable\Model\Sample::setSampleFileContent | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\AbstractEntity::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Attribute::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Attribute\AbstractAttribute::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Attribute\AbstractAttribute::setFrontendLabels | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Attribute\AbstractAttribute::setOptions | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Attribute\AbstractAttribute::setValidationRules | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Attribute\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Attribute\Frontend\AbstractFrontend::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Attribute\Group::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Attribute\Option::setStoreLabels | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Attribute\Source\Table::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Collection\AbstractCollection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Collection\VersionControl\AbstractCollection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\Type::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Form\Element::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Form\Fieldset::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\ResourceModel\Attribute\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\ResourceModel\Entity\Attribute::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\ResourceModel\Entity\Attribute\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\ResourceModel\Form\Attribute\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Model\ResourceModel\Form\Fieldset\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Eav\Setup\EavSetup::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Elasticsearch\Model\ResourceModel\Index::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Elasticsearch\SearchAdapter\Dynamic\DataProvider::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Email\Model\AbstractTemplate::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Email\Model\BackendTemplate::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Email\Model\Template::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Email\Model\Template\Filter::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Amqp\Config | Interface has been added. |
-| Magento\Framework\Amqp\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Amqp\Config::\_resetState | [public] Method has been added. |
-| Magento\Framework\Api\Search\FilterGroup::setFilters | [public] Method parameter typing changed. |
-| Magento\Framework\App\Action\Action::\_forward | [protected] Method parameter typing changed. |
-| Magento\Framework\App\Bootstrap::create | [public] Method parameter typing changed. |
-| Magento\Framework\App\Config\Value::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\App\Http\Context::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\App\Request\Http::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\App\Response\Http::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Config\Data::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Config\Data\Scoped::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Controller\Result\Json::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\DB\Adapter\Pdo\Mysql::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\DB\Adapter\Pdo\MysqlFactory::create | [public] Method parameter typing changed. |
-| Magento\Framework\DB\Ddl\Table::\_\_construct | [public] Method has been added. |
-| Magento\Framework\Data\Collection::getItemById | [public] Method return typing changed. |
-| Magento\Framework\Data\Collection\AbstractDb::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Data\Collection\Filesystem::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Data\Form::setElementRenderer | [public] Method parameter typing changed. |
-| Magento\Framework\Data\Form::setFieldsetElementRenderer | [public] Method parameter typing changed. |
-| Magento\Framework\Data\Form::setFieldsetRenderer | [public] Method parameter typing changed. |
-| Magento\Framework\Exception\AbstractAggregateException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Exception\AlreadyExistsException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Exception\BulkException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Exception\InputException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Exception\InputException::invalidFieldValue | [public] Method parameter typing changed. |
-| Magento\Framework\Exception\LocalizedException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Exception\NoSuchEntityException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Exception\SerializationException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Exception\TemporaryState\CouldNotSaveException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\File\Uploader::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Filter\Template::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\GraphQl\Exception\GraphQlAuthenticationException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\GraphQl\Exception\GraphQlInputException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\HTTP\PhpEnvironment\RemoteAddress::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Logger\Handler\Base::write | [protected] Method parameter typing changed. |
-| Magento\Framework\Mail\Template\TransportBuilder::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Model\AbstractExtensibleModel::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Model\AbstractModel::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Module\Setup\Migration::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Pricing\Price\Pool::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Pricing\Render::renderAmount | [public] Method parameter typing changed. |
-| Magento\Framework\Pricing\Render\RendererPool::createAmountRender | [public] Method parameter typing changed. |
-| Magento\Framework\Pricing\Render\RendererPool::getAdjustmentRenders | [public] Method parameter typing changed. |
-| Magento\Framework\Profiler::start | [public] Method parameter typing changed. |
-| Magento\Framework\Profiler\Driver\Standard\Stat::getFilteredTimerIds | [public] Method parameter typing changed. |
-| Magento\Framework\Search\Adapter\Mysql\TemporaryStorage::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Setup\Declaration\Schema\Diff\Diff::register | [public] Method parameter typing changed. |
-| Magento\Framework\Setup\Declaration\Schema\Dto\Table::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Setup\Declaration\Schema\ElementHistory::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Validation\ValidationException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Validator\AbstractValidator::setDefaultTranslator | [public] Method parameter typing changed. |
-| Magento\Framework\Validator\Exception::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\View\Context::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\View\Element\Context::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\View\Element\Template\Context::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\View\Element\UiComponentFactory::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult::setItems | [public] Method parameter typing changed. |
-| Magento\Framework\View\Layout\Data\Structure::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\View\Layout\GeneratorPool::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\View\Page\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\View\Result\Page::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Webapi\ErrorProcessor::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Webapi\ServiceInputProcessor::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Framework\Webapi\ServiceOutputProcessor::\_\_construct | [public] Method parameter typing changed. |
-| Magento\FunctionalTestingFramework\ObjectManager::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GiftMessage\Block\Cart\GiftOptions::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GiftMessage\Block\Cart\Item\Renderer\Actions\GiftOptions::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GiftMessage\Model\Message::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GoogleAdwords\Model\Config\Backend\AbstractConversion::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GoogleAnalytics\Block\Ga::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GoogleOptimizer\Helper\Data::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GoogleOptimizer\Helper\Form::addGoogleoptimizerFields | [public] Method parameter typing changed. |
-| Magento\GraphQl\Controller\GraphQl::\_\_construct | [public] Method parameter typing changed. |
-| Magento\GroupedProduct\Model\Product\Type\Grouped::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ImportExport\Model\Import::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ImportExport\Model\Import\AbstractEntity::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ImportExport\Model\Import\AbstractEntity::getBehavior | [public] Method parameter typing changed. |
-| Magento\InstantPurchase\Model\InstantPurchaseOption::\_\_construct | [public] Method parameter typing changed. |
-| Magento\InstantPurchase\Model\InstantPurchaseOptionFactory::create | [public] Method parameter typing changed. |
-| Magento\Integration\Model\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Integration\Model\Integration::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Integration\Model\IntegrationConfig::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Integration\Model\Oauth\Consumer::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Integration\Model\Oauth\Token::\_\_construct | [public] Method parameter typing changed. |
-| Magento\InventoryAdminUi\Ui\DataProvider\SourceDataProvider::\_\_construct | [public] Method parameter typing changed. |
-| Magento\InventoryAdminUi\Ui\DataProvider\StockDataProvider::\_\_construct | [public] Method parameter typing changed. |
-| Magento\InventoryShippingAdminUi\Block\Adminhtml\Order\View\ShipButton::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Inventory\Model\ResourceModel\Source\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\MediaStorage\Model\File\Storage::\_\_construct | [public] Method parameter typing changed. |
-| Magento\MediaStorage\Model\File\Storage\Database::\_\_construct | [public] Method parameter typing changed. |
-| Magento\MediaStorage\Model\File\Storage\Directory\Database::\_\_construct | [public] Method parameter typing changed. |
-| Magento\MediaStorage\Model\File\Uploader::\_\_construct | [public] Method parameter typing changed. |
-| Magento\MediaStorage\Model\ResourceModel\File\Storage\Database::\_\_construct | [public] Method parameter typing changed. |
-| Magento\MessageQueue\Model\ConsumerRunner::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Multishipping\Model\Checkout\Type\Multishipping::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Newsletter\Model\Problem::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Newsletter\Model\Queue::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Newsletter\Model\ResourceModel\Problem\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Newsletter\Model\ResourceModel\Queue\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Newsletter\Model\ResourceModel\Subscriber::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Newsletter\Model\ResourceModel\Subscriber\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Newsletter\Model\Subscriber::\_\_construct | [public] Method parameter typing changed. |
-| Magento\PageBuilder\Block\WysiwygSetup::\_\_construct | [public] Method parameter typing changed. |
-| Magento\PageBuilder\Component\Form\Element\Wysiwyg::\_\_construct | [public] Method parameter typing changed. |
-| Magento\PageBuilder\Controller\ContentType\Preview::\_\_construct | [public] Method parameter typing changed. |
-| Magento\PageBuilder\Model\Stage\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\PageBuilder\Model\Stage\Renderer\CmsStaticBlock::\_\_construct | [public] Method parameter typing changed. |
-| Magento\PageBuilder\Model\Stage\Renderer\WidgetDirective::\_\_construct | [public] Method parameter typing changed. |
-| Magento\PageCache\Model\Config::VARNISH\_7\_CONFIGURATION\_PATH | Constant has been added. |
-| Magento\PageCache\Model\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\PaymentServicesPaypal\Block\SmartButtons::\_\_construct | [public] Method parameter typing changed. |
-| Magento\PaymentServicesPaypal\Block\SmartButtons::doesQuoteExist | [public] Method has been added. |
-| Magento\PaymentServicesPaypal\Model\Api\PaymentOrderRequest::create | [public] Method parameter typing changed. |
-| Magento\PaymentServicesPaypal\Model\Api\PaymentOrderRequest::createGuest | [public] Method parameter typing changed. |
-| Magento\Payment\Gateway\Command\CommandManager::execute | [public] Method parameter typing changed. |
-| Magento\Payment\Gateway\Command\CommandManager::executeByCode | [public] Method parameter typing changed. |
-| Magento\Payment\Gateway\Command\GatewayCommand::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Payment\Gateway\Http\Client\Soap::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Payment\Gateway\Http\Client\Zend::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Payment\Helper\Data::getInfoBlock | [public] Method parameter typing changed. |
-| Magento\Payment\Model\Info::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Payment\Model\MethodList::getAvailableMethods | [public] Method parameter typing changed. |
-| Magento\Payment\Model\Method\AbstractMethod::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Payment\Model\Method\AbstractMethod::isAvailable | [public] Method parameter typing changed. |
-| Magento\Payment\Model\Method\Adapter::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Payment\Model\Method\Adapter::isAvailable | [public] Method parameter typing changed. |
-| Magento\Payment\Model\Method\Free::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Payment\Model\Method\Free::isAvailable | [public] Method parameter typing changed. |
-| Magento\Payment\Model\Method\Logger::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Payment\Model\Method\Logger::debug | [public] Method parameter typing changed. |
-| Magento\Paypal\Block\PayLater\Banner::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Paypal\Model\Api\ProcessableException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Paypal\Model\Billing\AbstractAgreement::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Paypal\Model\Billing\Agreement::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Paypal\Model\ResourceModel\Billing\Agreement\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Persistent\Model\Session::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ProductAlert\Model\Email::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ProductAlert\Model\Price::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ProductAlert\Model\Stock::\_\_construct | [public] Method parameter typing changed. |
-| Magento\ProductVideo\Block\Product\View\Gallery::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Cart\Data\CartItem::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote::assignCustomerWithAddressChange | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote::setBillingAddress | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote::setCurrency | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote::setCustomer | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote::setItems | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote::setShippingAddress | [public] Method parameter typing changed. |
-| Magento\Quote\Model\QuoteValidator::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote\Address::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote\Address::requestShippingRates | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote\Address\Total::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote\Item::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote\Item\AbstractItem::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Quote\Model\Quote\Payment::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Quote\Model\ResourceModel\Quote\Item\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Block\Adminhtml\Grid::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Block\Adminhtml\Grid\Column\Renderer\Currency::\_\_construct | [public] Method has been removed. |
-| Magento\Reports\Controller\Adminhtml\Report\AbstractReport::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Model\Event::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Model\Product\Index\AbstractIndex::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Model\Product\Index\Compared::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Model\ResourceModel\Customer\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Model\ResourceModel\Event::getCurrentStoreIds | [public] Method parameter typing changed. |
-| Magento\Reports\Model\ResourceModel\Order\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Model\ResourceModel\Product\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Model\ResourceModel\Product\Index\Collection\AbstractCollection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Model\ResourceModel\Product\Lowstock\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Model\ResourceModel\Quote\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Model\ResourceModel\Quote\Item\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Model\ResourceModel\Review\Customer\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Reports\Model\ResourceModel\Wishlist\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Review\Block\Form::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Review\Model\Rating::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Review\Model\ResourceModel\Rating::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Review\Model\ResourceModel\Rating\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Review\Model\ResourceModel\Rating\Option\Vote\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Review\Model\ResourceModel\Review\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Review\Model\ResourceModel\Review\Product\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Review\Model\ResourceModel\Review\Product\Collection::\_applyStoresFilterToSelect | [protected] Method parameter typing changed. |
-| Magento\Review\Model\Review::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Robots\Block\Data::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Robots\Model\Config\Value::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Rss\Model\Rss::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Rule\Model\AbstractModel::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Rule\Model\Condition\Product\AbstractProduct::\_\_construct | [public] Method parameter typing changed. |
-| Magento\SaaSCommon\Model\ResyncManager::DEFAULT\_RESYNC\_ENTITY\_TYPE | Constant has been added. |
-| Magento\SaaSCommon\Model\ResyncManager::partialResyncByIds | [public] Method has been added. |
-| Magento\SalesRule\Model\ResourceModel\Rule\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\SalesRule\Model\ResourceModel\Rule\Collection::setValidationFilter | [public] Method parameter typing changed. |
-| Magento\SalesRule\Model\Rule::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Block\Adminhtml\Order\Create\Search\Grid::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Block\Order\Info\Buttons\Rss::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Block\Order\Items::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Block\Order\Recent::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\AbstractModel::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\AdminOrder\Create::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Config\Ordered::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order::setBillingAddress | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order::setPayment | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order::setShippingAddress | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order::setStatusHistories | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Address::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Creditmemo::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\CreditmemoDocumentFactory::createFromInvoice | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\CreditmemoDocumentFactory::createFromOrder | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\CreditmemoFactory::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Creditmemo\Comment::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Creditmemo\Item::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Creditmemo\Notifier::notify | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Email\Sender\InvoiceSender::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Invoice::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\InvoiceDocumentFactory::create | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Invoice\Item::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Invoice\Notifier::notify | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Item::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Item::setProductOptions | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Payment::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Payment\Info::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Payment\Transaction::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Pdf\AbstractPdf::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Pdf\Items\AbstractItems::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Shipment::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Shipment::setPackages | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\ShipmentDocumentFactory::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\ShipmentDocumentFactory::create | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\ShipmentFactory::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Shipment\Item::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Shipment\Notifier::notify | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Shipment\Track::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Status\History::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sales\Model\ResourceModel\Collection\AbstractCollection::setItems | [public] Method parameter typing changed. |
-| Magento\Sales\Model\ResourceModel\Collection\AbstractCollection::setSearchCriteria | [public] Method parameter typing changed. |
-| Magento\Sales\Model\ResourceModel\Order\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Search\Model\Query::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Search\Model\QueryFactory::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Search\Model\ResourceModel\Query\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Search\Model\SearchEngine\Config\Data::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Search\Model\SynonymReader::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Search\Model\Synonym\MergeConflictException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Security\Model\AdminSessionInfo::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Security\Model\ResourceModel\AdminSessionInfo\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Security\Model\ResourceModel\PasswordResetRequestEvent\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\SendFriend\Model\SendFriend::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Setup\Module\SetupFactory::create | [public] Method parameter typing changed. |
-| Magento\Shipping\Model\Carrier\AbstractCarrier::\_getAllowedContainers | [protected] Method parameter typing changed. |
-| Magento\Shipping\Model\Carrier\AbstractCarrier::getContainerTypes | [public] Method parameter typing changed. |
-| Magento\Shipping\Model\Carrier\AbstractCarrier::getDeliveryConfirmationTypes | [public] Method parameter typing changed. |
-| Magento\Sitemap\Model\ResourceModel\Catalog\Product::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sitemap\Model\ResourceModel\Cms\Page::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Sitemap\Model\Sitemap::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Store\Block\Switcher::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Store\Model\Group::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Store\Model\Store::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Store\Model\StoreIsInactiveException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Store\Model\Website::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Swatches\Block\Product\Renderer\Configurable::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Swatches\Block\Product\Renderer\Listing\Configurable::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Swatches\Helper\Media::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Tax\Helper\Data::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Theme\Block\Adminhtml\Wysiwyg\Files\Tree::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Theme\Block\Html\Breadcrumbs::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Theme\Block\Html\Header::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Theme\Helper\Storage::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Ui\Component\Filters\Type\Select::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Ui\Component\Listing\Columns\Date::\_\_construct | [public] Method parameter typing changed. |
-| Magento\UrlRewrite\Model\Exception\UrlAlreadyExistsException::\_\_construct | [public] Method parameter typing changed. |
-| Magento\UrlRewrite\Model\ResourceModel\UrlRewriteCollection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\UrlRewrite\Model\UrlRewrite::\_\_construct | [public] Method parameter typing changed. |
-| Magento\UrlRewrite\Service\V1\Data\UrlRewrite::\_\_construct | [public] Method parameter typing changed. |
-| Magento\User\Model\ResourceModel\User::\_\_construct | [public] Method parameter typing changed. |
-| Magento\User\Model\User::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Variable\Model\Variable::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Variable\Model\Variable\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Vault\Model\Method\Vault::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Vault\Model\Method\Vault::isAvailable | [public] Method parameter typing changed. |
-| Magento\Webapi\Model\Config::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Weee\Helper\Data::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Weee\Model\Tax::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Widget\Model\Widget\Instance::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Image::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Wishlist\Block\Share\Email\Items::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Wishlist\Helper\Data::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Wishlist\Model\Item::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Wishlist\Model\Item\Option::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Wishlist\Model\ResourceModel\Item\Collection::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Wishlist\Model\Wishlist::\_\_construct | [public] Method parameter typing changed. |
-| Magento\Wishlist\Model\Wishlist\Data\WishlistItem::\_\_construct | [public] Method parameter typing changed. |
+##### Constant has been added
 
-#### Interface changes {#open-source-BICs-247-248-stable-interface}
+- Magento\PageCache\Model\Config::VARNISH_7_CONFIGURATION_PATH
+- Magento\SaaSCommon\Model\ResyncManager::DEFAULT_RESYNC_ENTITY_TYPE
 
-| What changed | How it changed |
-| --- | --- |
-| Magento\AdobeImsApi\Api\FlushUserTokensInterface::execute | [public] Method parameter typing changed. |
-| Magento\AdobeImsApi\Api\GetAccessTokenInterface::execute | [public] Method parameter typing changed. |
-| Magento\AdobeImsApi\Api\UserAuthorizedInterface::execute | [public] Method parameter typing changed. |
-| Magento\AdobeStockClientApi\Api\Client\FilesInterface::execute | [public] Method parameter typing changed. |
-| Magento\AdobeStockImageApi\Api\SaveLicensedImageInterface::execute | [public] Method parameter typing changed. |
-| Magento\Bundle\Api\Data\OptionInterface::setProductLinks | [public] Method parameter typing changed. |
-| Magento\CatalogGraphQl\Model\Resolver\Categories\DataProvider\Category\CollectionProcessorInterface::process | [public] Method parameter typing changed. |
-| Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product\CollectionProcessorInterface::process | [public] Method parameter typing changed. |
-| Magento\Catalog\Api\Data\CategoryTreeInterface::setChildrenData | [public] Method parameter typing changed. |
-| Magento\Catalog\Api\Data\ProductAttributeMediaGalleryEntryInterface::setTypes | [public] Method parameter typing changed. |
-| Magento\Catalog\Api\Data\ProductCustomOptionInterface::setValues | [public] Method parameter typing changed. |
-| Magento\Catalog\Api\Data\ProductInterface::setMediaGalleryEntries | [public] Method parameter typing changed. |
-| Magento\Catalog\Api\Data\ProductInterface::setOptions | [public] Method parameter typing changed. |
-| Magento\Catalog\Api\Data\ProductInterface::setProductLinks | [public] Method parameter typing changed. |
-| Magento\Catalog\Api\Data\ProductInterface::setTierPrices | [public] Method parameter typing changed. |
-| Magento\Catalog\Model\Product\CatalogPriceInterface::getCatalogPrice | [public] Method parameter typing changed. |
-| Magento\Checkout\Api\GuestPaymentInformationManagementInterface::savePaymentInformation | [public] Method parameter typing changed. |
-| Magento\Checkout\Api\GuestPaymentInformationManagementInterface::savePaymentInformationAndPlaceOrder | [public] Method parameter typing changed. |
-| Magento\Checkout\Api\PaymentInformationManagementInterface::savePaymentInformation | [public] Method parameter typing changed. |
-| Magento\Checkout\Api\PaymentInformationManagementInterface::savePaymentInformationAndPlaceOrder | [public] Method parameter typing changed. |
-| Magento\ConfigurableProduct\Api\Data\OptionInterface::setValues | [public] Method parameter typing changed. |
-| Magento\Customer\Api\AccountDelegationInterface::createRedirectForNew | [public] Method parameter typing changed. |
-| Magento\Customer\Api\Data\AddressInterface::setRegion | [public] Method parameter typing changed. |
-| Magento\Customer\Api\Data\AttributeMetadataInterface::setOptions | [public] Method parameter typing changed. |
-| Magento\Customer\Api\Data\CustomerInterface::setAddresses | [public] Method parameter typing changed. |
-| Magento\Customer\Api\Data\OptionInterface::setOptions | [public] Method parameter typing changed. |
-| Magento\Customer\CustomerData\SectionPoolInterface::getSectionsData | [public] Method parameter typing changed. |
-| Magento\Directory\Api\Data\CurrencyInformationInterface::setAvailableCurrencyCodes | [public] Method parameter typing changed. |
-| Magento\Directory\Api\Data\CurrencyInformationInterface::setExchangeRates | [public] Method parameter typing changed. |
-| Magento\Downloadable\Api\Data\LinkInterface::setLinkFileContent | [public] Method parameter typing changed. |
-| Magento\Downloadable\Api\Data\LinkInterface::setSampleFileContent | [public] Method parameter typing changed. |
-| Magento\Downloadable\Api\Data\SampleInterface::setSampleFileContent | [public] Method parameter typing changed. |
-| Magento\Eav\Api\Data\AttributeInterface::setFrontendLabels | [public] Method parameter typing changed. |
-| Magento\Eav\Api\Data\AttributeInterface::setOptions | [public] Method parameter typing changed. |
-| Magento\Eav\Api\Data\AttributeInterface::setValidationRules | [public] Method parameter typing changed. |
-| Magento\Eav\Api\Data\AttributeOptionInterface::setStoreLabels | [public] Method parameter typing changed. |
-| Magento\Eav\Model\Entity\AttributeLoaderInterface::loadAllAttributes | [public] Method parameter typing changed. |
-| Magento\Framework\Api\ImageProcessorInterface::save | [public] Method parameter typing changed. |
-| Magento\Framework\Api\SearchCriteriaInterface::setFilterGroups | [public] Method parameter typing changed. |
-| Magento\Framework\Api\SearchCriteriaInterface::setSortOrders | [public] Method parameter typing changed. |
-| Magento\Framework\Api\Search\SearchResultInterface::setItems | [public] Method parameter typing changed. |
-| Magento\Framework\App\ResourceConnection\ConnectionAdapterInterface::getConnection | [public] Method parameter typing changed. |
-| Magento\Framework\Filesystem\Directory\WriteInterface::copyFile | [public] Method parameter typing changed. |
-| Magento\Framework\Filesystem\Directory\WriteInterface::createSymlink | [public] Method parameter typing changed. |
-| Magento\Framework\Filesystem\Directory\WriteInterface::renameFile | [public] Method parameter typing changed. |
-| Magento\Framework\Filesystem\DriverInterface::copy | [public] Method parameter typing changed. |
-| Magento\Framework\Filesystem\DriverInterface::rename | [public] Method parameter typing changed. |
-| Magento\Framework\Filesystem\DriverInterface::symlink | [public] Method parameter typing changed. |
-| Magento\Framework\GraphQl\Query\ResolverInterface::resolve | [public] Method parameter typing changed. |
-| Magento\Framework\Mview\ViewInterface::unsubscribe | [public] Added optional parameter(s). |
-| Magento\Framework\Mview\ViewInterface::unsubscribe | [public] Method return typing changed. |
-| Magento\Framework\Oauth\NonceGeneratorInterface::generateNonce | [public] Method parameter typing changed. |
-| Magento\Framework\Profiler\DriverInterface::start | [public] Method parameter typing changed. |
-| Magento\Framework\Session\SessionManagerInterface::destroy | [public] Method parameter typing changed. |
-| Magento\Framework\Setup\ConsoleLoggerInterface | Interface was added. |
-| Magento\Framework\Setup\Declaration\Schema\Diff\DiffInterface::register | [public] Method parameter typing changed. |
-| Magento\Framework\Stdlib\CookieManagerInterface::deleteCookie | [public] Method parameter typing changed. |
-| Magento\Framework\Stdlib\CookieManagerInterface::setPublicCookie | [public] Method parameter typing changed. |
-| Magento\Framework\Stdlib\CookieManagerInterface::setSensitiveCookie | [public] Method parameter typing changed. |
-| Magento\Framework\Stdlib\Cookie\CookieScopeInterface::getCookieMetadata | [public] Method parameter typing changed. |
-| Magento\Framework\Stdlib\Cookie\CookieScopeInterface::getPublicCookieMetadata | [public] Method parameter typing changed. |
-| Magento\Framework\Stdlib\Cookie\CookieScopeInterface::getSensitiveCookieMetadata | [public] Method parameter typing changed. |
-| Magento\Framework\View\Design\FileResolution\Fallback\ResolverInterface::resolve | [public] Method parameter typing changed. |
-| Magento\InventoryApi\Api\SourceRepositoryInterface::getList | [public] Method parameter typing changed. |
-| Magento\InventoryApi\Api\StockRepositoryInterface::getList | [public] Method parameter typing changed. |
-| Magento\InventoryReservationsApi\Model\ReservationBuilderInterface::setMetadata | [public] Method parameter typing changed. |
-| Magento\Inventory\Model\Source\Command\GetListInterface::execute | [public] Method parameter typing changed. |
-| Magento\Inventory\Model\Stock\Command\GetListInterface::execute | [public] Method parameter typing changed. |
-| Magento\PageBuilder\Model\Dom\Adapter\DocumentInterface::createElement | [public] Method parameter typing changed. |
-| Magento\PageBuilder\Model\Dom\Adapter\DocumentInterface::saveHTML | [public] Method parameter typing changed. |
-| Magento\PaymentServicesPaypal\Api\PaymentOrderRequestInterface::create | [public] Method parameter typing changed. |
-| Magento\PaymentServicesPaypal\Api\PaymentOrderRequestInterface::createGuest | [public] Method parameter typing changed. |
-| Magento\Payment\Gateway\Command\CommandManagerInterface::execute | [public] Method parameter typing changed. |
-| Magento\Payment\Gateway\Command\CommandManagerInterface::executeByCode | [public] Method parameter typing changed. |
-| Magento\Payment\Model\MethodInterface::isAvailable | [public] Method parameter typing changed. |
-| Magento\Quote\Api\CartManagementInterface::placeOrder | [public] Method parameter typing changed. |
-| Magento\Quote\Api\CartTotalManagementInterface::collectTotals | [public] Method parameter typing changed. |
-| Magento\Quote\Api\Data\CartInterface::setBillingAddress | [public] Method parameter typing changed. |
-| Magento\Quote\Api\Data\CartInterface::setCurrency | [public] Method parameter typing changed. |
-| Magento\Quote\Api\Data\CartInterface::setCustomer | [public] Method parameter typing changed. |
-| Magento\Quote\Api\Data\CartInterface::setItems | [public] Method parameter typing changed. |
-| Magento\Quote\Api\Data\TotalsInterface::setItems | [public] Method parameter typing changed. |
-| Magento\Quote\Api\GuestCartManagementInterface::placeOrder | [public] Method parameter typing changed. |
-| Magento\Quote\Api\GuestCartTotalManagementInterface::collectTotals | [public] Method parameter typing changed. |
-| Magento\SalesRule\Api\Data\ConditionInterface::setConditions | [public] Method parameter typing changed. |
-| Magento\SalesRule\Api\Data\CouponSearchResultInterface::setItems | [public] Method parameter typing changed. |
-| Magento\SalesRule\Api\Data\RuleInterface::setActionCondition | [public] Method parameter typing changed. |
-| Magento\SalesRule\Api\Data\RuleInterface::setCondition | [public] Method parameter typing changed. |
-| Magento\SalesRule\Api\Data\RuleInterface::setProductIds | [public] Method parameter typing changed. |
-| Magento\SalesRule\Api\Data\RuleInterface::setStoreLabels | [public] Method parameter typing changed. |
-| Magento\SalesRule\Api\Data\RuleSearchResultInterface::setItems | [public] Method parameter typing changed. |
-| Magento\Sales\Api\Data\OrderInterface::setBillingAddress | [public] Method parameter typing changed. |
-| Magento\Sales\Api\Data\OrderInterface::setPayment | [public] Method parameter typing changed. |
-| Magento\Sales\Api\Data\OrderInterface::setStatusHistories | [public] Method parameter typing changed. |
-| Magento\Sales\Api\Data\OrderSearchResultInterface::setItems | [public] Method parameter typing changed. |
-| Magento\Sales\Api\Data\ShipmentInterface::setPackages | [public] Method parameter typing changed. |
-| Magento\Sales\Api\InvoiceOrderInterface::execute | [public] Method parameter typing changed. |
-| Magento\Sales\Api\RefundInvoiceInterface::execute | [public] Method parameter typing changed. |
-| Magento\Sales\Api\RefundOrderInterface::execute | [public] Method parameter typing changed. |
-| Magento\Sales\Api\ShipOrderInterface::execute | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Creditmemo\ItemCreationValidatorInterface::validate | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Creditmemo\NotifierInterface::notify | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Creditmemo\SenderInterface::send | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Invoice\NotifierInterface::notify | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Invoice\SenderInterface::send | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Shipment\NotifierInterface::notify | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Shipment\SenderInterface::send | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Validation\InvoiceOrderInterface::validate | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Validation\RefundInvoiceInterface::validate | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Validation\RefundOrderInterface::validate | [public] Method parameter typing changed. |
-| Magento\Sales\Model\Order\Validation\ShipOrderInterface::validate | [public] Method parameter typing changed. |
-| Magento\Shipping\Model\Carrier\AbstractCarrierInterface::getContainerTypes | [public] Method parameter typing changed. |
-| Magento\Shipping\Model\Carrier\AbstractCarrierInterface::getDeliveryConfirmationTypes | [public] Method parameter typing changed. |
-| Magento\Store\Api\StoreConfigManagerInterface::getStoreConfigs | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\AppliedTaxInterface::setRates | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\OrderTaxDetailsInterface::setAppliedTaxes | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\OrderTaxDetailsInterface::setItems | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\OrderTaxDetailsItemInterface::setAppliedTaxes | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\QuoteDetailsInterface::setBillingAddress | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\QuoteDetailsInterface::setCustomerTaxClassKey | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\QuoteDetailsInterface::setItems | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\QuoteDetailsInterface::setShippingAddress | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\QuoteDetailsItemInterface::setTaxClassKey | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\TaxDetailsInterface::setAppliedTaxes | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\TaxDetailsInterface::setItems | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\TaxDetailsItemInterface::setAppliedTaxes | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\TaxRateInterface::setTitles | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\TaxRuleInterface::setCustomerTaxClassIds | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\TaxRuleInterface::setProductTaxClassIds | [public] Method parameter typing changed. |
-| Magento\Tax\Api\Data\TaxRuleInterface::setTaxRateIds | [public] Method parameter typing changed. |
-| Magento\TwoFactorAuth\Api\DuoAuthenticateInterface::createAdminAccessTokenWithCredentialsAndPasscode | [public] Method has been added. |
-| Magento\TwoFactorAuth\Api\DuoConfigureInterface::duoActivate | [public] Method has been added. |
-| Magento\TwoFactorAuth\Api\DuoConfigureInterface::getDuoConfigurationData | [public] Method has been added. |
+##### Interface has been added
 
-#### Database changes {#open-source-BICs-247-248-stable-database}
+- Magento\Framework\Amqp\Config
 
-| What changed | How it changed |
-| --- | --- |
-| eav\_attribute\_option\_value/EAV\_ATTRIBUTE\_OPTION\_VALUE\_STORE\_ID\_OPTION\_ID | Unique key was added |
-| sales\_creditmemo\_comment/SALES\_CREDITMEMO\_COMMENT\_ENTITY\_ID\_USER\_ID\_USER\_TYPE | Unique key was added |
-| sales\_creditmemo\_comment/updated\_at | Column was added |
-| sales\_creditmemo\_comment/user\_id | Column was added |
-| sales\_creditmemo\_comment/user\_type | Column was added |
-| sales\_invoice\_comment/SALES\_INVOICE\_COMMENT\_ENTITY\_ID\_USER\_ID\_USER\_TYPE | Unique key was added |
-| sales\_invoice\_comment/updated\_at | Column was added |
-| sales\_invoice\_comment/user\_id | Column was added |
-| sales\_invoice\_comment/user\_type | Column was added |
-| sales\_order\_confirm\_cancel | Table was added |
-| sales\_order\_status\_change\_history | Table was added |
-| sales\_shipment\_comment/SALES\_SHIPMENT\_COMMENT\_ENTITY\_ID\_USER\_ID\_USER\_TYPE | Unique key was added |
-| sales\_shipment\_comment/updated\_at | Column was added |
-| sales\_shipment\_comment/user\_id | Column was added |
-| sales\_shipment\_comment/user\_type | Column was added |
+##### [protected] Method parameter typing changed
 
-#### Di changes {#open-source-BICs-247-248-stable-di}
+- Magento\Backend\App\AbstractAction::_forward
+- Magento\Backend\Block\Widget\Grid\Export::_getRowCollection
+- Magento\CatalogRule\Model\Indexer\IndexBuilder::applyAllRules
+- Magento\CatalogRule\Model\Indexer\IndexBuilder::getRuleProductsStmt
+- Magento\Config\Model\ResourceModel\Config::_construct
+- Magento\Framework\App\Action\Action::_forward
+- Magento\Framework\Logger\Handler\Base::write
+- Magento\Review\Model\ResourceModel\Review\Product\Collection::_applyStoresFilterToSelect
+- Magento\Shipping\Model\Carrier\AbstractCarrier::_getAllowedContainers
 
-| What changed | How it changed |
-| --- | --- |
-| Magento\Elasticsearch7\Model\Adapter\FieldMapper\ProductFieldMapper | Virtual Type was removed |
-| Magento\Elasticsearch7\Model\Client\ElasticsearchFactory | Virtual Type was removed |
-| Magento\Elasticsearch7\Model\DataProvider\Suggestions | Virtual Type was removed |
-| Magento\Elasticsearch7\Setup\InstallConfig | Virtual Type was removed |
-| \Magento\Elasticsearch7\Model\Adapter\FieldMapper\Product\FieldProvider\FieldName\Resolver\CompositeResolver | Virtual Type was removed |
+##### [public] Method has been added
 
-#### System changes {#open-source-BICs-247-248-stable-system}
+- Magento\Framework\Amqp\Config::_resetState
+- Magento\Framework\DB\Ddl\Table::__construct
+- Magento\PaymentServicesPaypal\Block\SmartButtons::doesQuoteExist
+- Magento\SaaSCommon\Model\ResyncManager::partialResyncByIds
 
-| What changed | How it changed |
-| --- | --- |
-| carriers/fedex/enabled\_tracking\_api | A field-node was added |
-| carriers/fedex/tracking\_api\_key | A field-node was added |
-| carriers/fedex/tracking\_api\_secret\_key | A field-node was added |
-| catalog/rule/share\_all\_catalog\_rules | A field-node was added |
-| catalog/rule/share\_applied\_catalog\_rules | A field-node was added |
-| catalog/search/elasticsearch7\_enable\_auth | A field-node was removed |
-| catalog/search/elasticsearch7\_index\_prefix | A field-node was removed |
-| catalog/search/elasticsearch7\_minimum\_should\_match | A field-node was removed |
-| catalog/search/elasticsearch7\_password | A field-node was removed |
-| catalog/search/elasticsearch7\_server\_hostname | A field-node was removed |
-| catalog/search/elasticsearch7\_server\_port | A field-node was removed |
-| catalog/search/elasticsearch7\_server\_timeout | A field-node was removed |
-| catalog/search/elasticsearch7\_test\_connect\_wizard | A field-node was removed |
-| catalog/search/elasticsearch7\_username | A field-node was removed |
-| catalog/search/elasticsearch8\_enable\_auth | A field-node was added |
-| catalog/search/elasticsearch8\_index\_prefix | A field-node was added |
-| catalog/search/elasticsearch8\_minimum\_should\_match | A field-node was added |
-| catalog/search/elasticsearch8\_password | A field-node was added |
-| catalog/search/elasticsearch8\_server\_hostname | A field-node was added |
-| catalog/search/elasticsearch8\_server\_port | A field-node was added |
-| catalog/search/elasticsearch8\_server\_timeout | A field-node was added |
-| catalog/search/elasticsearch8\_test\_connect\_wizard | A field-node was added |
-| catalog/search/elasticsearch8\_username | A field-node was added |
-| catalog/seo/product\_rewrite\_context | A field-node was added |
-| catalog/seo/product\_url\_transliteration | A field-node was added |
-| cataloginventory/options/not\_available\_message | A field-node was added |
-| customer/account\_information/graphql\_share\_all\_customer\_groups | A field-node was added |
-| customer/account\_information/graphql\_share\_customer\_group | A field-node was added |
-| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/mba\_scoping\_level | A field-node was added |
-| payment/recommended\_solutions/magento\_payments\_legacy/general\_configuration/paypal\_merchant\_id | A field-node was added |
-| promo/graphql/share\_all\_sales\_rule | A field-node was added |
-| promo/graphql/share\_applied\_sales\_rule | A field-node was added |
-| recaptcha\_frontend/type\_for/resend\_confirmation\_email | A field-node was added |
-| recaptcha\_frontend/type\_for/wishlist | A field-node was added |
-| system/full\_page\_cache/varnish/export\_button\_version7 | A field-node was added |
-| twofactorauth/duo/client\_id | A field-node was added |
-| twofactorauth/duo/client\_secret | A field-node was added |
-| twofactorauth/general/auth\_lock\_expire | A field-node was added |
-| twofactorauth/general/twofactorauth\_retry | A field-node was added |
-| twofactorauth/google/leeway | A field-node was added |
-| twofactorauth/google/otp\_window | A field-node was removed |
+##### [public] Method has been removed
 
-#### Xsd changes {#open-source-BICs-247-248-stable-xsd}
+- Magento\Reports\Block\Adminhtml\Grid\Column\Renderer\Currency::__construct
 
-| What changed | How it changed |
-| --- | --- |
-| magento/module-data-exporter/etc/et\_schema.xsd | A schema declaration was added |
-| magento/module-data-exporter/etc/et\_schema.xsd | A schema declaration was removed |
-| magento/module-elasticsearch/etc/esconfig.xsd | A schema declaration was added |
-| magento/module-elasticsearch/etc/esconfig.xsd | A schema declaration was removed |
+##### [public] Method parameter typing changed
 
-#### Class API membership changes {#open-source-BICs-247-248-stable-class-api-membership}
+- Magento\AdminNotification\Model\Feed::__construct
+- Magento\AdminNotification\Model\ResourceModel\System\Message\Collection::__construct
+- Magento\AdvancedSearch\Model\ResourceModel\Index::__construct
+- Magento\AdvancedSearch\Model\ResourceModel\Search\Grid\Collection::__construct
+- Magento\Backend\App\Area\FrontNameResolver::__construct
+- Magento\Backend\Block\Context::__construct
+- Magento\Backend\Block\Media\Uploader::__construct
+- Magento\Backend\Block\Menu::__construct
+- Magento\Backend\Block\System\Store\Edit::__construct
+- Magento\Backend\Block\Template\Context::__construct
+- Magento\Backend\Block\Widget\Context::__construct
+- Magento\Backend\Block\Widget\Form::__construct
+- Magento\Backend\Block\Widget\Grid\Massaction::__construct
+- Magento\Backend\Controller\Adminhtml\Auth\Login::__construct
+- Magento\Backend\Helper\Dashboard\Order::__construct
+- Magento\Backend\Model\Auth::throwException
+- Magento\Backend\Model\Auth\Session::__construct
+- Magento\Backend\Model\Menu::__construct
+- Magento\Backend\Model\Url::__construct
+- Magento\Backup\Model\Config\Backend\Cron::__construct
+- Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer::__construct
+- Magento\Bundle\Block\Adminhtml\Sales\Order\View\Items\Renderer::__construct
+- Magento\Bundle\Block\Sales\Order\Items\Renderer::__construct
+- Magento\Bundle\Helper\Catalog\Product\Configuration::__construct
+- Magento\Bundle\Model\Option::setProductLinks
+- Magento\Bundle\Model\Product\Price::__construct
+- Magento\Bundle\Model\Product\Type::__construct
+- Magento\Bundle\Model\ResourceModel\Selection::__construct
+- Magento\Bundle\Model\ResourceModel\Selection\Collection::__construct
+- Magento\Bundle\Model\Selection::__construct
+- Magento\Bundle\Pricing\Price\ConfiguredPrice::__construct
+- Magento\Captcha\Model\DefaultModel::__construct
+- Magento\CatalogImportExport\Model\Import\Product::__construct
+- Magento\CatalogImportExport\Model\Import\Product\Option::__construct
+- Magento\CatalogImportExport\Model\Import\Product\Type\AbstractType::__construct
+- Magento\CatalogImportExport\Model\Import\Uploader::__construct
+- Magento\CatalogInventory\Model\Adminhtml\Stock\Item::__construct
+- Magento\CatalogInventory\Model\ResourceModel\Indexer\Stock\DefaultStock::__construct
+- Magento\CatalogInventory\Model\Source\Stock::__construct
+- Magento\CatalogRule\Model\Indexer\IndexBuilder::__construct
+- Magento\CatalogRule\Model\ResourceModel\Rule\Collection::__construct
+- Magento\CatalogSearch\Model\Adminhtml\System\Config\Backend\Engine::__construct
+- Magento\CatalogSearch\Model\Advanced::__construct
+- Magento\CatalogSearch\Model\Indexer\Fulltext::__construct
+- Magento\CatalogSearch\Model\Indexer\Fulltext::executeByDimensions
+- Magento\CatalogSearch\Model\Indexer\Fulltext\Action\DataProvider::__construct
+- Magento\CatalogSearch\Model\Indexer\Fulltext\Action\Full::__construct
+- Magento\CatalogSearch\Model\Indexer\IndexStructure::__construct
+- Magento\CatalogSearch\Model\ResourceModel\Advanced\Collection::__construct
+- Magento\CatalogSearch\Model\ResourceModel\Fulltext::__construct
+- Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection::__construct
+- Magento\CatalogSearch\Model\ResourceModel\Search\Collection::__construct
+- Magento\CatalogSearch\Model\Search\RequestGenerator::__construct
+- Magento\CatalogWidget\Model\Rule::__construct
+- Magento\Catalog\Block\Adminhtml\Product\Composite\Configure::setProduct
+- Magento\Catalog\Block\Adminhtml\Product\Edit\Action\Attribute\Tab\Attributes::__construct
+- Magento\Catalog\Block\Category\View::__construct
+- Magento\Catalog\Block\Product\ImageFactory::create
+- Magento\Catalog\Block\Product\ProductList\Toolbar::__construct
+- Magento\Catalog\Block\Product\View\Gallery::__construct
+- Magento\Catalog\Block\Product\View\Options::setProduct
+- Magento\Catalog\Block\Product\View\Options\AbstractOptions::__construct
+- Magento\Catalog\Block\Product\View\Options\AbstractOptions::setProduct
+- Magento\Catalog\Block\Product\View\Options\Type\Select::__construct
+- Magento\Catalog\Controller\Adminhtml\Product\Initialization\Helper::__construct
+- Magento\Catalog\Helper\Image::__construct
+- Magento\Catalog\Helper\Product\ProductList::__construct
+- Magento\Catalog\Model\AbstractModel::__construct
+- Magento\Catalog\Model\Category::__construct
+- Magento\Catalog\Model\Category::setChildrenData
+- Magento\Catalog\Model\Category\Attribute\Backend\Image::__construct
+- Magento\Catalog\Model\Category\DataProvider::__construct
+- Magento\Catalog\Model\Config::__construct
+- Magento\Catalog\Model\Design::__construct
+- Magento\Catalog\Model\Indexer\Category\Product\AbstractAction::__construct
+- Magento\Catalog\Model\Product::__construct
+- Magento\Catalog\Model\Product::setMediaGalleryEntries
+- Magento\Catalog\Model\Product::setOptions
+- Magento\Catalog\Model\Product::setProductLinks
+- Magento\Catalog\Model\Product::setTierPrices
+- Magento\Catalog\Model\Product\Action::__construct
+- Magento\Catalog\Model\Product\Attribute\Backend\Price::__construct
+- Magento\Catalog\Model\Product\Compare\Item::__construct
+- Magento\Catalog\Model\Product\Compare\Item::bindCustomerLogout
+- Magento\Catalog\Model\Product\Compare\ListCompare::__construct
+- Magento\Catalog\Model\Product\Gallery\CreateHandler::__construct
+- Magento\Catalog\Model\Product\Gallery\Processor::__construct
+- Magento\Catalog\Model\Product\Gallery\UpdateHandler::__construct
+- Magento\Catalog\Model\Product\Link::__construct
+- Magento\Catalog\Model\Product\Option::__construct
+- Magento\Catalog\Model\Product\Option::setProduct
+- Magento\Catalog\Model\Product\Option::setValues
+- Magento\Catalog\Model\Product\Option\Value::__construct
+- Magento\Catalog\Model\Product\Type\AbstractType::__construct
+- Magento\Catalog\Model\Product\Type\Price::__construct
+- Magento\Catalog\Model\Product\Type\Price::setTierPrices
+- Magento\Catalog\Model\Product\Url::__construct
+- Magento\Catalog\Model\ResourceModel\AbstractResource::__construct
+- Magento\Catalog\Model\ResourceModel\Category\Collection::__construct
+- Magento\Catalog\Model\ResourceModel\Collection\AbstractCollection::__construct
+- Magento\Catalog\Model\ResourceModel\Eav\Attribute::__construct
+- Magento\Catalog\Model\ResourceModel\Layer\Filter\Price::__construct
+- Magento\Catalog\Model\ResourceModel\Product::__construct
+- Magento\Catalog\Model\ResourceModel\Product\Attribute\Collection::__construct
+- Magento\Catalog\Model\ResourceModel\Product\Collection::__construct
+- Magento\Catalog\Model\ResourceModel\Product\Compare\Item\Collection::__construct
+- Magento\Catalog\Model\ResourceModel\Product\Gallery::loadDataFromTableByValueId
+- Magento\Catalog\Model\ResourceModel\Product\Indexer\Price\DefaultPrice::__construct
+- Magento\Catalog\Model\ResourceModel\Product\Link\Product\Collection::__construct
+- Magento\Catalog\Model\ResourceModel\Product\Option\Collection::__construct
+- Magento\Catalog\Model\System\Config\Backend\Catalog\Url\Rewrite\Suffix::__construct
+- Magento\Catalog\Pricing\Price\TierPrice::__construct
+- Magento\Catalog\Ui\Component\ColumnFactory::__construct
+- Magento\Catalog\Ui\Component\Listing\Columns\Websites::__construct
+- Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AdvancedPricing::__construct
+- Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Categories::__construct
+- Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Eav::__construct
+- Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\General::__construct
+- Magento\Catalog\Ui\DataProvider\Product\ProductCustomOptionsDataProvider::__construct
+- Magento\Catalog\Ui\DataProvider\Product\ProductDataProvider::__construct
+- Magento\Checkout\Block\Cart\Item\Renderer::__construct
+- Magento\Checkout\Block\Cart\Shipping::__construct
+- Magento\Checkout\Block\Cart\Sidebar::__construct
+- Magento\Checkout\Block\Onepage::__construct
+- Magento\Checkout\Model\Cart\ImageProvider::__construct
+- Magento\Checkout\Model\Session::__construct
+- Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Tree::__construct
+- Magento\Cms\Model\Page::__construct
+- Magento\Cms\Model\Wysiwyg\Config::__construct
+- Magento\Cms\Model\Wysiwyg\Images\Storage::__construct
+- Magento\Config\App\Config\Type\System::__construct
+- Magento\Config\Block\System\Config\Edit::__construct
+- Magento\Config\Block\System\Config\Form::__construct
+- Magento\Config\Console\Command\ConfigSetCommand::__construct
+- Magento\Config\Console\Command\ConfigSet\DefaultProcessor::__construct
+- Magento\Config\Model\Config::__construct
+- Magento\Config\Model\Config\Backend\Admin\Custom::__construct
+- Magento\Config\Model\Config\Backend\Admin\Usecustom::__construct
+- Magento\Config\Model\Config\Backend\Admin\Usesecretkey::__construct
+- Magento\Config\Model\Config\Backend\Baseurl::__construct
+- Magento\Config\Model\Config\Backend\Currency\Allow::__construct
+- Magento\Config\Model\Config\Backend\Currency\Base::__construct
+- Magento\Config\Model\Config\Backend\Currency\Cron::__construct
+- Magento\Config\Model\Config\Backend\Encrypted::__construct
+- Magento\Config\Model\Config\Backend\File::__construct
+- Magento\Config\Model\Config\Backend\Image\Adapter::__construct
+- Magento\Config\Model\Config\Backend\Locale::__construct
+- Magento\Config\Model\Config\Backend\Log\Cron::__construct
+- Magento\Config\Model\Config\Backend\Secure::__construct
+- Magento\Config\Model\Config\Backend\Serialized::__construct
+- Magento\Config\Model\Config\Backend\Store::__construct
+- Magento\Config\Model\Config\Export\Comment::__construct
+- Magento\Config\Model\Config\Loader::__construct
+- Magento\Config\Model\Config\Source\Locale\Currency::__construct
+- Magento\Config\Model\Config\Structure\Data::__construct
+- Magento\Config\Model\Config\TypePool::__construct
+- Magento\ConfigurableProduct\Block\Adminhtml\Product\Composite\Fieldset\Configurable::__construct
+- Magento\ConfigurableProduct\Block\Adminhtml\Product\Steps\Bulk::__construct
+- Magento\ConfigurableProduct\Block\Product\View\Type\Configurable::__construct
+- Magento\ConfigurableProduct\Helper\Data::__construct
+- Magento\ConfigurableProduct\Model\Product\Type\Configurable::__construct
+- Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable\Attribute\Collection::__construct
+- Magento\Cron\Model\Schedule::__construct
+- Magento\CurrencySymbol\Model\System\Currencysymbol::__construct
+- Magento\Customer\Block\Account\AuthenticationPopup::__construct
+- Magento\Customer\Block\Address\Book::__construct
+- Magento\Customer\Block\Address\Book::getAddressHtml
+- Magento\Customer\Block\Address\Edit::__construct
+- Magento\Customer\Block\Adminhtml\Edit\Tab\Newsletter\Grid::__construct
+- Magento\Customer\Block\CustomerScopeData::__construct
+- Magento\Customer\Block\Form\Register::__construct
+- Magento\Customer\CustomerData\SectionPool::getSectionsData
+- Magento\Customer\Model\Address::__construct
+- Magento\Customer\Model\Address\AbstractAddress::__construct
+- Magento\Customer\Model\Customer::__construct
+- Magento\Customer\Model\Customer\DataProvider::__construct
+- Magento\Customer\Model\Data\Address::setRegion
+- Magento\Customer\Model\Group::__construct
+- Magento\Customer\Model\ResourceModel\Customer::__construct
+- Magento\Customer\Model\Session::__construct
+- Magento\Customer\Model\Url::__construct
+- Magento\Deploy\Package\Package::aggregate
+- Magento\Directory\Model\Country::__construct
+- Magento\Directory\Model\Currency::__construct
+- Magento\Directory\Model\ResourceModel\Country::__construct
+- Magento\Directory\Model\ResourceModel\Country\Collection::__construct
+- Magento\Directory\Model\ResourceModel\Region\Collection::__construct
+- Magento\Downloadable\Model\Link::__construct
+- Magento\Downloadable\Model\Link::setLinkFileContent
+- Magento\Downloadable\Model\Link::setSampleFileContent
+- Magento\Downloadable\Model\Product\Type::__construct
+- Magento\Downloadable\Model\ResourceModel\Sample\Collection::__construct
+- Magento\Downloadable\Model\Sales\Order\Pdf\Items\Creditmemo::__construct
+- Magento\Downloadable\Model\Sales\Order\Pdf\Items\Invoice::__construct
+- Magento\Downloadable\Model\Sample::__construct
+- Magento\Downloadable\Model\Sample::setSampleFileContent
+- Magento\Eav\Model\Config::__construct
+- Magento\Eav\Model\Entity\AbstractEntity::__construct
+- Magento\Eav\Model\Entity\Attribute::__construct
+- Magento\Eav\Model\Entity\Attribute\AbstractAttribute::__construct
+- Magento\Eav\Model\Entity\Attribute\AbstractAttribute::setFrontendLabels
+- Magento\Eav\Model\Entity\Attribute\AbstractAttribute::setOptions
+- Magento\Eav\Model\Entity\Attribute\AbstractAttribute::setValidationRules
+- Magento\Eav\Model\Entity\Attribute\Config::__construct
+- Magento\Eav\Model\Entity\Attribute\Frontend\AbstractFrontend::__construct
+- Magento\Eav\Model\Entity\Attribute\Group::__construct
+- Magento\Eav\Model\Entity\Attribute\Option::setStoreLabels
+- Magento\Eav\Model\Entity\Attribute\Source\Table::__construct
+- Magento\Eav\Model\Entity\Collection\AbstractCollection::__construct
+- Magento\Eav\Model\Entity\Collection\VersionControl\AbstractCollection::__construct
+- Magento\Eav\Model\Entity\Type::__construct
+- Magento\Eav\Model\Form\Element::__construct
+- Magento\Eav\Model\Form\Fieldset::__construct
+- Magento\Eav\Model\ResourceModel\Attribute\Collection::__construct
+- Magento\Eav\Model\ResourceModel\Entity\Attribute::__construct
+- Magento\Eav\Model\ResourceModel\Entity\Attribute\Collection::__construct
+- Magento\Eav\Model\ResourceModel\Form\Attribute\Collection::__construct
+- Magento\Eav\Model\ResourceModel\Form\Fieldset\Collection::__construct
+- Magento\Eav\Setup\EavSetup::__construct
+- Magento\Elasticsearch\Model\ResourceModel\Index::__construct
+- Magento\Elasticsearch\SearchAdapter\Dynamic\DataProvider::__construct
+- Magento\Email\Model\AbstractTemplate::__construct
+- Magento\Email\Model\BackendTemplate::__construct
+- Magento\Email\Model\Template::__construct
+- Magento\Email\Model\Template\Filter::__construct
+- Magento\Framework\Amqp\Config::__construct
+- Magento\Framework\Api\Search\FilterGroup::setFilters
+- Magento\Framework\App\Bootstrap::create
+- Magento\Framework\App\Config\Value::__construct
+- Magento\Framework\App\Http\Context::__construct
+- Magento\Framework\App\Request\Http::__construct
+- Magento\Framework\App\Response\Http::__construct
+- Magento\Framework\Config\Data::__construct
+- Magento\Framework\Config\Data\Scoped::__construct
+- Magento\Framework\Controller\Result\Json::__construct
+- Magento\Framework\DB\Adapter\Pdo\Mysql::__construct
+- Magento\Framework\DB\Adapter\Pdo\MysqlFactory::create
+- Magento\Framework\Data\Collection\AbstractDb::__construct
+- Magento\Framework\Data\Collection\Filesystem::__construct
+- Magento\Framework\Data\Form::setElementRenderer
+- Magento\Framework\Data\Form::setFieldsetElementRenderer
+- Magento\Framework\Data\Form::setFieldsetRenderer
+- Magento\Framework\Exception\AbstractAggregateException::__construct
+- Magento\Framework\Exception\AlreadyExistsException::__construct
+- Magento\Framework\Exception\BulkException::__construct
+- Magento\Framework\Exception\InputException::__construct
+- Magento\Framework\Exception\InputException::invalidFieldValue
+- Magento\Framework\Exception\LocalizedException::__construct
+- Magento\Framework\Exception\NoSuchEntityException::__construct
+- Magento\Framework\Exception\SerializationException::__construct
+- Magento\Framework\Exception\TemporaryState\CouldNotSaveException::__construct
+- Magento\Framework\File\Uploader::__construct
+- Magento\Framework\Filter\Template::__construct
+- Magento\Framework\GraphQl\Exception\GraphQlAuthenticationException::__construct
+- Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException::__construct
+- Magento\Framework\GraphQl\Exception\GraphQlInputException::__construct
+- Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException::__construct
+- Magento\Framework\HTTP\PhpEnvironment\RemoteAddress::__construct
+- Magento\Framework\Mail\Template\TransportBuilder::__construct
+- Magento\Framework\Model\AbstractExtensibleModel::__construct
+- Magento\Framework\Model\AbstractModel::__construct
+- Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection::__construct
+- Magento\Framework\Module\Setup\Migration::__construct
+- Magento\Framework\Pricing\Price\Pool::__construct
+- Magento\Framework\Pricing\Render::renderAmount
+- Magento\Framework\Pricing\Render\RendererPool::createAmountRender
+- Magento\Framework\Pricing\Render\RendererPool::getAdjustmentRenders
+- Magento\Framework\Profiler::start
+- Magento\Framework\Profiler\Driver\Standard\Stat::getFilteredTimerIds
+- Magento\Framework\Search\Adapter\Mysql\TemporaryStorage::__construct
+- Magento\Framework\Setup\Declaration\Schema\Diff\Diff::register
+- Magento\Framework\Setup\Declaration\Schema\Dto\Table::__construct
+- Magento\Framework\Setup\Declaration\Schema\ElementHistory::__construct
+- Magento\Framework\Validation\ValidationException::__construct
+- Magento\Framework\Validator\AbstractValidator::setDefaultTranslator
+- Magento\Framework\Validator\Exception::__construct
+- Magento\Framework\View\Context::__construct
+- Magento\Framework\View\Element\Context::__construct
+- Magento\Framework\View\Element\Template\Context::__construct
+- Magento\Framework\View\Element\UiComponentFactory::__construct
+- Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult::setItems
+- Magento\Framework\View\Layout\Data\Structure::__construct
+- Magento\Framework\View\Layout\GeneratorPool::__construct
+- Magento\Framework\View\Page\Config::__construct
+- Magento\Framework\View\Result\Page::__construct
+- Magento\Framework\Webapi\ErrorProcessor::__construct
+- Magento\Framework\Webapi\ServiceInputProcessor::__construct
+- Magento\Framework\Webapi\ServiceOutputProcessor::__construct
+- Magento\FunctionalTestingFramework\ObjectManager::__construct
+- Magento\GiftMessage\Block\Cart\GiftOptions::__construct
+- Magento\GiftMessage\Block\Cart\Item\Renderer\Actions\GiftOptions::__construct
+- Magento\GiftMessage\Model\Message::__construct
+- Magento\GoogleAdwords\Model\Config\Backend\AbstractConversion::__construct
+- Magento\GoogleAnalytics\Block\Ga::__construct
+- Magento\GoogleOptimizer\Helper\Data::__construct
+- Magento\GoogleOptimizer\Helper\Form::addGoogleoptimizerFields
+- Magento\GraphQl\Controller\GraphQl::__construct
+- Magento\GroupedProduct\Model\Product\Type\Grouped::__construct
+- Magento\ImportExport\Model\Import::__construct
+- Magento\ImportExport\Model\Import\AbstractEntity::__construct
+- Magento\ImportExport\Model\Import\AbstractEntity::getBehavior
+- Magento\InstantPurchase\Model\InstantPurchaseOption::__construct
+- Magento\InstantPurchase\Model\InstantPurchaseOptionFactory::create
+- Magento\Integration\Model\Config::__construct
+- Magento\Integration\Model\Integration::__construct
+- Magento\Integration\Model\IntegrationConfig::__construct
+- Magento\Integration\Model\Oauth\Consumer::__construct
+- Magento\Integration\Model\Oauth\Token::__construct
+- Magento\InventoryAdminUi\Ui\DataProvider\SourceDataProvider::__construct
+- Magento\InventoryAdminUi\Ui\DataProvider\StockDataProvider::__construct
+- Magento\InventoryShippingAdminUi\Block\Adminhtml\Order\View\ShipButton::__construct
+- Magento\Inventory\Model\ResourceModel\Source\Collection::__construct
+- Magento\MediaStorage\Model\File\Storage::__construct
+- Magento\MediaStorage\Model\File\Storage\Database::__construct
+- Magento\MediaStorage\Model\File\Storage\Directory\Database::__construct
+- Magento\MediaStorage\Model\File\Uploader::__construct
+- Magento\MediaStorage\Model\ResourceModel\File\Storage\Database::__construct
+- Magento\MessageQueue\Model\ConsumerRunner::__construct
+- Magento\Multishipping\Model\Checkout\Type\Multishipping::__construct
+- Magento\Newsletter\Model\Problem::__construct
+- Magento\Newsletter\Model\Queue::__construct
+- Magento\Newsletter\Model\ResourceModel\Problem\Collection::__construct
+- Magento\Newsletter\Model\ResourceModel\Queue\Collection::__construct
+- Magento\Newsletter\Model\ResourceModel\Subscriber::__construct
+- Magento\Newsletter\Model\ResourceModel\Subscriber\Collection::__construct
+- Magento\Newsletter\Model\Subscriber::__construct
+- Magento\PageBuilder\Block\WysiwygSetup::__construct
+- Magento\PageBuilder\Component\Form\Element\Wysiwyg::__construct
+- Magento\PageBuilder\Controller\ContentType\Preview::__construct
+- Magento\PageBuilder\Model\Stage\Config::__construct
+- Magento\PageBuilder\Model\Stage\Renderer\CmsStaticBlock::__construct
+- Magento\PageBuilder\Model\Stage\Renderer\WidgetDirective::__construct
+- Magento\PageCache\Model\Config::__construct
+- Magento\PaymentServicesPaypal\Block\SmartButtons::__construct
+- Magento\PaymentServicesPaypal\Model\Api\PaymentOrderRequest::create
+- Magento\PaymentServicesPaypal\Model\Api\PaymentOrderRequest::createGuest
+- Magento\Payment\Gateway\Command\CommandManager::execute
+- Magento\Payment\Gateway\Command\CommandManager::executeByCode
+- Magento\Payment\Gateway\Command\GatewayCommand::__construct
+- Magento\Payment\Gateway\Http\Client\Soap::__construct
+- Magento\Payment\Gateway\Http\Client\Zend::__construct
+- Magento\Payment\Helper\Data::getInfoBlock
+- Magento\Payment\Model\Info::__construct
+- Magento\Payment\Model\MethodList::getAvailableMethods
+- Magento\Payment\Model\Method\AbstractMethod::__construct
+- Magento\Payment\Model\Method\AbstractMethod::isAvailable
+- Magento\Payment\Model\Method\Adapter::__construct
+- Magento\Payment\Model\Method\Adapter::isAvailable
+- Magento\Payment\Model\Method\Free::__construct
+- Magento\Payment\Model\Method\Free::isAvailable
+- Magento\Payment\Model\Method\Logger::__construct
+- Magento\Payment\Model\Method\Logger::debug
+- Magento\Paypal\Block\PayLater\Banner::__construct
+- Magento\Paypal\Model\Api\ProcessableException::__construct
+- Magento\Paypal\Model\Billing\AbstractAgreement::__construct
+- Magento\Paypal\Model\Billing\Agreement::__construct
+- Magento\Paypal\Model\ResourceModel\Billing\Agreement\Collection::__construct
+- Magento\Persistent\Model\Session::__construct
+- Magento\ProductAlert\Model\Email::__construct
+- Magento\ProductAlert\Model\Price::__construct
+- Magento\ProductAlert\Model\Stock::__construct
+- Magento\ProductVideo\Block\Product\View\Gallery::__construct
+- Magento\Quote\Model\Cart\Data\CartItem::__construct
+- Magento\Quote\Model\Quote::__construct
+- Magento\Quote\Model\Quote::assignCustomerWithAddressChange
+- Magento\Quote\Model\Quote::setBillingAddress
+- Magento\Quote\Model\Quote::setCurrency
+- Magento\Quote\Model\Quote::setCustomer
+- Magento\Quote\Model\Quote::setItems
+- Magento\Quote\Model\Quote::setShippingAddress
+- Magento\Quote\Model\QuoteValidator::__construct
+- Magento\Quote\Model\Quote\Address::__construct
+- Magento\Quote\Model\Quote\Address::requestShippingRates
+- Magento\Quote\Model\Quote\Address\Total::__construct
+- Magento\Quote\Model\Quote\Item::__construct
+- Magento\Quote\Model\Quote\Item\AbstractItem::__construct
+- Magento\Quote\Model\Quote\Payment::__construct
+- Magento\Quote\Model\ResourceModel\Quote\Item\Collection::__construct
+- Magento\Reports\Block\Adminhtml\Grid::__construct
+- Magento\Reports\Controller\Adminhtml\Report\AbstractReport::__construct
+- Magento\Reports\Model\Event::__construct
+- Magento\Reports\Model\Product\Index\AbstractIndex::__construct
+- Magento\Reports\Model\Product\Index\Compared::__construct
+- Magento\Reports\Model\ResourceModel\Customer\Collection::__construct
+- Magento\Reports\Model\ResourceModel\Event::getCurrentStoreIds
+- Magento\Reports\Model\ResourceModel\Order\Collection::__construct
+- Magento\Reports\Model\ResourceModel\Product\Collection::__construct
+- Magento\Reports\Model\ResourceModel\Product\Index\Collection\AbstractCollection::__construct
+- Magento\Reports\Model\ResourceModel\Product\Lowstock\Collection::__construct
+- Magento\Reports\Model\ResourceModel\Quote\Collection::__construct
+- Magento\Reports\Model\ResourceModel\Quote\Item\Collection::__construct
+- Magento\Reports\Model\ResourceModel\Review\Customer\Collection::__construct
+- Magento\Reports\Model\ResourceModel\Wishlist\Collection::__construct
+- Magento\Review\Block\Form::__construct
+- Magento\Review\Model\Rating::__construct
+- Magento\Review\Model\ResourceModel\Rating::__construct
+- Magento\Review\Model\ResourceModel\Rating\Collection::__construct
+- Magento\Review\Model\ResourceModel\Rating\Option\Vote\Collection::__construct
+- Magento\Review\Model\ResourceModel\Review\Collection::__construct
+- Magento\Review\Model\ResourceModel\Review\Product\Collection::__construct
+- Magento\Review\Model\Review::__construct
+- Magento\Robots\Block\Data::__construct
+- Magento\Robots\Model\Config\Value::__construct
+- Magento\Rss\Model\Rss::__construct
+- Magento\Rule\Model\AbstractModel::__construct
+- Magento\Rule\Model\Condition\Product\AbstractProduct::__construct
+- Magento\SalesRule\Model\ResourceModel\Rule\Collection::__construct
+- Magento\SalesRule\Model\ResourceModel\Rule\Collection::setValidationFilter
+- Magento\SalesRule\Model\Rule::__construct
+- Magento\Sales\Block\Adminhtml\Order\Create\Search\Grid::__construct
+- Magento\Sales\Block\Order\Info\Buttons\Rss::__construct
+- Magento\Sales\Block\Order\Items::__construct
+- Magento\Sales\Block\Order\Recent::__construct
+- Magento\Sales\Model\AbstractModel::__construct
+- Magento\Sales\Model\AdminOrder\Create::__construct
+- Magento\Sales\Model\Config\Ordered::__construct
+- Magento\Sales\Model\Order::__construct
+- Magento\Sales\Model\Order::setBillingAddress
+- Magento\Sales\Model\Order::setPayment
+- Magento\Sales\Model\Order::setShippingAddress
+- Magento\Sales\Model\Order::setStatusHistories
+- Magento\Sales\Model\Order\Address::__construct
+- Magento\Sales\Model\Order\Config::__construct
+- Magento\Sales\Model\Order\Creditmemo::__construct
+- Magento\Sales\Model\Order\CreditmemoDocumentFactory::createFromInvoice
+- Magento\Sales\Model\Order\CreditmemoDocumentFactory::createFromOrder
+- Magento\Sales\Model\Order\CreditmemoFactory::__construct
+- Magento\Sales\Model\Order\Creditmemo\Comment::__construct
+- Magento\Sales\Model\Order\Creditmemo\Item::__construct
+- Magento\Sales\Model\Order\Creditmemo\Notifier::notify
+- Magento\Sales\Model\Order\Email\Sender\InvoiceSender::__construct
+- Magento\Sales\Model\Order\Invoice::__construct
+- Magento\Sales\Model\Order\InvoiceDocumentFactory::create
+- Magento\Sales\Model\Order\Invoice\Item::__construct
+- Magento\Sales\Model\Order\Invoice\Notifier::notify
+- Magento\Sales\Model\Order\Item::__construct
+- Magento\Sales\Model\Order\Item::setProductOptions
+- Magento\Sales\Model\Order\Payment::__construct
+- Magento\Sales\Model\Order\Payment\Info::__construct
+- Magento\Sales\Model\Order\Payment\Transaction::__construct
+- Magento\Sales\Model\Order\Pdf\AbstractPdf::__construct
+- Magento\Sales\Model\Order\Pdf\Items\AbstractItems::__construct
+- Magento\Sales\Model\Order\Shipment::__construct
+- Magento\Sales\Model\Order\Shipment::setPackages
+- Magento\Sales\Model\Order\ShipmentDocumentFactory::__construct
+- Magento\Sales\Model\Order\ShipmentDocumentFactory::create
+- Magento\Sales\Model\Order\ShipmentFactory::__construct
+- Magento\Sales\Model\Order\Shipment\Item::__construct
+- Magento\Sales\Model\Order\Shipment\Notifier::notify
+- Magento\Sales\Model\Order\Shipment\Track::__construct
+- Magento\Sales\Model\Order\Status\History::__construct
+- Magento\Sales\Model\ResourceModel\Collection\AbstractCollection::setItems
+- Magento\Sales\Model\ResourceModel\Collection\AbstractCollection::setSearchCriteria
+- Magento\Sales\Model\ResourceModel\Order\Collection::__construct
+- Magento\Search\Model\Query::__construct
+- Magento\Search\Model\QueryFactory::__construct
+- Magento\Search\Model\ResourceModel\Query\Collection::__construct
+- Magento\Search\Model\SearchEngine\Config\Data::__construct
+- Magento\Search\Model\SynonymReader::__construct
+- Magento\Search\Model\Synonym\MergeConflictException::__construct
+- Magento\Security\Model\AdminSessionInfo::__construct
+- Magento\Security\Model\ResourceModel\AdminSessionInfo\Collection::__construct
+- Magento\Security\Model\ResourceModel\PasswordResetRequestEvent\Collection::__construct
+- Magento\SendFriend\Model\SendFriend::__construct
+- Magento\Setup\Module\SetupFactory::create
+- Magento\Shipping\Model\Carrier\AbstractCarrier::getContainerTypes
+- Magento\Shipping\Model\Carrier\AbstractCarrier::getDeliveryConfirmationTypes
+- Magento\Sitemap\Model\ResourceModel\Catalog\Product::__construct
+- Magento\Sitemap\Model\ResourceModel\Cms\Page::__construct
+- Magento\Sitemap\Model\Sitemap::__construct
+- Magento\Store\Block\Switcher::__construct
+- Magento\Store\Model\Group::__construct
+- Magento\Store\Model\Store::__construct
+- Magento\Store\Model\StoreIsInactiveException::__construct
+- Magento\Store\Model\Website::__construct
+- Magento\Swatches\Block\Product\Renderer\Configurable::__construct
+- Magento\Swatches\Block\Product\Renderer\Listing\Configurable::__construct
+- Magento\Swatches\Helper\Media::__construct
+- Magento\Tax\Helper\Data::__construct
+- Magento\Theme\Block\Adminhtml\Wysiwyg\Files\Tree::__construct
+- Magento\Theme\Block\Html\Breadcrumbs::__construct
+- Magento\Theme\Block\Html\Header::__construct
+- Magento\Theme\Helper\Storage::__construct
+- Magento\Ui\Component\Filters\Type\Select::__construct
+- Magento\Ui\Component\Listing\Columns\Date::__construct
+- Magento\UrlRewrite\Model\Exception\UrlAlreadyExistsException::__construct
+- Magento\UrlRewrite\Model\ResourceModel\UrlRewriteCollection::__construct
+- Magento\UrlRewrite\Model\UrlRewrite::__construct
+- Magento\UrlRewrite\Service\V1\Data\UrlRewrite::__construct
+- Magento\User\Model\ResourceModel\User::__construct
+- Magento\User\Model\User::__construct
+- Magento\Variable\Model\Variable::__construct
+- Magento\Variable\Model\Variable\Config::__construct
+- Magento\Vault\Model\Method\Vault::__construct
+- Magento\Vault\Model\Method\Vault::isAvailable
+- Magento\Webapi\Model\Config::__construct
+- Magento\Weee\Helper\Data::__construct
+- Magento\Weee\Model\Tax::__construct
+- Magento\Widget\Model\Widget\Instance::__construct
+- Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Image::__construct
+- Magento\Wishlist\Block\Share\Email\Items::__construct
+- Magento\Wishlist\Helper\Data::__construct
+- Magento\Wishlist\Model\Item::__construct
+- Magento\Wishlist\Model\Item\Option::__construct
+- Magento\Wishlist\Model\ResourceModel\Item\Collection::__construct
+- Magento\Wishlist\Model\Wishlist::__construct
+- Magento\Wishlist\Model\Wishlist\Data\WishlistItem::__construct
 
-| What changed | How it changed |
-| --- | --- |
-| Magento\CatalogInventory\Model\Stock\Item | Class was added. |
-| Magento\Customer\Model\ResourceModel\Customer\Collection | Class was added. |
-| Magento\Downloadable\Model\Sales\Order\Pdf\Items\AbstractItems | Class was added. |
-| Magento\Framework\Api\SearchCriteria | Class was added. |
-| Magento\Framework\Data\Form\Element\Editor | Class was added. |
-| Magento\Framework\Data\Structure | Class was added. |
-| Magento\Framework\Flag | Class was added. |
-| Magento\Framework\Locale\Resolver | Class was added. |
-| Magento\Framework\Model\ResourceModel\Db\VersionControl\Collection | Class was added. |
-| Magento\Framework\Session\SessionManager | Class was added. |
-| Magento\Framework\Url | Class was added. |
-| Magento\MediaStorage\Model\File\Storage\Database\AbstractDatabase | Class was added. |
-| Magento\PageBuilder\Block\Adminhtml\Stage\Render | Class was removed. |
-| Magento\SalesRule\Model\Validator | Class was added. |
-| Magento\Sales\Model\Order\Total\Config\Base | Class was added. |
-| Magento\Sales\Model\ResourceModel\Report\Bestsellers\Collection | Class was added. |
-| Magento\Sales\Model\ResourceModel\Report\Collection\AbstractCollection | Class was added. |
-| Magento\Ui\DataProvider\ModifierPoolDataProvider | Class was added. |
-| Magento\Wishlist\Block\AbstractBlock | Class was added. |
+##### [public] Method return typing changed
+
+- Magento\Catalog\Model\AbstractModel::getAttributeDefaultValue
+- Magento\Framework\Data\Collection::getItemById
+
+#### Interface changes
+
+##### Interface was added
+
+- Magento\Framework\Setup\ConsoleLoggerInterface
+
+##### [public] Added optional parameter(s)
+
+- Magento\Framework\Mview\ViewInterface::unsubscribe
+
+##### [public] Method has been added
+
+- Magento\TwoFactorAuth\Api\DuoAuthenticateInterface::createAdminAccessTokenWithCredentialsAndPasscode
+- Magento\TwoFactorAuth\Api\DuoConfigureInterface::duoActivate
+- Magento\TwoFactorAuth\Api\DuoConfigureInterface::getDuoConfigurationData
+
+##### [public] Method parameter typing changed
+
+- Magento\AdobeImsApi\Api\FlushUserTokensInterface::execute
+- Magento\AdobeImsApi\Api\GetAccessTokenInterface::execute
+- Magento\AdobeImsApi\Api\UserAuthorizedInterface::execute
+- Magento\AdobeStockClientApi\Api\Client\FilesInterface::execute
+- Magento\AdobeStockImageApi\Api\SaveLicensedImageInterface::execute
+- Magento\Bundle\Api\Data\OptionInterface::setProductLinks
+- Magento\CatalogGraphQl\Model\Resolver\Categories\DataProvider\Category\CollectionProcessorInterface::process
+- Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product\CollectionProcessorInterface::process
+- Magento\Catalog\Api\Data\CategoryTreeInterface::setChildrenData
+- Magento\Catalog\Api\Data\ProductAttributeMediaGalleryEntryInterface::setTypes
+- Magento\Catalog\Api\Data\ProductCustomOptionInterface::setValues
+- Magento\Catalog\Api\Data\ProductInterface::setMediaGalleryEntries
+- Magento\Catalog\Api\Data\ProductInterface::setOptions
+- Magento\Catalog\Api\Data\ProductInterface::setProductLinks
+- Magento\Catalog\Api\Data\ProductInterface::setTierPrices
+- Magento\Catalog\Model\Product\CatalogPriceInterface::getCatalogPrice
+- Magento\Checkout\Api\GuestPaymentInformationManagementInterface::savePaymentInformation
+- Magento\Checkout\Api\GuestPaymentInformationManagementInterface::savePaymentInformationAndPlaceOrder
+- Magento\Checkout\Api\PaymentInformationManagementInterface::savePaymentInformation
+- Magento\Checkout\Api\PaymentInformationManagementInterface::savePaymentInformationAndPlaceOrder
+- Magento\ConfigurableProduct\Api\Data\OptionInterface::setValues
+- Magento\Customer\Api\AccountDelegationInterface::createRedirectForNew
+- Magento\Customer\Api\Data\AddressInterface::setRegion
+- Magento\Customer\Api\Data\AttributeMetadataInterface::setOptions
+- Magento\Customer\Api\Data\CustomerInterface::setAddresses
+- Magento\Customer\Api\Data\OptionInterface::setOptions
+- Magento\Customer\CustomerData\SectionPoolInterface::getSectionsData
+- Magento\Directory\Api\Data\CurrencyInformationInterface::setAvailableCurrencyCodes
+- Magento\Directory\Api\Data\CurrencyInformationInterface::setExchangeRates
+- Magento\Downloadable\Api\Data\LinkInterface::setLinkFileContent
+- Magento\Downloadable\Api\Data\LinkInterface::setSampleFileContent
+- Magento\Downloadable\Api\Data\SampleInterface::setSampleFileContent
+- Magento\Eav\Api\Data\AttributeInterface::setFrontendLabels
+- Magento\Eav\Api\Data\AttributeInterface::setOptions
+- Magento\Eav\Api\Data\AttributeInterface::setValidationRules
+- Magento\Eav\Api\Data\AttributeOptionInterface::setStoreLabels
+- Magento\Eav\Model\Entity\AttributeLoaderInterface::loadAllAttributes
+- Magento\Framework\Api\ImageProcessorInterface::save
+- Magento\Framework\Api\SearchCriteriaInterface::setFilterGroups
+- Magento\Framework\Api\SearchCriteriaInterface::setSortOrders
+- Magento\Framework\Api\Search\SearchResultInterface::setItems
+- Magento\Framework\App\ResourceConnection\ConnectionAdapterInterface::getConnection
+- Magento\Framework\Filesystem\Directory\WriteInterface::copyFile
+- Magento\Framework\Filesystem\Directory\WriteInterface::createSymlink
+- Magento\Framework\Filesystem\Directory\WriteInterface::renameFile
+- Magento\Framework\Filesystem\DriverInterface::copy
+- Magento\Framework\Filesystem\DriverInterface::rename
+- Magento\Framework\Filesystem\DriverInterface::symlink
+- Magento\Framework\GraphQl\Query\ResolverInterface::resolve
+- Magento\Framework\Oauth\NonceGeneratorInterface::generateNonce
+- Magento\Framework\Profiler\DriverInterface::start
+- Magento\Framework\Session\SessionManagerInterface::destroy
+- Magento\Framework\Setup\Declaration\Schema\Diff\DiffInterface::register
+- Magento\Framework\Stdlib\CookieManagerInterface::deleteCookie
+- Magento\Framework\Stdlib\CookieManagerInterface::setPublicCookie
+- Magento\Framework\Stdlib\CookieManagerInterface::setSensitiveCookie
+- Magento\Framework\Stdlib\Cookie\CookieScopeInterface::getCookieMetadata
+- Magento\Framework\Stdlib\Cookie\CookieScopeInterface::getPublicCookieMetadata
+- Magento\Framework\Stdlib\Cookie\CookieScopeInterface::getSensitiveCookieMetadata
+- Magento\Framework\View\Design\FileResolution\Fallback\ResolverInterface::resolve
+- Magento\InventoryApi\Api\SourceRepositoryInterface::getList
+- Magento\InventoryApi\Api\StockRepositoryInterface::getList
+- Magento\InventoryReservationsApi\Model\ReservationBuilderInterface::setMetadata
+- Magento\Inventory\Model\Source\Command\GetListInterface::execute
+- Magento\Inventory\Model\Stock\Command\GetListInterface::execute
+- Magento\PageBuilder\Model\Dom\Adapter\DocumentInterface::createElement
+- Magento\PageBuilder\Model\Dom\Adapter\DocumentInterface::saveHTML
+- Magento\PaymentServicesPaypal\Api\PaymentOrderRequestInterface::create
+- Magento\PaymentServicesPaypal\Api\PaymentOrderRequestInterface::createGuest
+- Magento\Payment\Gateway\Command\CommandManagerInterface::execute
+- Magento\Payment\Gateway\Command\CommandManagerInterface::executeByCode
+- Magento\Payment\Model\MethodInterface::isAvailable
+- Magento\Quote\Api\CartManagementInterface::placeOrder
+- Magento\Quote\Api\CartTotalManagementInterface::collectTotals
+- Magento\Quote\Api\Data\CartInterface::setBillingAddress
+- Magento\Quote\Api\Data\CartInterface::setCurrency
+- Magento\Quote\Api\Data\CartInterface::setCustomer
+- Magento\Quote\Api\Data\CartInterface::setItems
+- Magento\Quote\Api\Data\TotalsInterface::setItems
+- Magento\Quote\Api\GuestCartManagementInterface::placeOrder
+- Magento\Quote\Api\GuestCartTotalManagementInterface::collectTotals
+- Magento\SalesRule\Api\Data\ConditionInterface::setConditions
+- Magento\SalesRule\Api\Data\CouponSearchResultInterface::setItems
+- Magento\SalesRule\Api\Data\RuleInterface::setActionCondition
+- Magento\SalesRule\Api\Data\RuleInterface::setCondition
+- Magento\SalesRule\Api\Data\RuleInterface::setProductIds
+- Magento\SalesRule\Api\Data\RuleInterface::setStoreLabels
+- Magento\SalesRule\Api\Data\RuleSearchResultInterface::setItems
+- Magento\Sales\Api\Data\OrderInterface::setBillingAddress
+- Magento\Sales\Api\Data\OrderInterface::setPayment
+- Magento\Sales\Api\Data\OrderInterface::setStatusHistories
+- Magento\Sales\Api\Data\OrderSearchResultInterface::setItems
+- Magento\Sales\Api\Data\ShipmentInterface::setPackages
+- Magento\Sales\Api\InvoiceOrderInterface::execute
+- Magento\Sales\Api\RefundInvoiceInterface::execute
+- Magento\Sales\Api\RefundOrderInterface::execute
+- Magento\Sales\Api\ShipOrderInterface::execute
+- Magento\Sales\Model\Order\Creditmemo\ItemCreationValidatorInterface::validate
+- Magento\Sales\Model\Order\Creditmemo\NotifierInterface::notify
+- Magento\Sales\Model\Order\Creditmemo\SenderInterface::send
+- Magento\Sales\Model\Order\Invoice\NotifierInterface::notify
+- Magento\Sales\Model\Order\Invoice\SenderInterface::send
+- Magento\Sales\Model\Order\Shipment\NotifierInterface::notify
+- Magento\Sales\Model\Order\Shipment\SenderInterface::send
+- Magento\Sales\Model\Order\Validation\InvoiceOrderInterface::validate
+- Magento\Sales\Model\Order\Validation\RefundInvoiceInterface::validate
+- Magento\Sales\Model\Order\Validation\RefundOrderInterface::validate
+- Magento\Sales\Model\Order\Validation\ShipOrderInterface::validate
+- Magento\Shipping\Model\Carrier\AbstractCarrierInterface::getContainerTypes
+- Magento\Shipping\Model\Carrier\AbstractCarrierInterface::getDeliveryConfirmationTypes
+- Magento\Store\Api\StoreConfigManagerInterface::getStoreConfigs
+- Magento\Tax\Api\Data\AppliedTaxInterface::setRates
+- Magento\Tax\Api\Data\OrderTaxDetailsInterface::setAppliedTaxes
+- Magento\Tax\Api\Data\OrderTaxDetailsInterface::setItems
+- Magento\Tax\Api\Data\OrderTaxDetailsItemInterface::setAppliedTaxes
+- Magento\Tax\Api\Data\QuoteDetailsInterface::setBillingAddress
+- Magento\Tax\Api\Data\QuoteDetailsInterface::setCustomerTaxClassKey
+- Magento\Tax\Api\Data\QuoteDetailsInterface::setItems
+- Magento\Tax\Api\Data\QuoteDetailsInterface::setShippingAddress
+- Magento\Tax\Api\Data\QuoteDetailsItemInterface::setTaxClassKey
+- Magento\Tax\Api\Data\TaxDetailsInterface::setAppliedTaxes
+- Magento\Tax\Api\Data\TaxDetailsInterface::setItems
+- Magento\Tax\Api\Data\TaxDetailsItemInterface::setAppliedTaxes
+- Magento\Tax\Api\Data\TaxRateInterface::setTitles
+- Magento\Tax\Api\Data\TaxRuleInterface::setCustomerTaxClassIds
+- Magento\Tax\Api\Data\TaxRuleInterface::setProductTaxClassIds
+- Magento\Tax\Api\Data\TaxRuleInterface::setTaxRateIds
+
+##### [public] Method return typing changed
+
+- Magento\Framework\Mview\ViewInterface::unsubscribe
+
+#### Database changes
+
+##### Column was added
+
+- sales_creditmemo_comment/updated_at
+- sales_creditmemo_comment/user_id
+- sales_creditmemo_comment/user_type
+- sales_invoice_comment/updated_at
+- sales_invoice_comment/user_id
+- sales_invoice_comment/user_type
+- sales_shipment_comment/updated_at
+- sales_shipment_comment/user_id
+- sales_shipment_comment/user_type
+
+##### Table was added
+
+- sales_order_confirm_cancel
+- sales_order_status_change_history
+
+##### Unique key was added
+
+- eav_attribute_option_value/EAV_ATTRIBUTE_OPTION_VALUE_STORE_ID_OPTION_ID
+- sales_creditmemo_comment/SALES_CREDITMEMO_COMMENT_ENTITY_ID_USER_ID_USER_TYPE
+- sales_invoice_comment/SALES_INVOICE_COMMENT_ENTITY_ID_USER_ID_USER_TYPE
+- sales_shipment_comment/SALES_SHIPMENT_COMMENT_ENTITY_ID_USER_ID_USER_TYPE
+
+#### Di changes
+
+##### Virtual Type was removed
+
+- Magento\Elasticsearch7\Model\Adapter\FieldMapper\ProductFieldMapper
+- Magento\Elasticsearch7\Model\Client\ElasticsearchFactory
+- Magento\Elasticsearch7\Model\DataProvider\Suggestions
+- Magento\Elasticsearch7\Setup\InstallConfig
+- \Magento\Elasticsearch7\Model\Adapter\FieldMapper\Product\FieldProvider\FieldName\Resolver\CompositeResolver
+
+#### System changes
+
+##### A field-node was added
+
+- carriers/fedex/enabled_tracking_api
+- carriers/fedex/tracking_api_key
+- carriers/fedex/tracking_api_secret_key
+- catalog/rule/share_all_catalog_rules
+- catalog/rule/share_applied_catalog_rules
+- catalog/search/elasticsearch8_enable_auth
+- catalog/search/elasticsearch8_index_prefix
+- catalog/search/elasticsearch8_minimum_should_match
+- catalog/search/elasticsearch8_password
+- catalog/search/elasticsearch8_server_hostname
+- catalog/search/elasticsearch8_server_port
+- catalog/search/elasticsearch8_server_timeout
+- catalog/search/elasticsearch8_test_connect_wizard
+- catalog/search/elasticsearch8_username
+- catalog/seo/product_rewrite_context
+- catalog/seo/product_url_transliteration
+- cataloginventory/options/not_available_message
+- customer/account_information/graphql_share_all_customer_groups
+- customer/account_information/graphql_share_customer_group
+- payment/recommended_solutions/magento_payments_legacy/general_configuration/mba_scoping_level
+- payment/recommended_solutions/magento_payments_legacy/general_configuration/paypal_merchant_id
+- promo/graphql/share_all_sales_rule
+- promo/graphql/share_applied_sales_rule
+- recaptcha_frontend/type_for/resend_confirmation_email
+- recaptcha_frontend/type_for/wishlist
+- system/full_page_cache/varnish/export_button_version7
+- twofactorauth/duo/client_id
+- twofactorauth/duo/client_secret
+- twofactorauth/general/auth_lock_expire
+- twofactorauth/general/twofactorauth_retry
+- twofactorauth/google/leeway
+
+##### A field-node was removed
+
+- catalog/search/elasticsearch7_enable_auth
+- catalog/search/elasticsearch7_index_prefix
+- catalog/search/elasticsearch7_minimum_should_match
+- catalog/search/elasticsearch7_password
+- catalog/search/elasticsearch7_server_hostname
+- catalog/search/elasticsearch7_server_port
+- catalog/search/elasticsearch7_server_timeout
+- catalog/search/elasticsearch7_test_connect_wizard
+- catalog/search/elasticsearch7_username
+- twofactorauth/google/otp_window
+
+#### Xsd changes
+
+##### A schema declaration was added
+
+- var/jenkins/workspace/gendocs-core-BIC-reference/commerce/open-source-after/app/code/magento/module-data-exporter/etc/et_schema.xsd
+- var/jenkins/workspace/gendocs-core-BIC-reference/commerce/open-source-after/app/code/magento/module-elasticsearch/etc/esconfig.xsd
+
+##### A schema declaration was removed
+
+- var/jenkins/workspace/gendocs-core-BIC-reference/commerce/open-source-before/app/code/magento/module-data-exporter/etc/et_schema.xsd
+- var/jenkins/workspace/gendocs-core-BIC-reference/commerce/open-source-before/app/code/magento/module-elasticsearch/etc/esconfig.xsd
+
+#### Class API membership changes
+
+##### Class was added
+
+- Magento\CatalogInventory\Model\Stock\Item
+- Magento\Customer\Model\ResourceModel\Customer\Collection
+- Magento\Downloadable\Model\Sales\Order\Pdf\Items\AbstractItems
+- Magento\Framework\Api\SearchCriteria
+- Magento\Framework\Data\Form\Element\Editor
+- Magento\Framework\Data\Structure
+- Magento\Framework\Flag
+- Magento\Framework\Locale\Resolver
+- Magento\Framework\Model\ResourceModel\Db\VersionControl\Collection
+- Magento\Framework\Session\SessionManager
+- Magento\Framework\Url
+- Magento\MediaStorage\Model\File\Storage\Database\AbstractDatabase
+- Magento\SalesRule\Model\Validator
+- Magento\Sales\Model\Order\Total\Config\Base
+- Magento\Sales\Model\ResourceModel\Report\Bestsellers\Collection
+- Magento\Sales\Model\ResourceModel\Report\Collection\AbstractCollection
+- Magento\Ui\DataProvider\ModifierPoolDataProvider
+- Magento\Wishlist\Block\AbstractBlock
+
+##### Class was removed
+
+- Magento\PageBuilder\Block\Adminhtml\Stage\Render


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) converts tables to grouped lists because the long Class/Interface names in tables are hidden in cells and require scrolling. The very long names still overlap with the page's table of contents, but this is something to consider for future less critical improvements.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/php/development/backward-incompatible-changes/reference/
