### PR TITLE
Add web link checking validation

### DIFF
--- a/.github/workflows/validate-pr_job.yml
+++ b/.github/workflows/validate-pr_job.yml
@@ -33,10 +33,10 @@ jobs:
           node-version-file: '.nvmrc'
           cache-dependency-path: 'yarn.lock'
 
-      - name: Check links
+      - name: Run remark checks (see .remarkrc.yml for enabled plugins)
         run: yarn test
 
-  md-link-check:
+  web-link-check:
     runs-on: ubuntu-latest
     needs: remark-test
     steps:
@@ -51,10 +51,10 @@ jobs:
 
   build-test:
     runs-on: ubuntu-latest
-    needs: md-link-check
+    needs: web-link-check
     steps:
       - uses: actions/checkout@v4
-      - name: Use Setup Node and Install Dependencies Action
+      - name: Setup Node.js and install dependencies
         uses: commerce-docs/devsite-install-action@main
         with:
           node-version-file: '.nvmrc'


### PR DESCRIPTION
## Purpose of this pull request

This pull request updates the CI workflow in `.github/workflows/validate-pr_job.yml` to improve the validation process for pull requests. The most important changes are the addition of a dedicated markdown link check job and an update to job dependencies to ensure better sequencing.
**NOTE This update will apply to all Commerce DevSite projects because they all use this as a shared workflow job.**

**CI workflow improvements:**

* Added a new `md-link-check` job that uses [tcort/github-action-markdown-link-check@v1](https://github.com/marketplace/actions/markdown-link-check-action) to validate web links in modified markdown files. This job runs after `remark-test` and before the build and test steps.
* Updated the `build-test` job to depend on the completion of the new `md-link-check` job, ensuring that link validation occurs before building and testing.

