### PR TITLE
AC-14314:: [AdobeDocs Approval] Dev doc update after upgrading eslint to 9

### DIFF
--- a/src/pages/coding-standards/js.md
+++ b/src/pages/coding-standards/js.md
@@ -361,4 +361,36 @@ var foo = 'bar',
 
 There is a set of custom Eslint rules to ensure code compatibility with the latest versions of third-party libraries.
 
-These custom rules are included using the `rulePaths` setting in the [Eslint Grunt configuration](https://github.com/magento/magento2/blob/2.4/dev/tools/grunt/configs/eslint.json).
+In previous version of eslint these custom rules were included using the `rulePaths` setting in the [Eslint Grunt configuration](https://github.com/magento/magento2/blob/2.4/dev/tools/grunt/configs/eslint.json).
+
+However, since ESLint 9 has deprecated `rulePaths`, the configuration has been updated accordingly.
+
+This document outlines the necessary changes to implement custom Eslint rules.
+
+```json
+{
+  "file": {
+    "options": {
+      "overrideConfigFile": "vendor/magento/magento-coding-standard/eslint/eslint.config.mjs",
+      "useEslintrc": false
+    }
+  },
+  "test": {
+    "options": {
+      "overrideConfigFile": "vendor/magento/magento-coding-standard/eslint/eslint.config.mjs",
+      "outputFile": "dev/tests/static/eslint-error-report.xml",
+      "format": "junit",
+      "quiet": true
+    }
+  }
+}
+```
+### Applying custom rules
+
+To add or modify custom rules, update `eslint.config.mjs` in the `magento-coding-standard` repository.
+With latest version, configuration has changed from eslint to flat config. We use this https://eslint.org/docs/latest/use/configure/migration-guide as a 
+reference to migrate the eslint.
+
+This reference doc provides the command and other information in detail. such as to convert old `.eslintrc` file with new config
+run below command
+`npx  @eslint/migrate-config .eslintrc`

--- a/src/pages/coding-standards/js.md
+++ b/src/pages/coding-standards/js.md
@@ -361,11 +361,11 @@ var foo = 'bar',
 
 There is a set of custom Eslint rules to ensure code compatibility with the latest versions of third-party libraries.
 
-In previous version of eslint these custom rules were included using the `rulePaths` setting in the [Eslint Grunt configuration](https://github.com/magento/magento2/blob/2.4/dev/tools/grunt/configs/eslint.json).
+In previous versions of ESLint, these custom rules were included using the `rulePaths` setting in the [ESLint Grunt configuration](https://github.com/magento/magento2/blob/2.4/dev/tools/grunt/configs/eslint.json).
 
-However, since ESLint 9 has deprecated `rulePaths`, the configuration has been updated accordingly.
+However, since ESLint 9 has deprecated `rulePaths`, you must update the configuration accordingly.
 
-This document outlines the necessary changes to implement custom Eslint rules.
+The following example shows the necessary changes to implement custom Eslint rules `dev/tools/grunt/configs/eslint.json` .
 
 ```json
 {
@@ -385,12 +385,10 @@ This document outlines the necessary changes to implement custom Eslint rules.
   }
 }
 ```
+
 ### Applying custom rules
 
 To add or modify custom rules, update `eslint.config.mjs` in the `magento-coding-standard` repository.
-With latest version, configuration has changed from eslint to flat config. We use this https://eslint.org/docs/latest/use/configure/migration-guide as a 
-reference to migrate the eslint.
+In the latest version of ESLint, the configuration has transitioned from using the legacy `.eslintrc` settings to the new flat configuration.
+Refer to the [migration guide](https://eslint.org/docs/latest/use/configure/migration-guide) in the ESlint documentation for detailed instructions on migrating to the new format.
 
-This reference doc provides the command and other information in detail. such as to convert old `.eslintrc` file with new config
-run below command
-`npx  @eslint/migrate-config .eslintrc`

--- a/src/pages/coding-standards/js.md
+++ b/src/pages/coding-standards/js.md
@@ -391,4 +391,3 @@ The following example shows the necessary changes to implement custom Eslint rul
 To add or modify custom rules, update the `eslint.config.mjs` file in the `magento-coding-standard` repository.
 In the latest version of ESLint, the configuration has transitioned from using the legacy `.eslintrc` settings to the new flat configuration.
 Refer to the [migration guide](https://eslint.org/docs/latest/use/configure/migration-guide) in the ESlint documentation for detailed instructions on migrating to the new format.
-

--- a/src/pages/coding-standards/js.md
+++ b/src/pages/coding-standards/js.md
@@ -365,7 +365,7 @@ In previous versions of ESLint, these custom rules were included using the `rule
 
 However, since ESLint 9 has deprecated `rulePaths`, you must update the configuration accordingly.
 
-The following example shows the necessary changes to implement custom Eslint rules `dev/tools/grunt/configs/eslint.json` .
+The following example shows the necessary changes to implement custom Eslint rules in the `dev/tools/grunt/configs/eslint.json` file.
 
 ```json
 {
@@ -388,7 +388,7 @@ The following example shows the necessary changes to implement custom Eslint rul
 
 ### Applying custom rules
 
-To add or modify custom rules, update `eslint.config.mjs` in the `magento-coding-standard` repository.
+To add or modify custom rules, update the `eslint.config.mjs` file in the `magento-coding-standard` repository.
 In the latest version of ESLint, the configuration has transitioned from using the legacy `.eslintrc` settings to the new flat configuration.
 Refer to the [migration guide](https://eslint.org/docs/latest/use/configure/migration-guide) in the ESlint documentation for detailed instructions on migrating to the new format.
 


### PR DESCRIPTION

## Purpose of this pull request

This pull request (PR) provides configuration instructions for Investigate latest major version of grunt-eslint

See [AC-13683](https://jira.corp.adobe.com/browse/AC-13683) for details.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-php/blob/main/.github/CONTRIBUTING.md) for more information.
-->
