### PR TITLE
REST API constructor parameter validation

### DIFF
--- a/src/pages/development/components/web-api/services.md
+++ b/src/pages/development/components/web-api/services.md
@@ -89,6 +89,7 @@ Adobe Commerce 2.4.9 and all prior supported versions of Adobe Commerce have bee
 Supported parameter types:
 
 -  Simple types (string, int, float, boolean)
+-  Arrays of simple types
 -  `*\Api\Data\*Interface` classes
 
 Unsupported parameter types:
@@ -109,24 +110,17 @@ Developers that previously defined REST APIs must review service interfaces and 
 
 -  **Extension-specific APIs**: Review custom module API implementations.
 
-REST calls that implement unsupported parameter types cause the following behavior:
+### Troubleshooting
 
--  On version 2.4.7 and higher, invalid parameters are silently ignored. Requests succeed, but data might be missing.
--  On version 2.4.6 and lower, invalid parameters might trigger 400/500 errors.
+You might encounter the following error messages when you use an unsupported field name:
 
-These error messages might appear in logs or responses:
+-  On versions 2.4.7 and higher
 
--  Unsupported field names for version 2.4.7 and higher:
+   `{ "message": "\"{fieldName}\" is not supported. Correct the field name and try again." }`
 
-   ```json
-   { "message": "\"{fieldName}\" is not supported. Correct the field name and try again." }
-   ```
+-  On versions 2.4.6 and lower
 
--  Unsupported field names for 2.4.6 and lower:
-
-   ```json
-   { "message": "Property \"{fieldName}\" does not have accessor method \"{methodName}\" in class \"{className}\"." }
-   ```
+   `{ "message": "Property \"{fieldName}\" does not have accessor method \"{methodName}\" in class \"{className}\"." }`
 
 When these errors occur, constructor parameters using complex types are rejected.
 

--- a/src/pages/development/components/web-api/services.md
+++ b/src/pages/development/components/web-api/services.md
@@ -118,11 +118,15 @@ These error messages might appear in logs or responses:
 
 -  Unsupported field names for version 2.4.7 and higher:
 
-   ```{ "message": "\"{fieldName}\" is not supported. Correct the field name and try again." }```
+   ```json
+   { "message": "\"{fieldName}\" is not supported. Correct the field name and try again." }
+   ```
 
 -  Unsupported field names for 2.4.6 and lower:
 
-   ```{ "message": "Property \"{fieldName}\" does not have accessor method \"{methodName}\" in class \"{className}\"." }```
+   ```json
+   { "message": "Property \"{fieldName}\" does not have accessor method \"{methodName}\" in class \"{className}\"." }
+   ```
 
 When these errors occur, constructor parameters using complex types are rejected.
 

--- a/src/pages/development/components/web-api/services.md
+++ b/src/pages/development/components/web-api/services.md
@@ -84,7 +84,7 @@ If a service method argument is called `item`, there will be a problem during SO
 
 When a REST API call is made, the framework validates the constructor parameters of the class that implements the service interface. The framework checks that each parameter can be instantiated. If a parameter cannot be instantiated, the framework throws an exception.
 
-Adobe Commerce 2.4.9 and all prior supported versions of Adobe Commerce have been patched to validate constructors.
+Adobe Commerce 2.4.9 and all prior supported versions of Adobe Commerce have been patched to validate constructors. [Adobe Security Bulletin APSB25-88](https://helpx.adobe.com/security/products/magento/apsb25-88.html) describes the issue and provides additional information.
 
 Supported parameter types:
 

--- a/src/pages/development/components/web-api/services.md
+++ b/src/pages/development/components/web-api/services.md
@@ -84,7 +84,7 @@ If a service method argument is called `item`, there will be a problem during SO
 
 When a REST API call is made, the framework validates the constructor parameters of the class that implements the service interface. The framework checks that each parameter can be instantiated. If a parameter cannot be instantiated, the framework throws an exception.
 
-Adobe Commerce 2.4.9 and all prior supported versions of Adobe Commerce prior to 2.4.9 have been patched to validate constructors.
+Adobe Commerce 2.4.9 and all prior supported versions of Adobe Commerce have been patched to validate constructors.
 
 Supported parameter types:
 

--- a/src/pages/development/components/web-api/services.md
+++ b/src/pages/development/components/web-api/services.md
@@ -80,6 +80,52 @@ Following are some examples of various types and what they would look like in th
 
 If a service method argument is called `item`, there will be a problem during SOAP processing. All item nodes are removed during SOAP request processing. This is done to unwrap array items that are wrapped by the SOAP server into an `item` element.
 
+## REST API constructor parameter validation
+
+When a REST API call is made, the framework validates the constructor parameters of the class that implements the service interface. The framework checks that each parameter can be instantiated. If a parameter cannot be instantiated, the framework throws an exception.
+
+Adobe Commerce 2.4.9 and all prior supported versions of Adobe Commerce prior to 2.4.9 have been patched to validate constructors.
+
+Supported parameter types:
+
+-  Simple types (string, int, float, boolean)
+-  `*\Api\Data\*Interface` classes
+
+Unsupported parameter types:
+
+-  Models,
+-  Service classes
+-  Other complex types
+
+Unsupported parameters will not be instantiated from REST payloads.
+
+Developers that previously defined REST APIs must review service interfaces and implementations for unsupported constructor parameters. Look for these patterns:
+
+-  **Constructor Parameter Injection**: Look for nested objects in API payloads.
+
+-  **Complex Object Types**: Check for references to `Model` classes or services.
+
+-  **Custom Properties**: Identify any non-standard API parameters.
+
+-  **Extension-specific APIs**: Review custom module API implementations.
+
+REST calls that implement unsupported parameter types cause the following behavior:
+
+-  On version 2.4.7 and higher, invalid parameters are silently ignored. Requests succeed, but data might be missing.
+-  On version 2.4.6 and lower, invalid parameters might trigger 400/500 errors.
+
+These error messages might appear in logs or responses:
+
+-  Unsupported field names for version 2.4.7 and higher:
+
+   ```{ "message": "\"{fieldName}\" is not supported. Correct the field name and try again." }```
+
+-  Unsupported field names for 2.4.6 and lower:
+
+   ```{ "message": "Property \"{fieldName}\" does not have accessor method \"{methodName}\" in class \"{className}\"." }```
+
+When these errors occur, constructor parameters using complex types are rejected.
+
 ## webapi.xml configuration options
 
 To define web API components, set these attributes on these XML elements in the

--- a/src/pages/development/components/web-api/services.md
+++ b/src/pages/development/components/web-api/services.md
@@ -93,7 +93,7 @@ Supported parameter types:
 
 Unsupported parameter types:
 
--  Models,
+-  Models
 -  Service classes
 -  Other complex types
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds info about valid and invalid types of REST API constructor parameters.

[Security bulletin](https://helpx.adobe.com/security/products/magento/apsb25-88.html)
[KB topic](https://experienceleague.adobe.com/en/docs/experience-cloud-kcs/kbarticles/ka-27397)

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-php/blob/main/.github/CONTRIBUTING.md) for more information.
-->
