### PR TITLE
Update plugins.md removed wrong example of plugin usage and added right one

### DIFF
--- a/src/pages/development/components/plugins.md
+++ b/src/pages/development/components/plugins.md
@@ -78,22 +78,13 @@ In the plugin class, the `setName` method may have one of the following names:
 
 If the first letter in the name of the class method name for which you want to create a plugin is the `underscore` character, then you do not need to capitalize it in the plugin class.
 
-For example, to create a plugin for the `_construct` method of some class:
+You can use plugins (interceptors) on PHP magic methods, such as `__get`, `__set`, or `__call`. The Adobe Commerce and Magento Open Source dependency injection system allows interceptors to wrap these magic methods just like standard public methods.
 
-```php
-...
-    public function _construct()
-    {
-        ...
-    }
-...
-```
+Use the following method names for the `_get` method in the plugin class:
 
-Use the following method names for the `_construct` method in the plugin class:
-
-*  `before_construct`
-*  `around_construct`
-*  `after_construct`
+*  `before_get`
+*  `around_get`
+*  `after_get`
 
 ## Before methods
 


### PR DESCRIPTION
## Purpose of this pull request
Docs: Replace incorrect __construct plugin example with valid magic method example. Removed an invalid example showing a plugin applied to the __construct method, which contradicts documented plugin limitations. Replaced it with a functional example of intercepting PHP magic methods (__get and __call) based on verified community solutions on https://magento.stackexchange.com/questions/309817/how-to-change-product-images-with-external-image-url-in-all-magento-2-frontend-a#answer-309826

## Affected pages
https://developer.adobe.com/commerce/php/development/components/plugins
<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-php/blob/main/.github/CONTRIBUTING.md) for more information.
-->
