### PR TITLE
Customer grid indexer mode (2.4.8)

### DIFF
--- a/src/pages/development/components/indexing/index.md
+++ b/src/pages/development/components/indexing/index.md
@@ -109,7 +109,7 @@ Reindexing can be performed in two modes:
 
    The `customer_grid` indexer behavior changed in 2.4.8.
 
-   * **Prior to 2.4.8**: The indexer can only be reindexed using the Update on Save mode and does not support the Update by Schedule mode.
+   * **Prior to 2.4.8**: The indexer can only be reindexed using the Update on Save mode and does not support the Update by Schedule mode. See the [knowledge base](https://experienceleague.adobe.com/en/docs/commerce-knowledge-base/kb/troubleshooting/miscellaneous/new-customers-not-displayed-in-customer-grid-after-csv-import#affected-versions) for troubleshooting the customer grid after a CSV import.
 
    * **2.4.8 and later**: The indexer supports both Update on Save and Update by Schedule modes, and defaults to Update by Schedule.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) clarifies the default mode for the Customer Grid indexer, which changed in 2.4.8.

See https://github.com/magento/magento2/issues/40043 for details.

>[!NOTE]
>~Related to additional PRs in private repos. Will post relevant commits here after merging and syncing public mirrors.~

Related to:

- [76483e3](https://github.com/AdobeDocs/commerce-operations.en/commit/76483e33f2259df65df6c1d6f5a0baf372c16965)
- [5294e7e](https://github.com/AdobeDocs/commerce-admin.en/commit/5294e7e31941d13d2cbeae89851bfe3a800acc6e)

## Affected pages

https://developer.adobe.com/commerce/php/development/components/indexing/#indexing-modes

whatsnew
Clarified the default mode for the [Customer Grid indexer](https://developer.adobe.com/commerce/php/development/components/indexing), which changed in 2.4.8.