### PR TITLE
Update subresourcee integrity docs for 2.4.9 release

### DIFF
--- a/src/pages/development/security/subresource-integrity.md
+++ b/src/pages/development/security/subresource-integrity.md
@@ -50,7 +50,7 @@ Adobe Commerce and Magento Open Source 2.4.8 and later no longer use a cache to 
 Adobe Commerce and Magento Open Source 2.4.9 and later store SRI hashes in files scoped by area, theme, and locale, rather than a single file per area.
 
 Subresource Integrity hashes are stored in `sri-hashes.json` files scoped by area, theme, and locale under the `pub/static` directory.
-For example, SRI hashes for the `adminhtml/Magento/backend/en_US/requirejs/require.js` file will be located in the `pub/static/adminhtml/Magento/backend/en_US/sri-hashes.json` file.
+For example, SRI hashes for the `adminhtml/Magento/backend/en_US/requirejs/require.js` file are stored in the `pub/static/adminhtml/Magento/backend/en_US/sri-hashes.json` file.
 
 Hashes for runtime-generated merged JavaScript files are stored separately in `pub/static/_cache/merged/sri-hashes.json`.
 

--- a/src/pages/development/security/subresource-integrity.md
+++ b/src/pages/development/security/subresource-integrity.md
@@ -32,17 +32,31 @@ The default SRI feature is implemented only on the payment pages for the admin a
 
 ## Subresource Integrity Hash Generation
 
+<InlineAlert slots="text" />
+Adobe Commerce and Magento Open Source 2.4.9 and later support SRI hash generation for all JavaScript assets, including those processed through minification, bundling, and merging.
+
 The Subresource Integrity hash generation process begins once [static content](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/cli/static-view/static-view-file-deployment) for each package area has been deployed.
-The [postprocessor](https://github.com/magento/magento2/tree/2.4-develop/app/code/Magento/Csp/Model/Deploy/Package/Processor/PostProcessor) class then systematically processes all javascript files within each package and generates integrity hashes.
-The postprocessor class triggers the [SubresourceIntegrityCollector](https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Csp/Model/SubresourceIntegrityCollector.php) class to collect the hashes which are stored in the filesystem after all packages are deployed.
+The [postprocessor](https://github.com/magento/magento2/tree/2.4-develop/app/code/Magento/Csp/Model/Deploy/Package/Processor/PostProcessor) class then systematically processes all JavaScript files within each package and generates SHA-256 integrity hashes, including minified file variants. This process covers all Static Content Deployment (SCD) strategies: Standard, Quick, and Compact.
+The postprocessor class triggers the [SubresourceIntegrityCollector](https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Csp/Model/SubresourceIntegrityCollector.php) class to collect the hashes, which are saved to a scoped, per-package repository immediately after each package is deployed.
+Hashes for bundled JavaScript assets are also generated at deploy time. Hashes for runtime-generated merged JavaScript assets are captured on first use and stored separately in `pub/static/_cache/merged/sri-hashes.json`.
 All integrity hashes are stored in the filesystem via the [Storage](https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Csp/Model/SubresourceIntegrity/Storage/File.php) class.
 
 ## Subresource Integrity Storage
 
 <InlineAlert slots="text" />
 Adobe Commerce and Magento Open Source 2.4.8 and later no longer use a cache to store SRI hashes. The implementation has been refactored to store the hashes in the local filesystem instead. This ensures that SRI hashes are still intact and not effected by purging of caches.
-Subresource Integrity hashes are stored in JSON files in the `pub/static` directory by the deployed package area (frontend, base or admin).
-For example, SRI hashes for the `adminhtml/Magento/backend/en_US/requirejs/require.js` file will be located in the `pub/static/adminhtml/sri-hashes.json` file.
+
+<InlineAlert slots="text" />
+Adobe Commerce and Magento Open Source 2.4.9 and later store SRI hashes in files scoped by area, theme, and locale, rather than a single file per area.
+
+Subresource Integrity hashes are stored in `sri-hashes.json` files scoped by area, theme, and locale under the `pub/static` directory.
+For example, SRI hashes for the `adminhtml/Magento/backend/en_US/requirejs/require.js` file will be located in the `pub/static/adminhtml/Magento/backend/en_US/sri-hashes.json` file.
+
+Hashes for runtime-generated merged JavaScript files are stored separately in `pub/static/_cache/merged/sri-hashes.json`.
+
+Scoping hash files by area, theme, and locale prevents a single large file from degrading page and checkout performance as additional themes and locales are added.
+
+When running a partial static content deployment with the `--area`, `--theme`, or `--language` options, only the SRI hash files that match the specified scope are removed and regenerated, leaving all other locales and themes intact.
 
 ### Subresource Integrity for Remote Resources
 


### PR DESCRIPTION
## Purpose of this pull request

Updated subresource-integrity.md to reflect SRI improvements introduced in 2.4.9 (AC-16041).

  Hash Generation
  - Added a 2.4.9 version note indicating that SRI hash generation now covers JavaScript assets processed through minification, bundling, and merging.
  - Updated the body text to clarify that SHA-256 hashes are generated including minified file variants, and that coverage spans all SCD strategies
  (Standard, Quick, and Compact).
  - Updated the collector description to reflect that hashes are now saved to a scoped, per-package repository immediately after each package is deployed,
  rather than after all packages are deployed.
  - Clarified that bundled asset hashes are generated at deploy time, while merged asset hashes are captured at runtime and stored in
  pub/static/_cache/merged/sri-hashes.json.                                                                                                    
                                                                                                        
  Storage                                                                                                                                      
  - Added a 2.4.9 version note indicating that SRI hash files are now scoped by area, theme, and locale.                                                 
  - Corrected the storage path example from pub/static/adminhtml/sri-hashes.json to pub/static/adminhtml/Magento/backend/en_US/sri-hashes.json.
  - Documented the separate merged assets hash file at pub/static/_cache/merged/sri-hashes.json.                                                             
  - Added an explanation of the performance motivation behind per-scope storage.
  - Added a note that partial static content deployments (--area, --theme, --language) only remove and regenerate SRI files matching the specified scope. 

JIRA ticket:  AC-16041
                                                                                                                                                           

## Affected pages

https://developer.adobe.com/commerce/php/development/security/subresource-integrity
