### PR TITLE
Move content from Getting Started guide

### DIFF
--- a/src/data/navigation/sections/development.js
+++ b/src/data/navigation/sections/development.js
@@ -306,6 +306,10 @@ module.exports = [
               path: "/development/components/web-api/services/",
             },
             {
+              title: "Resource accessibility",
+              path: "/development/components/web-api/resource-accessibility/",
+            },
+            {
               title: "Set custom routes",
               path: "/development/components/web-api/custom-routes/",
             },

--- a/src/data/navigation/sections/development.js
+++ b/src/data/navigation/sections/development.js
@@ -318,6 +318,10 @@ module.exports = [
               path: "/development/components/web-api/request-processor-pool/",
             },
             {
+              title: "cURL service wrapper",
+              path: "/development/components/web-api/curl/",
+            },
+            {
               title: "Inventory Management API reference",
               path: "/development/components/web-api/inventory-management/",
             },

--- a/src/pages/development/components/web-api/curl.md
+++ b/src/pages/development/components/web-api/curl.md
@@ -1,0 +1,251 @@
+---
+title: cURL service wrapper | Commerce PHP Extensions
+description: Learn how to use the curl service wrapper to make calls.
+keywords:
+  - Extensions
+---
+
+# Using the cURL service wrapper
+
+Adobe Commerce and Magento Open Source provide a service-wrapper for using cURL instead of using the default PHP cURL. The class ``Magento\Framework\HTTP\Client\Curl`` may be used to work with HTTP protocol using cURL library.
+
+First, create an instance of `Magento\Framework\HTTP\Client\Curl`.
+
+```php
+/**
+* Constructor.
+*
+* @param Magento\Framework\HTTP\Client\Curl $curl
+*/
+public function __construct(
+   Magento\Framework\HTTP\Client\Curl $curl
+) {
+   $this->curl = $curl;
+}
+```
+
+## Make a GET request
+
+```php
+// get method
+$this->curl->get($url);
+
+// output of curl request
+$result = $this->curl->getBody();
+```
+
+where `$url` is the endpoint URL.
+
+## Make a POST request
+
+```php
+// post method
+$this->curl->post($url, $params);
+
+// output of curl requestt
+$result = $this->curl->getBody();
+```
+
+where  `$url` is the endpoint URL, `$params` is an array of data that is being sent via the POST request. Other parameters may be added in the URL directly.
+A `$params` example:
+
+```php
+$params = [
+  'user[email]' => $user->getEmail(),
+  'user[cellphone]' => $providerInfo['phone_number'],
+  'user[country_code]' => $providerInfo['country_code'],
+]
+```
+
+The cURL client can also add headers, basic authorization, additional cURL options, and cookies in the cURL request. The cURL client provides these methods before using `get` or `post` method.
+
+## Set a cURL header using the `addHeader` method
+
+The `addHeader` method accepts two parameters. The cURL header name and a cURL header value.
+
+```php
+$this->curl->addHeader("Content-Type", "application/json");
+$this->curl->addHeader("Content-Length", 200);
+```
+
+## Set a cURL header using the `setHeaders` method
+
+The `setHeaders` method accepts an array as a parameter.
+
+```php
+$headers = ["Content-Type" => "application/json", "Content-Length" => "200"];
+$this->curl->setHeaders($headers);
+```
+
+## Set basic authorization in cURL
+
+Set the basic authorization using the `setCredentials` method.
+
+```php
+$userName = "User_Name";
+$password = "User_Password";
+
+$this->curl->setCredentials($userName, $password);
+```
+
+It is equivalent to setting CURLOPT_HTTPHEADER value:
+
+```php
+"Authorization : " . "Basic " . base64_encode($userName . ":" . $password)
+```
+
+## Set cURL options usingthe `setOption` method
+
+The `setOption` method accepts two parameters. The cURL option name and the cURL option value.
+
+```php
+$this->curl->setOption(CURLOPT_RETURNTRANSFER, true);
+$this->curl->setOption(CURLOPT_PORT, 8080);
+```
+
+## Set cURL options using the `setOptions` method
+
+The `setOptions` method accepts an array as a parameter.
+
+```php
+$options = [CURLOPT_RETURNTRANSFER => true, CURLOPT_PORT => 8080];
+
+$this->curl->setOptions($options);
+```
+
+## Set cURL cookies using the `addCookie` method
+
+The `addCookie` method accepts an array as a parameter. The cookie name and the cookie value.
+
+```php
+$this->curl->addCookie("cookie-name", "cookie-value");
+```
+
+## Set cURL cookies using the `setCookies` method
+
+The ``setCookies`` method accepts an array as a parameter.
+
+```php
+$cookies = ["cookie-name-1" => "cookie-value-1", "cookie-name-2" => "cookie-value-2"];
+$this->curl->setCookies($cookies);
+```
+
+## Example usage
+
+For example, the `Magento\Marketplace\Model\Partners` class gets partners info using cURL from the API of Magento connect.
+
+```php
+namespace Magento\Marketplace\Model;
+
+use Magento\Framework\HTTP\Client\Curl;
+use Magento\Marketplace\Helper\Cache;
+use Magento\Backend\Model\UrlInterface;
+
+/**
+ * @api
+ * @since 100.0.2
+ */
+class Partners
+{
+    /**
+     * @var Curl
+     */
+    protected $curlClient;
+
+    /**
+     * @var string
+     */
+    protected $urlPrefix = 'https://';
+
+    /**
+     * @var string
+     */
+    protected $apiUrl = 'magento.com/magento-connect/platinumpartners/list';
+
+    /**
+     * @var \Magento\Marketplace\Helper\Cache
+     */
+    protected $cache;
+
+    /**
+     * @var UrlInterface
+     */
+    private $backendUrl;
+
+    /**
+     * @param Curl $curl
+     * @param Cache $cache
+     * @param UrlInterface $backendUrl
+     */
+    public function __construct(Curl $curl, Cache $cache, UrlInterface $backendUrl)
+    {
+        $this->curlClient = $curl;
+        $this->cache = $cache;
+        $this->backendUrl = $backendUrl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getApiUrl()
+    {
+        return $this->urlPrefix . $this->apiUrl;
+    }
+
+    /**
+     * Gets partners json
+     *
+     * @return array
+     */
+    public function getPartners()
+    {
+        $apiUrl = $this->getApiUrl();
+        try {
+            $this->getCurlClient()->post($apiUrl, []);
+            $this->getCurlClient()->setOptions(
+                [
+                    CURLOPT_REFERER => $this->getReferer()
+                ]
+            );
+            $response = json_decode($this->getCurlClient()->getBody(), true);
+            if ($response['partners']) {
+                $this->getCache()->savePartnersToCache($response['partners']);
+                return $response['partners'];
+            } else {
+                return $this->getCache()->loadPartnersFromCache();
+            }
+        } catch (\Exception $e) {
+            return $this->getCache()->loadPartnersFromCache();
+        }
+    }
+
+    /**
+     * @return Curl
+     */
+    public function getCurlClient()
+    {
+        return $this->curlClient;
+    }
+
+    /**
+     * @return cache
+     */
+    public function getCache()
+    {
+        return $this->cache;
+    }
+
+    /**
+     * @return string
+     */
+    public function getReferer()
+    {
+        return \Magento\Framework\App\Request\Http::getUrlNoScript($this->backendUrl->getBaseUrl())
+        . 'admin/marketplace/index/index';
+    }
+}
+```
+
+All cURL client instances are created in `__construct`.
+The `getPartners` method uses the cURL client to make a POST request, the `post` method takes the first parameter the URL to the API of `magento-connect`, while the second parameter is an empty array. Then, the option `CURLOPT_REFERER` is added by the `setOptions` method of the cURL client.
+As a result, the script calls the `getBody` method of the cURL client.

--- a/src/pages/development/components/web-api/resource-accessibility.md
+++ b/src/pages/development/components/web-api/resource-accessibility.md
@@ -1,0 +1,96 @@
+---
+title: Resource accessibility | Commerce PHP Extensions
+description: Describes how resources accessibility is configured.
+keywords:
+  - Extensions
+  - REST
+  - Security
+---
+
+# Resource accessibility
+
+The list of resources that you can access depends on your user type. All customers have the same permissions, and as a result the same resources accessible. The preceding statement is true for guest users as well.
+Each administrator or integration user can have a unique set of permissions which is configured in the Admin.
+Permissions required to access particular resource are configured in the `webapi.xml` file. This table lists the resources that each user type can access:
+
+User type | Accessible resources (defined in `webapi.xml`)
+--- | ---
+Administrator or Integration | Resources for which administrators or integrators are authorized. For example, if administrators are authorized for the `Magento_Customer::group` resource, they can make a `GET /V1/customerGroups/:id` call.
+Customer | Resources with `anonymous` or `self` permission
+Guest user | Resources with `anonymous` permission
+
+## Relationship between `acl.xml` and `webapi.xml`
+
+The `acl.xml` file defines the access control list (ACL) for a given module. It defines the available set of permissions to access resources.
+
+All `acl.xml` files across all modules are consolidated to build an ACL tree, which is used to select allowed Admin role resources or third-party integration access (**System** > **Extension** > **Integration** > **Add New Integration** > **Available APIs**).
+
+### Sample customer `acl.xml`
+
+For example, account management, customer configuration, and customer group resource permissions are defined in the Customer module's [`acl.xml`](https://github.com/magento/magento2/tree/2.4/app/code/Magento/Customer/etc/acl.xml).
+
+When a developer creates the Web API configuration file (`webapi.xml`), the permissions defined in acl.xml are referenced to create access rights for each API resource.
+
+### Sample (truncated) customer `webapi.xml`
+
+```xml
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
+    <!-- Customer Group -->
+    <route url="/V1/customerGroups/:id" method="GET">
+        <service class="Magento\Customer\Api\GroupRepositoryInterface" method="getById"/>
+        <resources>
+            <resource ref="Magento_Customer::group"/>
+        </resources>
+    </route>
+............
+.......
+.....
+    <!-- Customer Account -->
+    <route url="/V1/customers/:customerId" method="GET">
+        <service class="Magento\Customer\Api\CustomerRepositoryInterface" method="getById"/>
+        <resources>
+            <resource ref="Magento_Customer::customer"/>
+        </resources>
+    </route>
+    <route url="/V1/customers" method="POST">
+        <service class="Magento\Customer\Api\AccountManagementInterface" method="createAccount"/>
+        <resources>
+            <resource ref="anonymous"/>
+        </resources>
+    </route>
+    <route url="/V1/customers/:customerId" method="PUT">
+        <service class="Magento\Customer\Api\CustomerRepositoryInterface" method="save"/>
+        <resources>
+            <resource ref="Magento_Customer::manage"/>
+        </resources>
+    </route>
+    <route url="/V1/customers/me" method="PUT">
+        <service class="Magento\Customer\Api\CustomerRepositoryInterface" method="save"/>
+        <resources>
+            <resource ref="self"/>
+        </resources>
+        <data>
+            <parameter name="customer.id" force="true">%customer_id%</parameter>
+        </data>
+    </route>
+..........
+.....
+...
+```
+
+For example, in the preceding `webapi.xml` for the customerGroups resource, only a user with `Magento_Customer::group` authorization can `GET /V1/customerGroups/:id`. On the other hand, you can create a customer using `POST /V1/customers` anonymously (or by a guest).
+
+Authorization is granted to either an administrator (or an integration) defined in the Admin with the customer group selected as one of the resources in the ACL tree.
+
+<InlineAlert variant="info" slots="text"/>
+
+<div>
+
+A guest or anonymous is a special permission that doesn't need to be defined in `acl.xml` (and will not show up in the permissions tree in the Admin). It just indicates that the current resource in `webapi.xml` can be accessed without the need for authentication.
+
+<br></br>
+
+Similarly, self is a special access used if you already have an authenticated session with the system. Self access enables a user to access resources they own. For example, `GET /V1/customers/me` fetches the logged-in customer's details. This is typically useful for JavaScript-based widgets.
+
+</div>


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) moves sections of from the [Authentication](https://developer.adobe.com/commerce/webapi/get-started/authentication/) and [curl](https://developer.adobe.com/commerce/webapi/get-started/gs-curl/) topics in the Getting Started guide. This information is about constructing modules that contain REST calls and does not belong in the webapi repo.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-php/blob/main/.github/CONTRIBUTING.md) for more information.
-->
