### PR TITLE
Remove arrays from supported param types

### DIFF
--- a/src/pages/development/components/web-api/services.md
+++ b/src/pages/development/components/web-api/services.md
@@ -89,7 +89,6 @@ Adobe Commerce 2.4.9 and all prior supported versions of Adobe Commerce have bee
 Supported parameter types:
 
 -  Simple types (string, int, float, boolean)
--  Arrays of simple types
 -  `*\Api\Data\*Interface` classes
 
 Unsupported parameter types:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) corrects a mistake made in #414 

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-php/blob/main/.github/CONTRIBUTING.md) for more information.
-->
