### PR TITLE
Fix invalid class used for output escaping view-models.md

### DIFF
--- a/src/pages/development/components/view-models.md
+++ b/src/pages/development/components/view-models.md
@@ -64,12 +64,11 @@ You can access the public methods for the view model class in the template:
 ```html
 <?php
 
-/** @var $viewModel \ExampleCorp\Catalog\ViewModel\MyNewViewModel */
-
+/** @var \ExampleCorp\Catalog\ViewModel\MyNewViewModel $viewModel */
 $viewModel = $block->getViewModel();
 
 ?>
-<h1><?= $block->escapeHtml($viewModel->getTitle()); ?></h1>
+<h1><?= $escaper->escapeHtml($viewModel->getTitle()); ?></h1>
 ```
 
 ## Examples
@@ -138,10 +137,10 @@ class PreparePostData implements ArgumentInterface
 The following is an example of the view model initialization in the `app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml` template.
 
 ```php
-/** @var $viewModel /Magento/Catalog/ViewModel/Product/Listing/PreparePostData */
+/** @var /Magento/Catalog/ViewModel/Product/Listing/PreparePostData $viewModel */
 $viewModel = $block->getViewModel();
 $postArray = $viewModel->getPostData(
-    $block->escapeUrl($block->getAddToCartUrl($_item)),
+    $escaper->escapeUrl($block->getAddToCartUrl($_item)),
     ['product' => $_item->getEntityId()]
 );
 ```


### PR DESCRIPTION
## Purpose of this pull request

1. `$block->escape...` methods should not be used for escaping
2. `@var` property should have `Type` and then `Variable Name`, not the other way around

## Affected pages

- https://developer.adobe.com/commerce/php/development/components/view-models/


## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-php/blob/main/.github/CONTRIBUTING.md) for more information.
-->
